### PR TITLE
Define format in jq code

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1295,7 +1295,7 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_min_by_impl, "_min_by_impl", 2},
   {(cfunction_ptr)f_max_by_impl, "_max_by_impl", 2},
   {(cfunction_ptr)f_error, "error", 2},
-  {(cfunction_ptr)f_format, "format", 2},
+  {(cfunction_ptr)f_format, "_format", 2},
   {(cfunction_ptr)f_env, "env", 1},
   {(cfunction_ptr)f_get_search_list, "get_search_list", 1},
   {(cfunction_ptr)f_get_prog_origin, "get_prog_origin", 1},

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -287,3 +287,5 @@ def walk(f):
   elif type == "array" then map( walk(f) ) | f
   else f
   end;
+
+def format(fmt): _format(fmt);

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -316,6 +316,7 @@ def _totcl:
 def format(fmt):
   if fmt == "tcl" then
     _totcl
+    | sub("^{(?<contents>.*)}$"; .contents)
   else
     _format(fmt)
   end;

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -288,4 +288,28 @@ def walk(f):
   else f
   end;
 
-def format(fmt): _format(fmt);
+# Convert the input to a string representation of Tcl dictionaries.
+def totcl:
+  if type == "array" then
+    # Convert array to object with keys 0, 1, 2... and process
+    # it as object.
+    [range(0;length) as $i
+        | {key: $i | tostring, value: .[$i]}]
+    | from_entries
+    | totcl
+  elif type == "object" then
+    to_entries
+    | [.[] | "{" + .key + "} {" + (.value | totcl) + "}"]
+    | join(" ")
+  else
+    tostring
+    | gsub("{";"\\{")
+    | gsub("}";"\\}")
+  end;
+
+def format(fmt):
+  if fmt == "tcl" then
+    totcl
+  else
+    _format(fmt)
+  end;

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -289,17 +289,16 @@ def walk(f):
   end;
 
 # Convert the input to a string representation of Tcl dictionaries.
-def totcl:
+def _totcl:
   if type == "array" then
     # Convert array to object with keys 0, 1, 2... and process
     # it as object.
-    [range(0;length) as $i
-        | {key: $i | tostring, value: .[$i]}]
+    [range(0;length) as $i | {key: $i | tostring, value: .[$i]}]
     | from_entries
-    | totcl
+    | _totcl
   elif type == "object" then
     to_entries
-    | [.[] | "{" + .key + "} {" + (.value | totcl) + "}"]
+    | [.[] | "{" + .key + "} {" + (.value | _totcl) + "}"]
     | join(" ")
   else
     tostring
@@ -309,7 +308,7 @@ def totcl:
 
 def format(fmt):
   if fmt == "tcl" then
-    totcl
+    _totcl
   else
     _format(fmt)
   end;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -89,6 +89,10 @@ null
 ["foo", 1, ["a", 1, "b", 2, {"foo":"bar"}]]
 ["foo",1,["a",1,"b",2,{"foo":"bar"}]]
 
+@tcl
+[0,"foo",{"bar":{"baz":"quux"}}]
+"{0} {0} {1} {foo} {2} {{bar} {{baz} {quux}}}"
+
 #
 # Dictionary construction syntax
 #

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -91,27 +91,39 @@ null
 
 @tcl
 [0,"foo",{"bar":{"baz":"quux"}}]
-"{0 0 1 foo 2 {bar {baz quux}}}"
+"0 0 1 foo 2 {bar {baz quux}}"
 
 @tcl
 {"greeting":"Hello, world!", "bools": [false, true], "nothing": null}
-"{greeting {Hello, world!} bools {0 false 1 true} nothing null}"
+"greeting {Hello, world!} bools {0 false 1 true} nothing null"
 
 @tcl
 ["{","}"]
-"{0 \\{ 1 \\}}"
+"0 \\{ 1 \\}"
 
 @tcl
 ["a{","b}"]
-"{0 a\\{ 1 b\\}}"
+"0 a\\{ 1 b\\}"
 
 @tcl
 ["\\{","\\}"]
-"{0 \\\\\\{ 1 \\\\\\}}"
+"0 \\\\\\{ 1 \\\\\\}"
 
 @tcl
 [" \\"]
-"{0 \\ \\\\}"
+"0 \\ \\\\"
+
+@tcl
+5
+"5"
+
+@tcl
+"abc"
+"abc"
+
+@tcl
+"}"
+"\\}"
 
 #
 # Dictionary construction syntax

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -91,7 +91,27 @@ null
 
 @tcl
 [0,"foo",{"bar":{"baz":"quux"}}]
-"{0} {0} {1} {foo} {2} {{bar} {{baz} {quux}}}"
+"{0 0 1 foo 2 {bar {baz quux}}}"
+
+@tcl
+{"greeting":"Hello, world!", "bools": [false, true], "nothing": null}
+"{greeting {Hello, world!} bools {0 false 1 true} nothing null}"
+
+@tcl
+["{","}"]
+"{0 \\{ 1 \\}}"
+
+@tcl
+["a{","b}"]
+"{0 a\\{ 1 b\\}}"
+
+@tcl
+["\\{","\\}"]
+"{0 \\\\\\{ 1 \\\\\\}}"
+
+@tcl
+[" \\"]
+"{0 \\ \\\\}"
 
 #
 # Dictionary construction syntax


### PR DESCRIPTION
The proposed change makes it easier to extend `format` with new formats (#1227). The reasoning is that it is often more straightforward to implement a serialization algorithm recursively in a high-level functional language than in C.

I've implemented serialization to Tcl dictionaries (#685) in pure jq code as an example. This version differs slightly from the one in #685 to work around forward slash (`\`) escaping issues in `src/builtin.jq`.

<s>Perhaps the function `totcl` should be renamed `_totcl`.</s> Edit: Done.
