### PR TITLE
fix portability problems, found in NetBSD-7.1/amd64

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ if MAINTAINER_MODE
 BUILT_SOURCES = src/lexer.h src/lexer.c src/parser.h src/parser.c 	\
 		src/builtin.inc src/version.h
 src/lexer.c: src/lexer.l
-	$(AM_V_LEX) flex -o src/lexer.c --header-file=src/lexer.h $<
+	$(AM_V_LEX) flex -o src/lexer.c --header-file=src/lexer.h src/lexer.l
 src/lexer.h: src/lexer.c
 else
 BUILT_SOURCES = src/builtin.inc src/version.h
@@ -101,7 +101,7 @@ src/version.h: .remake-version-h
 src/main.c: src/version.h
 
 src/builtin.inc: src/builtin.jq
-	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $^ > $@
+	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' src/builtin.jq > $@
 src/builtin.o: src/builtin.inc
 
 bin_PROGRAMS = jq
@@ -130,10 +130,10 @@ if ENABLE_DOCS
 jq.1: $(srcdir)/docs/content/3.manual/manual.yml
 	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; '$(BUNDLER)' exec rake manpage ) > $@ || { rm -f $@; false; }
 jq.1.prebuilt: jq.1
-	$(AM_V_GEN) cp $^ $@ || { rm -f $@; false; }
+	$(AM_V_GEN) cp jq.1 $@ || { rm -f $@; false; }
 else
 jq.1: $(srcdir)/jq.1.prebuilt
-	$(AM_V_GEN) cp $^ $@
+	$(AM_V_GEN) cp $(srcdir)/jq.1.prebuilt $@
 endif
 
 

--- a/config/m4/check-math-func.m4
+++ b/config/m4/check-math-func.m4
@@ -1,4 +1,7 @@
 dnl AC_FIND_FUNC(func, arguments)
 AC_DEFUN([AC_CHECK_MATH_FUNC], [
-  AC_FIND_FUNC_NO_LIBS([$1], [m], [#include <math.h>], [$2])
+  AC_FIND_FUNC_NO_LIBS([$1], [m], [
+    #include <stdlib.h>
+    #include <math.h>
+  ], [$2])
 ])

--- a/config/m4/find-func-no-libs2.m4
+++ b/config/m4/find-func-no-libs2.m4
@@ -20,7 +20,7 @@ if eval "test \"\$ac_cv_func_$1\" != yes" ; then
 		*) ac_lib="-l$ac_lib" ;;
 		esac
 		LIBS="$6 $ac_lib $5 $ac_save_LIBS"
-		AC_LINK_IFELSE([AC_LANG_PROGRAM([[$3]],[[$1($4)]])],[eval "if test -n \"$ac_lib\";then ac_cv_funclib_$1=$ac_lib; else ac_cv_funclib_$1=yes; fi";break])
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[$3]],[[$1($4*rand())]])],[eval "if test -n \"$ac_lib\";then ac_cv_funclib_$1=$ac_lib; else ac_cv_funclib_$1=yes; fi";break])
 	done
 	eval "ac_cv_funclib_$1=\${ac_cv_funclib_$1-no}"
 	LIBS="$ac_save_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PREREQ([2.64])
 AC_CONFIG_AUX_DIR([config])
 AM_INIT_AUTOMAKE([1.11.2 subdir-objects parallel-tests foreign -Wall])
 AM_SILENT_RULES([yes])
+AC_USE_SYSTEM_EXTENSIONS
 AM_PROG_AR
 AM_MAINTAINER_MODE([enable])
 AC_PROG_CC

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1282,7 +1282,12 @@ static jv f_strptime(jq_state *jq, jv a, jv b) {
   const char *fmt = jv_string_value(b);
   const char *end = strptime(input, fmt, &tm);
 
-  if (end == NULL || (*end != '\0' && !isspace(*end))) {
+  /*
+   * "*end" may be a signed char, and passing a value which is less than -1
+   * to isspace() violates the C standard, thus, casting to (unsigned char *)
+   * is necessary.
+   */
+  if (end == NULL || (*end != '\0' && !isspace(*(unsigned char *)end))) {
     jv e = jv_invalid_with_msg(jv_string_fmt("date \"%s\" does not match format \"%s\"", input, fmt));
     jv_free(a);
     jv_free(b);

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1,12 +1,3 @@
-#define _BSD_SOURCE
-#define _GNU_SOURCE
-#ifndef __sun__
-# define _XOPEN_SOURCE
-# define _XOPEN_SOURCE_EXTENDED 1
-#else
-# define _XPG6
-# define __EXTENSIONS__
-#endif
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/src/compile.c
+++ b/src/compile.c
@@ -1,6 +1,3 @@
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE // for strdup
-#endif
 #include <assert.h>
 #include <math.h>
 #include <string.h>

--- a/src/inject_errors.c
+++ b/src/inject_errors.c
@@ -1,5 +1,3 @@
-
-#define _GNU_SOURCE /* for RTLD_NEXT */
 #include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/src/main.c
+++ b/src/main.c
@@ -102,8 +102,13 @@ static void die() {
 
 
 
+/*
+ * "text[1]" may be a signed char, and passing a value which is less than -1
+ * to isalpha() violates the C standard, thus, casting to (unsigned char *)
+ * is necessary.
+ */
 static int isoptish(const char* text) {
-  return text[0] == '-' && (text[1] == '-' || isalpha(text[1]));
+  return text[0] == '-' && (text[1] == '-' || isalpha(((const unsigned char *)text)[1]));
 }
 
 static int isoption(const char* text, char shortopt, const char* longopt, size_t *short_opts) {

--- a/src/util.c
+++ b/src/util.c
@@ -1,8 +1,3 @@
-
-#ifdef HAVE_MEMMEM
-#define _GNU_SOURCE
-#endif
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <assert.h>


### PR DESCRIPTION
There are 4 portability problems in jq,

For example, it dumps core as follows on NetBSD-7.1/amd64, as described in https://gnats.netbsd.org/52460 :
```
$ echo 334 | jq 'strftime("%Y-%m-%dT%H:%M:%SZ")'
Memory fault (core dumped)
```
This is caused by missing function prototype of gmtime_r() due to inconsistent use of *_SOURCE macros, and that's fixed in df9a0963 in this pull request.

There are 3 other problems, and all of them are fixed in this pull request.

NOTE: this problem was originally found by Takehiko NOZAKI, and basic fixes are made by him and Kimihiro Nonaka.  But if there is any problem in these fixes, it's my fault since I made final modification.