### PR TITLE
pick init file from multiple candidates and filter search path to dirs

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -3106,7 +3106,7 @@ sections:
 
       The default search path is the search path given to the `-L`
       command-line option, else `["~/.jq", "$ORIGIN/../lib/jq",
-      "$ORIGIN/../lib"]`.
+      "$ORIGIN/../lib"]`. Any non-directory entries are ignored.
 
       Null and empty string path elements terminate search path
       processing.
@@ -3123,7 +3123,9 @@ sections:
       For example, with `-L$HOME/.jq` a module `foo` can be found in
       `$HOME/.jq/foo.jq` and `$HOME/.jq/foo/foo.jq`.
 
-      If "$HOME/.jq" is a file, it is sourced into the main program.
+      An init file will be sourced into the main program if found. The
+      init used will be first of "$HOME/.jqrc", "$HOME/.jq", or
+      "$HOME/.jq/jqrc" that exists and is a file.
 
     entries:
       - title: "`import RelativePathString as NAME [<metadata>];`"

--- a/src/execute.c
+++ b/src/execute.c
@@ -1182,6 +1182,10 @@ jv jq_get_prog_origin(jq_state *jq) {
   return jq_get_attr(jq, jv_string("PROGRAM_ORIGIN"));
 }
 
+jv jq_get_init_file_path(jq_state *jq) {
+  return jq_get_attr(jq, jv_string("JQ_INIT_FILE_PATH"));
+}
+
 jv jq_get_lib_dirs(jq_state *jq) {
   return jq_get_attr(jq, jv_string("JQ_LIBRARY_PATH"));
 }

--- a/src/jq.h
+++ b/src/jq.h
@@ -42,6 +42,7 @@ void jq_set_attrs(jq_state *, jv);
 jv jq_get_attrs(jq_state *);
 jv jq_get_jq_origin(jq_state *);
 jv jq_get_prog_origin(jq_state *);
+jv jq_get_init_file_path(jq_state *);
 jv jq_get_lib_dirs(jq_state *);
 void jq_set_attr(jq_state *, jv, jv);
 jv jq_get_attr(jq_state *, jv);

--- a/tests/shtest
+++ b/tests/shtest
@@ -202,6 +202,35 @@ if [ "$(HOME="$mods" $VALGRIND $Q $JQ -nr fg)" != foobar ]; then
     exit 1
 fi
 
+#1501
+touch "$d/.jqrc"
+if [ "$(HOME="$d" $VALGRIND $Q $JQ -n get_init_file_path)" != "\"$d/.jqrc\"" ]; then
+    echo 'failure (#1501): init file should be ~/.jqrc' 1>&2
+    exit 1
+fi
+
+rm "$d/.jqrc"
+touch "$d/.jq"
+if [ "$(HOME="$d" $VALGRIND $Q $JQ -n get_init_file_path)" != "\"$d/.jq\"" ]; then
+    echo 'failure (#1501): init file should be ~/.jq' 1>&2
+    exit 1
+fi
+
+rm "$d/.jq"
+mkdir "$d/.jq"
+touch "$d/.jq/jqrc"
+if [ "$(HOME="$d" $VALGRIND $Q $JQ -n get_init_file_path)" != "\"$d/.jq/jqrc\"" ]; then
+    echo 'failure (#1501): init file should be ~/.jq/jqrc' 1>&2
+    exit 1
+fi
+rm "$d/.jq/jqrc"
+
+if [ $(HOME="$d" bash -c "$VALGRIND $Q $JQ -n 'get_search_list' | grep '$d/\.jq' | wc -l") -eq 0 ]; then
+    echo 'failure (#1501): jq module search path should include ~/.jq' 1>&2
+    exit 1
+fi
+rmdir "$d/.jq"
+
 if [ $(HOME="$mods" $VALGRIND $Q $JQ --debug-dump-disasm -n fg | grep '^[a-z]' | wc -l) -gt 3 ]; then
     echo "Binding too many defs into program" 1>&2
     exit 1


### PR DESCRIPTION
This adds a JQ_INIT_FILE_PATH jq attr which is set as the first of ~/.jqrc, ~/.jq, or ~/.jq/jqrc that exists and is a file. This gets sourced into the program as before. It also filters JQ_LIBRARY_PATH to only directories. Let me know how it looks.