### PR TITLE
project/1, query/1 and unify/1 added to builtin.jq, with tests and documentation

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -1655,6 +1655,58 @@ sections:
             input: '[1,2,3]'
             output: ['[1,2,3,4]']
 
+
+      - title: "`project(q)`"
+        body: |
+
+          Assuming the input is an object and that e is an object or
+          an array of strings, project(e) returns an object with the
+          same keys as in e, in the same order, but with values
+          determined by the corresponding keys in the input object;
+          the value associated with a missing key is null.
+
+        examples:
+          - program: 'project(["a","d"])'
+            input:   '{"b":2, "a":1, "c":3}'
+            output:  ['{"a":1, "d": null}']
+
+          - program: 'project({"a":10,"d":20})'
+            input:   '{"b":2, "a":1, "c":3}'
+            output:  ['{"a":1, "d": null}']
+
+
+      - title: "`query(obj)`"
+        body: |
+          query(obj) uses the object, obj, as a template to query the input.
+          If obj can be unified with the input in the sense that unify(obj) yields u,
+          then query(obj) emits u|project(obj). Otherwise, nothing is emitted.
+
+        example: 
+          - program: '.[] | query( {"author": "Grahame", "title": null} ) | .title'
+            input:  '[{"title": "Wind in the Willows",  "author": "Grahame"}, {"title": "Voss", "author": "White"}, {"title": "The Reluctant Dragon", "author": "Grahame"}]'
+            output:
+              -  '"Wind in the Willows"'
+              -  '"The Reluctant Dragon"'
+
+      - title: "`unify(e)`"
+        body: |
+
+          unify(e) emits the unification of the input entity with e if
+          possible or null otherwise; both the input and e may be any JSON entity.
+          Unification is based on replacing nulls with corresponding values at
+          structurally equivalent locations.
+
+        examples:
+          - program: 'unify(null)'
+            input:   'null'
+            output:  ['null']
+
+          - program: 'unify( {"a":null, "b": 2} )'
+            input:   '{"a":1, "b": null}'
+            output:  ['{"a":1, "b": 2}']
+
+
+
       - title: "String interpolation - `\\(foo)`"
         body: |
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1190,6 +1190,46 @@ bsearch(4)
 [1,2,3]
 -4
 
+walk(if type == "object" and .id == 0 then null else . end)
+[1,2,{"id":1, "next":{"id":0}}]
+[1,2,{"id":1,"next":null}]
+
+walk(if type == "object" then with_entries( select( .value != null )) else . end)
+[1,2,{"id":1, "next":null}]
+[1,2,{"id":1}]
+
+unify( {"address": { "number": 110 } } )
+{"color": "red", "address": { "street": "Brodway"} }
+{"color": "red", "address": { "street": "Brodway", "number": 110 } }
+
+unify( {"color": "red", "address": { "street": "Brodway"} } )
+{"address": { "number": 110 } }
+{"color": "red", "address": { "street": "Brodway", "number": 110 } }
+
+unify( {} )
+{"color": "red", "address": { "street": "Brodway"} } 
+{"color": "red", "address": { "street": "Brodway"} } 
+
+unify( {"color": "red", "address": { "street": "Brodway"} })
+{}
+{"color": "red", "address": { "street": "Brodway"} }
+
+unify( null )
+{"color": "red", "address": { "street": "Brodway"} }
+{"color": "red", "address": { "street": "Brodway"} }
+
+unify( {"color": "red", "address": { "street": "Brodway"} })
+null 
+{"color": "red", "address": { "street": "Brodway"} }
+
+unify( null )
+null
+null
+
+[.[] | query( {"author": "Grahame", "title": null} ) | .title]
+[{"title": "Wind in the Willows",  "author": "Grahame"}, {"title": "Voss", "author": "White"}, {"title": "The Reluctant Dragon", "author": "Grahame"}]
+["Wind in the Willows", "The Reluctant Dragon"]
+
 [strptime("%Y-%m-%dT%H:%M:%SZ")|(.,mktime)]
 "2015-03-05T23:51:47Z"
 [[2015,2,5,23,51,47,4,63],1425599507]


### PR DESCRIPTION
`make check` ran successfully.
### Summary:

```
   query(q)   provides a kind of "query by example" functionality based on
              unification, where q is normally a query object that may contain 
              nested objects and arrays.

   project(e) emits the projection of the input object, as defined by
              e, which is normally an object or an array of strings;

    unify(e)  emits the unification of the input entity with e if
              possible or null otherwise, where e may be any JSON entity.
```
### Description:

```
query(q)
      is defined as: unify(q) | select(.) | project(q);

project(e)
      Assuming the input is an object and that e is an object or an array of strings,
      project(e) returns an object with the same keys as in e, in
      the same order, but with values determined by the
      corresponding keys in the input object;

unify(e)
      This filter attempts to unify the input and e using a
      recursive process for both arrays and objects; on success, the
      filter emits the unified entity; on failure, the filter emits
      null.  Both the input and e may be arbitrary JSON entities.
      Unification is based on replacing nulls with corresponding values at
      structurally equivalent locations.
      Note that x|unify(y) yields null either if x and y are both null, or
      if unification fails.
```

unify/1 is defined so as to achieve the following basic principles, where
      it is to be understood that x, y and z are valid JSON values:
1. Non-failure: x|unify(y) always yields a value.
2. Zero: null|unify(x) is x
3. Reflexivity: x|unify(x) is x
4. Symmetry: x|unify(y) == y|unify(x)
5. Idempotence: unify(y)|unify(y) is unify(y)
6. Commutativity: unify(x)|unify(y) is unify(y)|unify(x)
7. Associativity:  (unify(x)|unify(y))|unify(y) is unify(x)|(unify(y))|unify(y))
8. If x and y cannot be unified, x|unify(y) yields null.
## Semantics of (x|unify(y))

Terminology: 
If x and y are not both null but x|unify(y) is null, then the unification of x and y is said to fail.

If x and y are two scalars, then x|unify(y) is:
      if x == y then x elif x == null then y elif y == null then x else null end;

if x and y are two objects, and if $keys is (x + y) | keys | unique,
      then (x|unify(y)) is the sum of {($k): (x[$k] | unify(y[$k]) )} as $k ranges through $keys,
      provided that none of these values reflects unification failure;

 if x and y are two arrays of the same length, 
        and if z is the array formed from (x[i]|unify(y[i]))
        and if z[i] is only null when x[i] and y[i] are both null,
        then (x|unify(y)) is z;

otherwise x|unify(y) is null.

Notice that:
-  e|unify(null) yields e by symmetry
-  x|unify(y) is null if and only if x==y==null or x and y fail to unify.
-  if $a is {"a": null} then {} | unify($a) is $a.
