### PR TITLE
Add fromstream_with_dups() builtin (fix #1795)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
                         - valgrind
                         - bison
                         - automake
+                        - git
 
             before_install:
                 - uname -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,8 @@ jobs:
                 - uname -s
                 - brew update
                 - brew install flex bison
-                - rvm install ruby-1.9.3-p551
-                - rvm use 1.9.3
+                - rvm install ruby-2.3.0
+                - rvm use 2.3.0
                 - gem install bundler
                 - rm src/{lexer,parser}.{c,h}
                 - sed -i.bak '/^AM_INIT_AUTOMAKE(\[-Wno-portability 1\.14\])$/s/14/11/' modules/oniguruma/configure.ac

--- a/docs/content/3.manual/manual.yml
+++ b/docs/content/3.manual/manual.yml
@@ -2924,6 +2924,9 @@ sections:
       single JSON text that is 1GB in size, streaming it will allow you
       to process it much more quickly.
 
+      Streaming not only allows for online consumption of large JSON
+      texts, but also allows for processing of duplicate object keys.
+
       However, streaming isn't easy to deal with as the jq program will
       have `[<path>, <leaf-value>]` (and a few other forms) as inputs.
 
@@ -2961,6 +2964,35 @@ sections:
           - program: 'fromstream(1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]]))'
             input: 'null'
             output: ['[2]']
+
+      - title: "`fromstream_with_dups(stream_expression)`"
+        body: |
+
+          Outputs values corresponding to the stream expression's
+          outputs.  The values of object's keys are collected into
+          arrays, so that if there are duplicates in the input, then
+          those will all be available.
+
+        examples:
+          - program: 'fromstream_with_dups([["a"],0],[["a"],1],[["b"],2],[["b"]])'
+            input: 'null'
+            output: ['{"a":[0,1],"b":[2]}']
+
+      - title: "`fromstream_with_dups(stream_expression; fixup_object)`"
+        body: |
+
+          Same as `fromstream_with_dups/1`, but the `fixup_object`
+          expression makes it possible to rewrite objects to handle
+          duplicates in other ways than as arrays.
+
+          In the example below the first value of any key is used
+          instead of the last as jq's JSON parser normally does.
+
+        examples:
+          - program: 'def fix: reduce keys_unsorted[] as $key (.; .[$key] |= .[0]);
+                      fromstream_with_dups(.[]; fix)'
+            input: '[[["a"],0],[["a"],1],[["b"],2],[["b"]]]'
+            output: ['{"a":0,"b":2}']
 
       - title: "`tostream`"
         body: |

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -236,6 +236,30 @@ def fromstream(i):
     else empty
     end
   );
+def fromstream_with_dups(i; fix):
+  foreach i as $i (
+    [null, null];
+
+    if ($i | length) == 2 then
+      if ($i[0] | length) == 0 then .
+      elif $i[0][-1]|type == "string" then
+        [ ( .[0] | setpath($i[0]; getpath($i[0]) + [$i[1]]) ), .[1] ]
+      else [ ( .[0] | setpath($i[0]; $i[1]) ), .[1] ]
+      end
+    elif ($i[0] | length) == 1 then [ null, .[0] ]
+    else .
+    end;
+
+    if ($i | length) == 1 then
+      if ($i[0] | length) == 1 then
+        .[1] | if type=="object" then fix else . end
+      else empty
+      end
+    elif ($i[0] | length) == 0 then $i[1]
+    else empty
+    end
+  );
+def fromstream_with_dups(i): fromstream_with_dups(i; .);
 def tostream:
   {string:true,number:true,boolean:true,null:true} as $leaf_types |
   . as $dot |


### PR DESCRIPTION
This commit adds a pair of built-ins for dealing with streamed JSON
texts that have duplicate keys.

Eventually we may need a `tostream_with_dups` as well that implements a
convention that array values in objects are to be presented as duplicate
keys with array elements as values.  There are ambiguity issues, like
how should one stream `{"a":[]}`.