### PR TITLE
Use an unreachable commit ID instead of a tag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 m4_define([jq_version],
-          m4_esyscmd_s([(git rev-parse --verify -q jq-1.0 > /dev/null &&
+          m4_esyscmd_s([(git rev-parse --verify -q eca89ac > /dev/null &&
                         (git describe --tags --dirty --match 'jq-*'|sed 's/^jq-//')) ||
                         echo `git rev-parse --abbrev-ref HEAD`-`git describe --always --dirty`])))
 

--- a/scripts/version
+++ b/scripts/version
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 cd `dirname "$0"`
-if git rev-parse --verify -q jq-1.0 > /dev/null 2>&1; then
+if git rev-parse --verify -q eca89ac > /dev/null 2>&1; then
     git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
 else
     b=`git rev-parse --abbrev-ref HEAD`


### PR DESCRIPTION
For git v1.7.1 (eg. on CentOS 6), a shallow clone achieved by `git clone --depth 1` clones not only the latest commit on master branch but also all branches and all tags, which makes the tag `jq-1.0` available.

As a result, the shallow-clone-detecting command passes and the `git describe` is incorrectly called.

This patch replaces the tag jq-1.0 with eca89ac, which is the initial commit.