### PR TITLE
Make INDEX/2 more efficient

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -295,11 +295,7 @@ def walk(f):
 
 # SQL-ish operators here:
 def INDEX(stream; idx_expr):
-  reduce stream as $row ({};
-    .[$row|idx_expr|
-      if type != "string" then tojson
-      else .
-      end] |= $row);
+  reduce stream as $row ({}; .[($row|idx_expr|tostring)] |= $row);
 def INDEX(idx_expr): INDEX(.[]; idx_expr);
 def JOIN($idx; idx_expr):
   [.[] | [., $idx[idx_expr]]];


### PR DESCRIPTION
Hi,

I think there is some faster (a little bit) and more readable implementation of SQL-ish INDEX(...).

About 10% performance win:

~/.jq
```
# better implementation?
def INDEX2(stream; idx_expr):
  reduce stream as $row ({}; .[($row|idx_expr|tostring)] |= $row);
def INDEX2(idx_expr): INDEX2(.[]; idx_expr);
```
```
$ ./jq-index.sh
+ jq -n '[ range(1024*2000) | {id: . } ] | INDEX(.id)  | empty'

real    0m21.124s
user    0m0.000s
sys     0m0.015s
+ jq -n '[ range(1024*2000) | {id: . } ] | INDEX2(.id) | empty'

real    0m19.165s
user    0m0.000s
sys     0m0.015s
```

Thank You for the great job!

Regards