### PR TITLE
Add snap packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ tests/*.trs
 cscope.in.out
 cscope.out
 cscope.po.out
+
+snapcraft.yaml
+jq_*.snap
+prime
+setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ before_install:
       brew install flex         || true;
       brew install bison        || true;
       brew install oniguruma    || true;
-      - if [ "$TRAVIS_OS_NAME" != "linux" ]; then
-        brew uninstall libtool  || true;
-        brew install libtool    || true;
-      fi
     - rm src/{lexer,parser}.{c,h}
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ before_install:
       brew install flex         || true;
       brew install bison        || true;
       brew install oniguruma    || true;
+      - if [ "$TRAVIS_OS_NAME" != "linux" ]; then
+        brew uninstall libtool  || true;
+        brew install libtool    || true;
+      fi
     - rm src/{lexer,parser}.{c,h}
 
 install:

--- a/AUTHORS
+++ b/AUTHORS
@@ -69,3 +69,4 @@ tal@whatexit.org     <tal@whatexit.org>
 Travis Gockel        <travis@gockelhut.com>
 Zhiming Wang         <zmwangx@gmail.com>
 13ren                <melbourne.research@gmail.com>
+Lee Trager           <lee.trager@canonical.com>       - Snap packaging

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Kim De Mey           <kim.demey@gmail.com>            - build
 Kim Toms             <kim.toms@bplglobal.net>
 LCD 47               <lcd047@gmail.com>
 Lee Thompson         <stagr.lee@gmail.com>            - autoconf stuff, rpm
+Lee Trager           <lee.trager@canonical.com>       - Snap packaging
 Marc Abramowitz      <marc@marc-abramowitz.com>
 Marc Bruggmann       <marcbr@spotify.com>
 Markus Lanthaler     <mark_lanthaler@gmx.net>         - doc fixes
@@ -69,4 +70,3 @@ tal@whatexit.org     <tal@whatexit.org>
 Travis Gockel        <travis@gockelhut.com>
 Zhiming Wang         <zmwangx@gmail.com>
 13ren                <melbourne.research@gmail.com>
-Lee Trager           <lee.trager@canonical.com>       - Snap packaging

--- a/Makefile.am
+++ b/Makefile.am
@@ -175,6 +175,15 @@ rpm: dist jq.spec
 	find rpm/RPMS/ -name "*.rpm" -exec mv {} ./ \;
 	rm -rf rpm
 
+snap: snapcraft.yaml.template
+	@echo "Packaging jq as a snap..."
+	mkdir -p setup/gui
+	cp docs/public/jq.png setup/gui/icon.png
+	cp COPYING setup/license.txt
+	rm -f snapcraft.yaml
+	sed 's/@JQ_VERSION@/1.5/g' snapcraft.yaml.template > snapcraft.yaml
+	snapcraft snap
+
 dist-clean-local:
 	rm -f ${BUILT_SOURCES}
 

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -1,0 +1,22 @@
+name: jq
+version: @JQ_VERSION@
+summary: jq is a lightweight and flexible command-line JSON processor.
+description: jq is like sed for JSON data - you can use it to slice and filter and map and transform structured data with the same ease that sed, awk, grep and friends let you play with text.
+confinement: strict
+
+apps:
+  jq:
+    command: bin/jq
+
+parts:
+  jq:
+    plugin: autotools
+    source: .
+    filesets:
+      binaries:
+       - bin/jq
+       - lib/libjq.so*
+    stage:
+      - $binaries
+    snap:
+      - $binaries


### PR DESCRIPTION
This adds [Snap packaging](http://snapcraft.io/) to jq. The snap can be built by running
`make snap`

The jq snap can then be published to the [Snapcraft store](https://uappexplorer.com/apps) by following [the Snap publishing document](http://snapcraft.io/docs/build-snaps/publish)
