### PR TITLE
Added jv_is_integer_large() to the library.

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -7,6 +7,7 @@
 #include <stdarg.h>
 #include <limits.h>
 #include <math.h>
+#include <float.h>
 
 #include "jv_alloc.h"
 #include "jv.h"
@@ -157,6 +158,18 @@ int jv_is_integer(jv j){
   }
 
   return x == (int)x;
+}
+
+int jv_is_integer_large(jv j){
+  if(jv_get_kind(j) != JV_KIND_NUMBER){
+    return 0;
+  }
+  double x = jv_number_value(j);
+
+  double ipart;
+  double fpart = modf(x, &ipart);
+
+  return fabs(fpart) < DBL_EPSILON;
 }
 
 /*

--- a/src/jv.c
+++ b/src/jv.c
@@ -153,18 +153,6 @@ int jv_is_integer(jv j){
     return 0;
   }
   double x = jv_number_value(j);
-  if(x != x || x > INT_MAX || x < INT_MIN){
-    return 0;
-  }
-
-  return x == (int)x;
-}
-
-int jv_is_integer_large(jv j){
-  if(jv_get_kind(j) != JV_KIND_NUMBER){
-    return 0;
-  }
-  double x = jv_number_value(j);
 
   double ipart;
   double fpart = modf(x, &ipart);

--- a/src/jv.h
+++ b/src/jv.h
@@ -63,6 +63,7 @@ jv jv_bool(int);
 jv jv_number(double);
 double jv_number_value(jv);
 int jv_is_integer(jv);
+int jv_is_integer_large(jv);
 
 jv jv_array(void);
 jv jv_array_sized(int);

--- a/src/jv.h
+++ b/src/jv.h
@@ -63,7 +63,6 @@ jv jv_bool(int);
 jv jv_number(double);
 double jv_number_value(jv);
 int jv_is_integer(jv);
-int jv_is_integer_large(jv);
 
 jv jv_array(void);
 jv jv_array_sized(int);


### PR DESCRIPTION
This change adds a new function to the library called `jv_is_integer_large()`, which returns true for any `JV_KIND_NUMBER` that fits into a `double` and has a fractional part smaller than the system's epsilon.

It was written to let [PyJQ](https://github.com/doloopwhile/pyjq) make decisions about using the arbitrarily-large integer types available in Python.  (A companion pull request for that project is forthcoming.)

Gory details about why:  https://github.com/perfsonar/pscheduler/issues/717
