### PR TITLE
jv: Add some support for 64 bit ints in a very conservative way

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -137,14 +137,27 @@ static void jvp_invalid_free(jv x) {
  * Numbers
  */
 
-jv jv_number(double x) {
-  jv j = {JV_KIND_NUMBER, 0, 0, 0, {.number = x}};
+jv jv_number_full(double x, int64_t y) {
+  jv j = {JV_KIND_NUMBER, 0, 0, 0, {.number.dbl = x, .number.int64 = y}};
   return j;
+}
+
+jv jv_number(double x) {
+  int64_t y = 0;
+  if(x == x && x < INT_MAX && x > INT_MIN && x == (int)x) {
+    y = x;
+  }
+  return jv_number_full(x, y);
 }
 
 double jv_number_value(jv j) {
   assert(jv_get_kind(j) == JV_KIND_NUMBER);
-  return j.u.number;
+  return j.u.number.dbl;
+}
+
+int64_t jv_number_value_int64(jv j) {
+  assert(jv_get_kind(j) == JV_KIND_NUMBER);
+  return j.u.number.int64;
 }
 
 int jv_is_integer(jv j){

--- a/src/jv.h
+++ b/src/jv.h
@@ -27,7 +27,10 @@ typedef struct {
   int size;
   union {
     struct jv_refcnt* ptr;
-    double number;
+    struct {
+      double dbl;
+      int64_t int64;
+    } number;
   } u;
 } jv;
 
@@ -60,8 +63,10 @@ jv jv_true(void);
 jv jv_false(void);
 jv jv_bool(int);
 
+jv jv_number_full(double, int64_t);
 jv jv_number(double);
 double jv_number_value(jv);
+int64_t jv_number_value_int64(jv);
 int jv_is_integer(jv);
 
 jv jv_array(void);

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <errno.h>
 #include "jv.h"
 #include "jv_dtoa.h"
 #include "jv_unicode.h"
@@ -490,7 +491,12 @@ static pfunc check_literal(struct jv_parser* p) {
     double d = jvp_strtod(&p->dtoa, p->tokenbuf, &end);
     if (end == 0 || *end != 0)
       return "Invalid numeric literal";
-    TRY(value(p, jv_number(d)));
+    end = 0;
+    errno = 0;
+    int64_t i = strtoll(p->tokenbuf, &end, 10);
+    if (end == 0 || *end != 0 || errno != 0)
+      i = 0;
+    TRY(value(p, jv_number_full(d, i)));
   }
   p->tokenpos = 0;
   return 0;

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <string.h>
+#include <inttypes.h>
 
 #ifdef WIN32
 #include <windows.h>
@@ -176,6 +177,13 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     put_str("true", F, S, flags & JV_PRINT_ISATTY);
     break;
   case JV_KIND_NUMBER: {
+    int64_t i = jv_number_value_int64(x);
+    if (i) {
+      char buf[21];
+      snprintf(buf, sizeof(buf), "%" PRId64, i);
+      put_str(buf, F, S, flags & JV_PRINT_ISATTY);
+      break;
+    }
     double d = jv_number_value(x);
     if (d != d) {
       // JSON doesn't have NaN, so we'll render it as "null"


### PR DESCRIPTION
This adds an extra int64_t field to jv, which is only written when
parsing number literals (and only if they are integers within range),
and only read when printing.

Any operations done over those numbers will downgrade them to a double
with 53 bit precision. This is intentional for the scope of this patch:

```
$ echo 111111111111111111 | jq -c '[., 1*.]'
[111111111111111111,111111111111111100]
```

For ints between 53 and 64 bits, this matches the behavior of awk,
as suggested in the bug tracker by tischwa:

```
$ echo 111111111111111111 | awk '{print $1, 1*$1}'
111111111111111111 111111111111111104
```

---

Fixes issue #369 (at least partially)

I tried to add tests but the stuff in jq.test seems to be parsed by jq itself, so they end up being comparisons between the double values, not the int64 ones.

This is an itch i've really needed to scratch for a long time. Using jq as a pretty printer for json, I almost started getting used to big numbers getting mangled. Not anymore!
