### PR TITLE
jv: Add some support for 64 bit ints in a very conservative way (ALTERNATIVE)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,8 @@ if test "x$valgrind_cmd" = "x" ; then
 fi
 AC_CHECK_FUNCS(memmem)
 AC_CHECK_FUNCS(mkstemp)
+AC_CHECK_FUNCS(strtoimax)
+AC_CHECK_FUNCS(strtoumax)
 
 AC_CHECK_HEADER("shlwapi.h",[have_win32=1;])
 AM_CONDITIONAL([WIN32], [test "x$have_win32" = x1])

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -363,6 +363,33 @@ static jv f_tonumber(jq_state *jq, jv input) {
   return type_error(input, "cannot be parsed as a number");
 }
 
+static jv f_toint(jq_state *jq, jv input) {
+  input = f_tonumber(jq, input);
+  if (!jv_is_valid(input))
+    return input;
+  if (jv_is_int64(input) || jv_is_uint64(input))
+    return input;
+  double d = jv_number_value(input);
+  if (d < 0 && d >= INT64_MIN) {
+    int64_t i = d;
+    if (i < 0)
+      return jv_int64(i);
+  } else if (d < UINT64_MAX) {
+    uint64_t u = d;
+    if (d == (double)u)
+      return jv_uint64(u);
+  }
+  return jv_number(nearbyint(d));
+}
+
+static jv f_isint(jq_state *jq, jv input) {
+  if (jv_get_kind(input) != JV_KIND_NUMBER)
+    return type_error(input, "only numbers can be integers");
+  if (jv_is_int64(input) || jv_is_uint64(input) || jv_is_integer(input))
+    return jv_true();
+  return jv_false();
+}
+
 static jv f_length(jq_state *jq, jv input) {
   if (jv_get_kind(input) == JV_KIND_ARRAY) {
     return jv_number(jv_array_length(input));
@@ -1285,6 +1312,8 @@ static const struct cfunction function_list[] = {
   {(cfunction_ptr)f_json_parse, "fromjson", 1},
   {(cfunction_ptr)f_tonumber, "tonumber", 1},
   {(cfunction_ptr)f_tostring, "tostring", 1},
+  {(cfunction_ptr)f_toint, "tointeger", 1},
+  {(cfunction_ptr)f_isint, "isinteger", 1},
   {(cfunction_ptr)f_keys, "keys", 1},
   {(cfunction_ptr)f_keys_unsorted, "keys_unsorted", 1},
   {(cfunction_ptr)f_startswith, "startswith", 2},

--- a/src/jv.c
+++ b/src/jv.c
@@ -191,6 +191,10 @@ int64_t jv_int64_value(jv j)
       return (int64_t)j.u.uint64;
     return INT64_MAX;
   }
+  if (j.u.number > 0 && (int64_t)j.u.number < 0)
+    return INT64_MAX;
+  if (j.u.number < 0 && (int64_t)j.u.number > 0)
+    return INT64_MIN;
 #endif
   return j.u.number;
 }
@@ -207,6 +211,10 @@ uint64_t jv_uint64_value(jv j)
       return j.u.int64;
     return 0;
   }
+  if (j.u.number < 0)
+    return 0;
+  if (j.u.number > (double)UINT64_MAX)
+    return UINT64_MAX;
 #endif
   return j.u.number;
 }

--- a/src/jv.c
+++ b/src/jv.c
@@ -231,6 +231,7 @@ int jv_is_integer(jv j){
   }
 #endif
   double x = jv_number_value(j);
+  /* XXX Check against actual double min/max integers */
   if(x != x || x > INT_MAX || x < INT_MIN){
     return 0;
   }

--- a/src/jv.h
+++ b/src/jv.h
@@ -16,18 +16,26 @@ typedef enum {
   JV_KIND_OBJECT
 } jv_kind;
 
+typedef enum {
+  JV_SUBKIND_NONE,
+  JV_SUBKIND_INT64,
+  JV_SUBKIND_UINT64,
+} jv_subkind;
+
 struct jv_refcnt;
 
 /* All of the fields of this struct are private.
    Really. Do not play with them. */
 typedef struct {
   unsigned char kind_flags;
-  unsigned char pad_;
+  unsigned char subkind_flags;
   unsigned short offset;  /* array offsets */
   int size;
   union {
     struct jv_refcnt* ptr;
     double number;
+    int64_t int64;
+    uint64_t uint64;
   } u;
 } jv;
 
@@ -37,6 +45,7 @@ typedef struct {
  */
 
 jv_kind jv_get_kind(jv);
+jv_subkind jv_get_subkind(jv);
 const char* jv_kind_name(jv_kind);
 static int jv_is_valid(jv x) { return jv_get_kind(x) != JV_KIND_INVALID; }
 
@@ -61,8 +70,14 @@ jv jv_false(void);
 jv jv_bool(int);
 
 jv jv_number(double);
+jv jv_int64(int64_t);
+jv jv_uint64(uint64_t);
 double jv_number_value(jv);
+int64_t jv_int64_value(jv);
+uint64_t jv_uint64_value(jv);
 int jv_is_integer(jv);
+int jv_is_int64(jv);
+int jv_is_uint64(jv);
 
 jv jv_array(void);
 jv jv_array_sized(int);

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -1,6 +1,7 @@
 #include <assert.h>
-#include <stdio.h>
+#include <inttypes.h>
 #include <float.h>
+#include <stdio.h>
 #include <string.h>
 
 #ifdef WIN32
@@ -182,6 +183,21 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     put_str("true", F, S, flags & JV_PRINT_ISATTY);
     break;
   case JV_KIND_NUMBER: {
+#ifndef JQ_OMIT_INTS
+    if (jv_is_int64(x)) {
+      int64_t i64 = jv_int64_value(x);
+      char buf[21];
+      (void) snprintf(buf, sizeof(buf), "%" PRId64, i64);
+      put_str(buf, F, S, flags & JV_PRINT_ISATTY);
+      break;
+    } else if (jv_is_uint64(x)) {
+      uint64_t u64 = jv_uint64_value(x);
+      char buf[21];
+      (void) snprintf(buf, sizeof(buf), "%" PRIu64, u64);
+      put_str(buf, F, S, flags & JV_PRINT_ISATTY);
+      break;
+    }
+#endif
     double d = jv_number_value(x);
     if (d != d) {
       // JSON doesn't have NaN, so we'll render it as "null"


### PR DESCRIPTION
This is a variant of #1246 that doesn't change the size of a `jv`.

@dequis What do you think?