### PR TITLE
Use decnum for addition

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -90,11 +90,7 @@ static jv f_plus(jq_state *jq, jv input, jv a, jv b) {
     jv_free(b);
     return a;
   } else if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    jv r = jv_number(jv_number_value(a) +
-                     jv_number_value(b));
-    jv_free(a);
-    jv_free(b);
-    return r;
+    return jv_number_add(a, b);
   } else if (jv_get_kind(a) == JV_KIND_STRING && jv_get_kind(b) == JV_KIND_STRING) {
     return jv_string_concat(a, b);
   } else if (jv_get_kind(a) == JV_KIND_ARRAY && jv_get_kind(b) == JV_KIND_ARRAY) {

--- a/src/jv.c
+++ b/src/jv.c
@@ -486,8 +486,9 @@ jv jv_number_add(jv a, jv b) {
   if (jvp_number_is_literal(a) && jvp_number_is_literal(b)) {
     decNumber *da = jvp_dec_number_ptr(a);
     decNumber *db = jvp_dec_number_ptr(b);
-    unsigned digits = MAX(da->digits, db->digits) + 1;
 
+    unsigned digits = MAX(da->digits+da->exponent, db->digits+db->exponent) -
+                      MIN(da->exponent, db->exponent) + 1;
     jvp_literal_number *nlit = jvp_literal_number_alloc(digits);
     nlit->refcnt = JV_REFCNT_INIT;
     nlit->literal_data = NULL;
@@ -495,6 +496,7 @@ jv jv_number_add(jv a, jv b) {
 
     decContext *ctx = DEC_CONTEXT();
     decNumberAdd(&nlit->num_decimal, da, db, ctx);
+    decNumberReduce(&nlit->num_decimal, &nlit->num_decimal, ctx);
     // TODO: Check context for error?
 
     jv_free(a);

--- a/src/jv.c
+++ b/src/jv.c
@@ -230,28 +230,24 @@ static decContext* tsd_dec_ctx_get(pthread_key_t *key) {
     return ctx;
   }
 
-  decContext _ctx = {
-      0,
-      DEC_MAX_EMAX,
-      DEC_MIN_EMAX,
-      DEC_ROUND_HALF_UP,
-      0, /*no errors*/
-      0, /*status*/
-      0, /*no clamping*/
-    };
-  if (key == &dec_ctx_key) {
-    _ctx.digits = DEC_MAX_DIGITS;
-  } else if (key == &dec_ctx_dbl_key) {
-    _ctx.digits = BIN64_DEC_PRECISION;
+  ctx = malloc(sizeof(decContext));
+  if (!ctx) {
+    return ctx;
   }
 
-  ctx = malloc(sizeof(decContext));
-  if (ctx) {
-    *ctx = _ctx;
-    if (pthread_setspecific(*key, ctx) != 0) {
-      fprintf(stderr, "error: cannot store thread specific data");
-      abort();
-    }
+  // Initialize the context, clear any traps
+  decContextDefault(ctx, DEC_INIT_BASE);
+  ctx->traps = 0;
+
+  if (key == &dec_ctx_key) {
+    ctx->digits = DEC_MAX_DIGITS;
+  } else if (key == &dec_ctx_dbl_key) {
+    ctx->digits = BIN64_DEC_PRECISION;
+  }
+
+  if (pthread_setspecific(*key, ctx) != 0) {
+    fprintf(stderr, "error: cannot store thread specific data");
+    abort();
   }
   return ctx;
 }

--- a/src/jv.c
+++ b/src/jv.c
@@ -496,7 +496,7 @@ jv jv_number_add(jv a, jv b) {
 
     decContext *ctx = DEC_CONTEXT();
     decNumberAdd(&nlit->num_decimal, da, db, ctx);
-    decNumberReduce(&nlit->num_decimal, &nlit->num_decimal, ctx);
+    decNumberTrim(&nlit->num_decimal);
     // TODO: Check context for error?
 
     jv_free(a);

--- a/src/jv.c
+++ b/src/jv.c
@@ -487,12 +487,13 @@ jv jv_number_add(jv a, jv b) {
     decNumber *da = jvp_dec_number_ptr(a);
     decNumber *db = jvp_dec_number_ptr(b);
     unsigned digits = MAX(da->digits, db->digits) + 1;
-    jvp_literal_number *nlit = jvp_literal_number_alloc(digits);
 
+    jvp_literal_number *nlit = jvp_literal_number_alloc(digits);
     nlit->refcnt = JV_REFCNT_INIT;
     nlit->literal_data = NULL;
-    decContext *ctx = DEC_CONTEXT();
     nlit->num_double = NAN;
+
+    decContext *ctx = DEC_CONTEXT();
     decNumberAdd(&nlit->num_decimal, da, db, ctx);
     // TODO: Check context for error?
 

--- a/src/jv.h
+++ b/src/jv.h
@@ -63,6 +63,7 @@ jv jv_number(double);
 jv jv_number_with_literal(const char*);
 double jv_number_value(jv);
 int jv_is_integer(jv);
+jv jv_number_add(jv a, jv b);
 
 int jv_number_has_literal(jv n);
 const char* jv_number_get_literal(jv);

--- a/src/parser.c
+++ b/src/parser.c
@@ -372,7 +372,7 @@ static block constant_fold(block a, block b, int op) {
     int cmp = jv_cmp(jv_a, jv_b);
 
     switch (op) {
-    case '+': res = jv_number(na + nb); break;
+    case '+': res = jv_number_add(jv_copy(jv_a), jv_copy(jv_b)); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;

--- a/src/parser.c
+++ b/src/parser.c
@@ -369,7 +369,10 @@ static block constant_fold(block a, block b, int op) {
     double na = jv_number_value(jv_a);
     double nb = jv_number_value(jv_b);
 
-    int cmp = jv_cmp(jv_a, jv_b);
+    // Once we implement the rest of the arithmetic operations, all of these
+    // copy/frees can be optimized away, if we move the call to jv_cmp inside
+    // the switch cases. We'd just need to move the final frees into the default
+    int cmp = jv_cmp(jv_copy(jv_a), jv_copy(jv_b));
 
     switch (op) {
     case '+': res = jv_number_add(jv_copy(jv_a), jv_copy(jv_b)); break;
@@ -384,6 +387,8 @@ static block constant_fold(block a, block b, int op) {
     case GREATEREQ: res = (cmp >= 0 ? jv_true() : jv_false()); break;
     default: break;
     }
+    jv_free(jv_a);
+    jv_free(jv_b);
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {
     res = jv_string_concat(block_const(a),  block_const(b));
   } else {

--- a/src/parser.y
+++ b/src/parser.y
@@ -222,7 +222,10 @@ static block constant_fold(block a, block b, int op) {
     double na = jv_number_value(jv_a);
     double nb = jv_number_value(jv_b);
 
-    int cmp = jv_cmp(jv_a, jv_b);
+    // Once we implement the rest of the arithmetic operations, all of these
+    // copy/frees can be optimized away, if we move the call to jv_cmp inside
+    // the switch cases. We'd just need to move the final frees into the default
+    int cmp = jv_cmp(jv_copy(jv_a), jv_copy(jv_b));
 
     switch (op) {
     case '+': res = jv_number_add(jv_copy(jv_a), jv_copy(jv_b)); break;
@@ -237,6 +240,8 @@ static block constant_fold(block a, block b, int op) {
     case GREATEREQ: res = (cmp >= 0 ? jv_true() : jv_false()); break;
     default: break;
     }
+    jv_free(jv_a);
+    jv_free(jv_b);
   } else if (op == '+' && block_const_kind(a) == JV_KIND_STRING) {
     res = jv_string_concat(block_const(a),  block_const(b));
   } else {

--- a/src/parser.y
+++ b/src/parser.y
@@ -225,7 +225,7 @@ static block constant_fold(block a, block b, int op) {
     int cmp = jv_cmp(jv_a, jv_b);
 
     switch (op) {
-    case '+': res = jv_number(na + nb); break;
+    case '+': res = jv_number_add(jv_copy(jv_a), jv_copy(jv_b)); break;
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1698,8 +1698,13 @@ map(. == 1)
 null
 false
 
+# Applying addition to the value will not truncate the result to double
 
-# Applying arithmetic to the value will truncate the result to double
+. + 1
+418502930602131457
+418502930602131458
+
+# Applying other arithmetic to the value will truncate the result to double
 
 . - 10
 13911860366432393


### PR DESCRIPTION
This is meant to be an example for how we might use decNumber to start implementing some arithmetic (and potentially some math functions, depending on what's available). It's not quite ready for merge- we should switch to using this in our constant folding code, and I still need to figure out what errors to look for on the context after the addition.

This adds a new `jv_number_add` function that adds two number jvs, consumes a reference for each of them, and returns a new number.

I changed a couple small things about allocation of literal numbers:
- I switched to using the `decContextDefault` function to make sure we initialize the context properly (we had an error that used the wrong value for one of the fields- I'm not sure what the impact really was, though)
- I reduced the number of units we allocate by 1, as there's always at least one in the `decNumber` itself.