### PR TITLE
Fix truncate_stream example

### DIFF
--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -2887,7 +2887,7 @@ sections:
           given streaming expression.
 
         examples:
-          - program: '[1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])]'
+          - program: '[truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])]'
             input: '1'
             output: ['[[[0],2],[[0]]]']
 


### PR DESCRIPTION
The input is `1`, then the script also gives an input of `1`.