### PR TITLE
Better dumping

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1189,7 +1189,11 @@ static jv f_debug(jq_state *jq, jv input) {
 }
 
 static jv f_stderr(jq_state *jq, jv input) {
-  jv_dumpf(jv_copy(input), stderr, 0);
+  jq_msg_cb cb;
+  void *data;
+  jq_get_stderr_cb(jq, &cb, &data);
+  if (cb != NULL)
+    cb(data, jv_copy(input));
   return input;
 }
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -49,6 +49,8 @@ struct jq_state {
   void *input_cb_data;
   jq_msg_cb debug_cb;
   void *debug_cb_data;
+  jq_msg_cb stderr_cb;
+  void *stderr_cb_data;
 };
 
 struct closure {
@@ -1237,6 +1239,16 @@ void jq_set_debug_cb(jq_state *jq, jq_msg_cb cb, void *data) {
 void jq_get_debug_cb(jq_state *jq, jq_msg_cb *cb, void **data) {
   *cb = jq->debug_cb;
   *data = jq->debug_cb_data;
+}
+
+void jq_set_stderr_cb(jq_state *jq, jq_msg_cb cb, void *data) {
+  jq->stderr_cb = cb;
+  jq->stderr_cb_data = data;
+}
+
+void jq_get_stderr_cb(jq_state *jq, jq_msg_cb *cb, void **data) {
+  *cb = jq->stderr_cb;
+  *data = jq->stderr_cb_data;
 }
 
 void

--- a/src/jq.h
+++ b/src/jq.h
@@ -38,6 +38,9 @@ void jq_get_input_cb(jq_state *, jq_input_cb *, void **);
 void jq_set_debug_cb(jq_state *, jq_msg_cb, void *);
 void jq_get_debug_cb(jq_state *, jq_msg_cb *, void **);
 
+void jq_set_stderr_cb(jq_state *, jq_msg_cb, void *);
+void jq_get_stderr_cb(jq_state *, jq_msg_cb *, void **);
+
 void jq_set_attrs(jq_state *, jv);
 jv jq_get_attrs(jq_state *);
 jv jq_get_jq_origin(jq_state *);

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -200,7 +200,7 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int
         printf(" for test at line number %u: %s\n", lineno, prog);
         pass = 0;
       }
-      jv as_string = jv_dump_string(jv_copy(expected), rand() & ~(JV_PRINT_COLOR|JV_PRINT_REFCOUNT));
+      jv as_string = jv_dump_string(jv_copy(expected), rand() & ~(JV_PRINT_COLOR|JV_PRINT_REFCOUNT|JV_PRINT_RAW));
       jv reparsed = jv_parse_sized(jv_string_value(as_string), jv_string_length_bytes(jv_copy(as_string)));
       assert(jv_equal(jv_copy(expected), jv_copy(reparsed)));
       jv_free(as_string);

--- a/src/jv.h
+++ b/src/jv.h
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#define JV_STRINGIFY(x) #x
+#define JV_TOSTRING(x) JV_STRINGIFY(x)
+
 typedef enum {
   JV_KIND_INVALID,
   JV_KIND_NULL,
@@ -207,12 +210,16 @@ enum jv_print_flags {
   JV_PRINT_REFCOUNT = 32,
   JV_PRINT_TAB      = 64,
   JV_PRINT_ISATTY   = 128,
+  // JV_PRINT_SPACE* stores the indentation level (3-bit number)
   JV_PRINT_SPACE0   = 256,
   JV_PRINT_SPACE1   = 512,
   JV_PRINT_SPACE2   = 1024,
 };
+// position of JV_PRINT_SPACE0 in the enum
+#define JV_PRINT_INDENT_OFFSET 8
+#define JV_PRINT_INDENT_MAX 7
 #define JV_PRINT_INDENT_FLAGS(n) \
-    ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? 0 : (n) << 8 | JV_PRINT_PRETTY)
+    ((n) < 0 || (n) > JV_PRINT_INDENT_MAX ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? 0 : (n) << JV_PRINT_INDENT_OFFSET | JV_PRINT_PRETTY)
 void jv_dumpf(jv, FILE *f, int flags);
 void jv_dump(jv, int flags);
 void jv_show(jv, int flags);

--- a/src/jv.h
+++ b/src/jv.h
@@ -214,6 +214,8 @@ enum jv_print_flags {
   JV_PRINT_SPACE0   = 256,
   JV_PRINT_SPACE1   = 512,
   JV_PRINT_SPACE2   = 1024,
+  JV_PRINT_RAW      = 2048,
+  JV_PRINT_RAWCOLOR = 4096,
 };
 // position of JV_PRINT_SPACE0 in the enum
 #define JV_PRINT_INDENT_OFFSET 8

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -115,9 +115,68 @@ static void put_indent(int n, int flags, FILE* fout, jv* strout, int T) {
   }
 }
 
+static void jvp_dump_char(int c, const char* cstart, const char* cend,
+    int ascii_only, char buf[static 32], FILE* F, jv* S, int T) {
+  // sizeof(buf) cannot be used, despite the size expression & guarantees
+  const int bufsize = 32;
+  assert(c != -1);
+  int unicode_escape = 0;
+  if (0x20 <= c && c <= 0x7E) {
+    // printable ASCII
+    if (c == '"' || c == '\\') {
+      put_char('\\', F, S, T);
+    }
+    put_char(c, F, S, T);
+  } else if (c < 0x20 || c == 0x7F) {
+    // ASCII control character
+    switch (c) {
+    case '\b':
+      put_char('\\', F, S, T);
+      put_char('b', F, S, T);
+      break;
+    case '\t':
+      put_char('\\', F, S, T);
+      put_char('t', F, S, T);
+      break;
+    case '\r':
+      put_char('\\', F, S, T);
+      put_char('r', F, S, T);
+      break;
+    case '\n':
+      put_char('\\', F, S, T);
+      put_char('n', F, S, T);
+      break;
+    case '\f':
+      put_char('\\', F, S, T);
+      put_char('f', F, S, T);
+      break;
+    default:
+      unicode_escape = 1;
+      break;
+    }
+  } else {
+    if (ascii_only) {
+      unicode_escape = 1;
+    } else {
+      put_buf(cstart, cend - cstart, F, S, T);
+    }
+  }
+  if (unicode_escape) {
+    if (c <= 0xffff) {
+      snprintf(buf, bufsize, "\\u%04x", c);
+    } else {
+      c -= 0x10000;
+      snprintf(buf, bufsize, "\\u%04x\\u%04x",
+              0xD800 | ((c & 0xffc00) >> 10),
+              0xDC00 | (c & 0x003ff));
+    }
+    put_str(buf, F, S, T);
+  }
+}
 
 static void jvp_dump_string(jv str, int flags, FILE* F, jv* S) {
   assert(jv_get_kind(str) == JV_KIND_STRING);
+  const int ascii_only = flags & JV_PRINT_ASCII;
   const int T = flags & JV_PRINT_ISATTY;
   const char* i = jv_string_value(str);
   const char* end = i + jv_string_length_bytes(jv_copy(str));
@@ -126,59 +185,7 @@ static void jvp_dump_string(jv str, int flags, FILE* F, jv* S) {
   char buf[32];
   put_char('"', F, S, T);
   while ((i = jvp_utf8_next((cstart = i), end, &c))) {
-    assert(c != -1);
-    int unicode_escape = 0;
-    if (0x20 <= c && c <= 0x7E) {
-      // printable ASCII
-      if (c == '"' || c == '\\') {
-        put_char('\\', F, S, T);
-      }
-      put_char(c, F, S, T);
-    } else if (c < 0x20 || c == 0x7F) {
-      // ASCII control character
-      switch (c) {
-      case '\b':
-        put_char('\\', F, S, T);
-        put_char('b', F, S, T);
-        break;
-      case '\t':
-        put_char('\\', F, S, T);
-        put_char('t', F, S, T);
-        break;
-      case '\r':
-        put_char('\\', F, S, T);
-        put_char('r', F, S, T);
-        break;
-      case '\n':
-        put_char('\\', F, S, T);
-        put_char('n', F, S, T);
-        break;
-      case '\f':
-        put_char('\\', F, S, T);
-        put_char('f', F, S, T);
-        break;
-      default:
-        unicode_escape = 1;
-        break;
-      }
-    } else {
-      if (flags & JV_PRINT_ASCII) {
-        unicode_escape = 1;
-      } else {
-        put_buf(cstart, i - cstart, F, S, T);
-      }
-    }
-    if (unicode_escape) {
-      if (c <= 0xffff) {
-        snprintf(buf, sizeof(buf), "\\u%04x", c);
-      } else {
-        c -= 0x10000;
-        snprintf(buf, sizeof(buf), "\\u%04x\\u%04x",
-                0xD800 | ((c & 0xffc00) >> 10),
-                0xDC00 | (c & 0x003ff));
-      }
-      put_str(buf, F, S, T);
-    }
+    jvp_dump_char(c, cstart, i, ascii_only, buf, F, S, T);
   }
   assert(c != -1);
   put_char('"', F, S, T);

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -109,7 +109,7 @@ static void put_indent(int n, int flags, FILE* fout, jv* strout, int T) {
     while (n--)
       put_char('\t', fout, strout, T);
   } else {
-    n *= ((flags & (JV_PRINT_SPACE0 | JV_PRINT_SPACE1 | JV_PRINT_SPACE2)) >> 8);
+    n *= ((flags & (JV_PRINT_SPACE0 | JV_PRINT_SPACE1 | JV_PRINT_SPACE2)) >> JV_PRINT_INDENT_OFFSET);
     while (n--)
       put_char(' ', fout, strout, T);
   }

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -115,8 +115,10 @@ static void put_indent(int n, int flags, FILE* fout, jv* strout, int T) {
   }
 }
 
-static void jvp_dump_string(jv str, int ascii_only, FILE* F, jv* S, int T) {
+
+static void jvp_dump_string(jv str, int flags, FILE* F, jv* S) {
   assert(jv_get_kind(str) == JV_KIND_STRING);
+  const int T = flags & JV_PRINT_ISATTY;
   const char* i = jv_string_value(str);
   const char* end = i + jv_string_length_bytes(jv_copy(str));
   const char* cstart;
@@ -160,7 +162,7 @@ static void jvp_dump_string(jv str, int ascii_only, FILE* F, jv* S, int T) {
         break;
       }
     } else {
-      if (ascii_only) {
+      if (flags & JV_PRINT_ASCII) {
         unicode_escape = 1;
       } else {
         put_buf(cstart, i - cstart, F, S, T);
@@ -212,7 +214,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
       jv msg = jv_invalid_get_msg(jv_copy(x));
       if (jv_get_kind(msg) == JV_KIND_STRING) {
         put_str("<invalid:", F, S, flags & JV_PRINT_ISATTY);
-        jvp_dump_string(msg, flags | JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+        jvp_dump_string(msg, flags | JV_PRINT_ASCII, F, S);
         put_str(">", F, S, flags & JV_PRINT_ISATTY);
       } else {
         put_str("<invalid>", F, S, flags & JV_PRINT_ISATTY);
@@ -257,7 +259,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     break;
   }
   case JV_KIND_STRING:
-    jvp_dump_string(x, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+    jvp_dump_string(x, flags, F, S);
     if (flags & JV_PRINT_REFCOUNT)
       put_refcnt(C, refcnt, F, S, flags & JV_PRINT_ISATTY);
     break;
@@ -344,7 +346,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
 
       first = 0;
       if (color) put_str(FIELD_COLOR, F, S, flags & JV_PRINT_ISATTY);
-      jvp_dump_string(key, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
+      jvp_dump_string(key, flags, F, S);
       jv_free(key);
       if (color) put_str(COLRESET, F, S, flags & JV_PRINT_ISATTY);
 

--- a/src/main.c
+++ b/src/main.c
@@ -240,6 +240,11 @@ static void debug_cb(void *data, jv input) {
   fprintf(stderr, "\n");
 }
 
+static void stderr_cb(void *data, jv input) {
+  int dumpopts = *(int *)data;
+  jv_dumpf(input, stderr, (dumpopts & ~JV_PRINT_PRETTY) | JV_PRINT_RAW);
+}
+
 #ifdef WIN32
 int umain(int argc, char* argv[]);
 
@@ -655,6 +660,9 @@ int main(int argc, char* argv[]) {
 
   // Let jq program call `debug` builtin and have that go somewhere
   jq_set_debug_cb(jq, debug_cb, &dumpopts);
+
+  // Let jq program call `stderr` builtin and have that go somewhere
+  jq_set_stderr_cb(jq, stderr_cb, &dumpopts);
 
   if (nfiles == 0)
     jq_util_input_add_input(input_state, "-");

--- a/src/main.c
+++ b/src/main.c
@@ -358,7 +358,7 @@ int main(int argc, char* argv[]) {
         if (!short_opts) continue;
       }
       if (isoption(argv[i], 'c', "compact-output", &short_opts)) {
-        dumpopts &= ~(JV_PRINT_TAB | JV_PRINT_INDENT_FLAGS(7));
+        dumpopts &= ~(JV_PRINT_TAB | JV_PRINT_INDENT_FLAGS(JV_PRINT_INDENT_MAX));
         if (!short_opts) continue;
       }
       if (isoption(argv[i], 'C', "color-output", &short_opts)) {
@@ -412,7 +412,7 @@ int main(int argc, char* argv[]) {
 #endif
       }
       if (isoption(argv[i], 0, "tab", &short_opts)) {
-        dumpopts &= ~JV_PRINT_INDENT_FLAGS(7);
+        dumpopts &= ~JV_PRINT_INDENT_FLAGS(JV_PRINT_INDENT_MAX);
         dumpopts |= JV_PRINT_TAB | JV_PRINT_PRETTY;
         continue;
       }
@@ -421,10 +421,11 @@ int main(int argc, char* argv[]) {
           fprintf(stderr, "%s: --indent takes one parameter\n", progname);
           die();
         }
-        dumpopts &= ~(JV_PRINT_TAB | JV_PRINT_INDENT_FLAGS(7));
+        dumpopts &= ~(JV_PRINT_TAB | JV_PRINT_INDENT_FLAGS(JV_PRINT_INDENT_MAX));
         int indent = atoi(argv[i+1]);
-        if (indent < -1 || indent > 7) {
-          fprintf(stderr, "%s: --indent takes a number between -1 and 7\n", progname);
+        if (indent < -1 || indent > JV_PRINT_INDENT_MAX) {
+          fprintf(stderr,
+                  "%s: --indent takes a number between -1 and " JV_TOSTRING(JV_PRINT_INDENT_MAX) "\n", progname);
           die();
         }
         dumpopts |= JV_PRINT_INDENT_FLAGS(indent);


### PR DESCRIPTION
A fair amount of refactoring went into this PR to make each step clear and prevent issues like those in #1789, where escaping wasn't correctly handled. I'll summarize the non-bugfix commits, and the commit messages for the fixes follow. `jvp_dump_string` changed from consuming a boolean-use `int ascii_only` to `enum jv_print_flags` `int flags`. This makes `jvp_dump_string` more capable of responding to input formats, reducing pressure on consumers to get it right. `jvp_dump_char` is factored out from `jvp_dump_string`, making future increases in complexity to both clearer. `JV_PRINT_RAW` and `JV_PRINT_RAWCOLOR` flags are introduced to `enum jv_print_flags`, consolidating prints in `main.c`'s `process` to `jv_dump(result, dumpopts)`. The `JV_PRINT_RAW` flag is not passed down to recursive `jv_dump*` calls for arrays or objects. `JV_PRINT_RAWCOLOR` is unset by default and has no API currently, but is there if colored, raw output is desired in the future. `JV_PRINT_RAWCOLOR` avoids problems with colored output by noticing when a type would be raw printed and disabling `JV_PRINT_COLOR` before that's a problem.

### Fix `stderr/0` builtin to match documentation

> It's supposed to print raw, compact, and with no decoration or trailing newline. Previously, it would print JSON formatted, compact, with no trailing newline and no easy way to obtain one, and ignoring the `--ascii-output` / `-a` flag.

`f_stderr`, instead of calling `jv_dumpf(jv_copy(input), stderr, 0)`, now has a `stderr_cb` setup similar to `f_debug` that it uses identically. The only functional difference is `main.c`'s `stderr_cb`:

```c
static void stderr_cb(void *data, jv input) {
  int dumpopts = *(int *)data;
  jv_dumpf(input, stderr, (dumpopts & ~JV_PRINT_PRETTY) | JV_PRINT_RAW);
  // debug_cb prints a newline here.
}
```

### Bring `--raw-output` and `--ascii-output` to agreement

> Escapes are still printed whenever characters outside the ASCII plane are encountered. To avoid ambiguity, backslash is the only ASCII character escaped (as `\\`).
>
> Fixes #1788, properly this time. Closes #1789.

`jvp_dump_char` gains a boolean-use `int raw` parameter that is used to always print ASCII characters (save backslash) and turn on escapes for everything else. `jvp_dump_string` learns to handle raw strings in the non-`(raw && !ascii_only)` path. Due to the earlier changes, every other use of raw strings is immediately corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stedolan/jq/1993)
<!-- Reviewable:end -->
