### PR TITLE
Unify/simplify the MultiByteToWideChar() code and add wrappers for open()/stat()

### DIFF
--- a/src/linker.c
+++ b/src/linker.c
@@ -35,7 +35,9 @@ static int path_is_relative(jv p) {
   const char *s = jv_string_value(p);
 
 #ifdef WIN32
-  int res = PathIsRelativeA(s);
+  wchar_t *ws = utf8_to_utf16(s);
+  int res = PathIsRelativeW(ws);
+  jv_mem_free(ws);
 #else
   int res = *s != '/';
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -65,6 +65,33 @@ int open(const char *fname, int mode, ...) {
   return fd;
 }
 
+int stat(const char *fname, struct stat *stat) {
+  wchar_t *wfname = utf8_to_utf16(fname);
+
+  struct _stat wstat;
+  int res = _wstat(wfname, &wstat);
+
+  if(res == -1)
+    memset(stat, 0, sizeof(struct stat));
+  else
+  {
+    stat->st_dev   = wstat.st_dev;
+    stat->st_ino   = wstat.st_ino;
+    stat->st_mode  = wstat.st_mode;
+    stat->st_nlink = wstat.st_nlink;
+    stat->st_uid   = wstat.st_uid;
+    stat->st_gid   = wstat.st_gid;
+    stat->st_rdev  = wstat.st_rdev;
+    stat->st_size  = wstat.st_size;
+    stat->st_atime = wstat.st_atime;
+    stat->st_mtime = wstat.st_mtime;
+    stat->st_ctime = wstat.st_ctime;
+  }
+
+  jv_mem_free(wfname);
+  return res;
+}
+
 FILE *fopen(const char *fname, const char *mode) {
   wchar_t *wfname = utf8_to_utf16(fname);
   wchar_t *wmode = utf8_to_utf16(mode);

--- a/src/util.h
+++ b/src/util.h
@@ -61,4 +61,14 @@ const void *_jq_memmem(const void *haystack, size_t haystacklen,
    _a > _b ? _a : _b; })
 #endif
 
+#ifdef WIN32
+/*
+ * UTF-8 -> UTF-16 conversion function.
+ * Encapsulates MultiByteToWideChar().
+ *
+ * Memory disposal: manual, via jv_mem_free()
+ */
+wchar_t *utf8_to_utf16(const char *mstr);
+#endif
+
 #endif /* UTIL_H */


### PR DESCRIPTION
This is the patch I mentioned on https://github.com/stedolan/jq/issues/1066#issuecomment-494579743.
Patches 2 subtle buffer overruns in:
```c
// cchWideChar is the size, in characters, of the buffer indicated by lpWideCharStr.
// It was erroneously being passed twice that origina value, the corresponding number of bytes.
MultiByteToWideChar(CP_UTF8, 0, fname, -1, wfname, sz);
                                                   ^^
MultiByteToWideChar(CP_UTF8, 0, mode, -1, wmode, sz);
                                                 ^^
```
by way of unifying duplicate code into a separate function: `utf8_to_utf16()`.
Also added a corresponding wrapper for `open() -> _wopen()`.

~Pending: dealing with the unsolved problem with modules located in Unicode paths.~
Edit: dealt with.