### PR TITLE
Fix assertion when using multiple data imports

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -1347,6 +1347,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
       code[pos++] = nesting_level(bc, curr->bound_by);
       uint16_t var = (uint16_t)curr->bound_by->imm.intval;
       code[pos++] = var;
+      if (var > maxvar) maxvar = var;
     } else if (op->flags & OP_HAS_CONSTANT) {
       code[pos++] = jv_array_length(jv_copy(constant_pool));
       constant_pool = jv_array_append(constant_pool, jv_copy(curr->imm.constant));


### PR DESCRIPTION
```jq
import "a" as $a;
import "b" as $b;
def f: $a,$b;
f
```

This fails an assertion: `Assertion failed: (var < fr->bc->nlocals), function frame_local_var, file src/execute.c, line 104.`

The issue _appears_ to be that we don't properly increment the number of local vars defined in the frame where we `STORE_GLOBAL`, which means we can easily have more vars stored than we expect in our assertions. The code for `STOREV` _does_ increment this, so I duplicated that logic into `STORE_GLOBAL`. I can't think of any ways that this might cause issues. @nicowilliams can you?