### PR TITLE
wip: feat: terminate jq immediately after the outgoing pipe closed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,7 +105,7 @@ src/builtin.inc: src/builtin.jq
 src/builtin.o: src/builtin.inc
 
 bin_PROGRAMS = jq
-jq_SOURCES = src/main.c src/version.h
+jq_SOURCES = src/main.c src/version.h src/signal.c
 jq_LDFLAGS = -static-libtool-libs
 jq_LDADD = libjq.la -lm
 

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 #include "jq.h"
 #include "jv_alloc.h"
 #include "util.h"
+#include "src/signal.h"
 #include "src/version.h"
 
 int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
@@ -272,6 +273,10 @@ int main(int argc, char* argv[]) {
     ret = 2;
     goto out;
   }
+
+#ifndef WIN32
+  jq_register_signal_handler();
+#endif
 
   int dumpopts = JV_PRINT_INDENT_FLAGS(2);
   const char* program = 0;

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include "signal.h"
+
+void jq_handle_sigpipe(int signum)
+{
+#ifndef WIN32
+  signal(SIGPIPE, SIG_IGN);
+  fprintf(stderr, "jq: error: received SIGPIPE\n");
+  exit(128 + SIGPIPE);
+#endif
+}
+
+void jq_register_signal_handler()
+{
+#ifndef WIN32
+  if (signal(SIGPIPE, jq_handle_sigpipe) == SIG_ERR ) {
+    fprintf(stderr, "jq: failed to register signal handler");
+    exit(1);
+  }
+#endif
+}

--- a/src/signal.h
+++ b/src/signal.h
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+
+void jq_handle_signal(int);
+void jq_register_signal_handler();


### PR DESCRIPTION
This should work. In reality, this does compile, but doesn't function when I actually try to emit SIGPIPE by doing:

```
cat | ./jq . | bash -c 'sleep 1; foo'
bash: foo: command not found
```

My understanding is that the missing command `foo` should immediately result in SIGPIPE on the jq command, so that
this feature terminates jq immediately.

I'd greatly appreciate it if anyone could share your insight on how I could make it actually work :pray:

Resolves #1691