### PR TITLE
Ignore jq.exe, fixed gcc compiler warnings for msys2 (windows).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tests/*.trs
 cscope.in.out
 cscope.out
 cscope.po.out
+jq.exe

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -915,13 +915,16 @@ static jv f_error(jq_state *jq, jv input, jv msg) {
 // FIXME Should autoconf check for this!
 #ifndef WIN32
 extern const char **environ;
+typedef const char ** environ_ptr;
+#else
+typedef char ** environ_ptr;
 #endif
 
 static jv f_env(jq_state *jq, jv input) {
   jv_free(input);
   jv env = jv_object();
   const char *var, *val;
-  for (const char **e = environ; *e != NULL; e++) {
+  for (environ_ptr e = environ; *e != NULL; e++) {
     var = e[0];
     val = strchr(e[0], '=');
     if (val == NULL)

--- a/src/jv_dtoa.c
+++ b/src/jv_dtoa.c
@@ -2336,6 +2336,7 @@ jvp_strtod
 	ULong y, z;
 	BCinfo bc;
 	Bigint *bb=0, *bb1, *bd=0, *bd0, *bs=0, *delta=0;
+	(void)(test_scale); // Unused variable in some builds.
 #ifdef Avoid_Underflow
 	ULong Lsb, Lsb1;
 #endif


### PR DESCRIPTION
src/builtin.c:924:26: warning: initialization from incompatible pointer type [-Wincompatible-pointer-types]
src/jv_dtoa.c:2330:54: warning: variable test_scale set but not used [-Wunused-but-set-variable]
