### PR TITLE
add nested array indexing example

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -378,6 +378,10 @@ sections:
             input: '[1,2,3]'
             output: ['2']
 
+          - program: '.letters[1]'
+            input: '{"letters":["a","b","c","d"]}'
+            output: '"b"'
+
       - title: "Array/String Slice: `.[10:15]`"
         body: |
 


### PR DESCRIPTION
This PR adds an example to the docs to help people who've hit the snag
discussed in #1168.

Having an example allows people who hit this snag to relatively quickly
see what they've done wrong, rather than having to probe further into a
cryptic error message:
```
jq: error: syntax error, unexpected $end, expecting FORMAT or QQSTRING_START (Unix shell quoting issues?)
```

Having it just as an example allows people to be informed of the behavior
without the burden of needing to explain it with additional text.