### PR TITLE
Fix to incorrect --stream paths

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -113,10 +113,11 @@ sections:
 
       * `--stream`:
 
-        Parse the input in streaming fashion, outputing arrays of path
-        and leaf values (scalars and empty arrays or empty objects).
-        For example, `"a"` becomes `[[],"a"]`, and `[[],"a",["b"]]`
-        becomes `[[0],[]]`, `[[1],"a"]`, and `[[1,0],"b"]`.
+        Parse the input in depth-first, streaming fashion, outputting 
+        arrays of path and leaf values (scalars and empty arrays or 
+        empty objects). For example, `"a"` becomes `[[],"a"]`, and 
+        `[[],"a",["b"]]` becomes `[[0],[]]`, `[[1],"a"]`, and 
+        `[[2,0],"b"]`.
 
         This is useful for processing very large inputs.  Use this in
         conjunction with filtering and the `reduce` and `foreach` syntax

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -116,8 +116,8 @@ sections:
         Parse the input in depth-first, streaming fashion, outputting 
         arrays of path and leaf values (scalars and empty arrays or 
         empty objects). For example, `"a"` becomes `[[],"a"]`, and 
-        `[[],"a",["b"]]` becomes `[[0],[]]`, `[[1],"a"]`, and 
-        `[[2,0],"b"]`.
+        `[[],"a",["b"]]` becomes `[[0],[]]`, `[[1],"a"]`, `[[2,0],"b"]`,
+        `[[2,0]]` and `[[2]]`.
 
         This is useful for processing very large inputs.  Use this in
         conjunction with filtering and the `reduce` and `foreach` syntax


### PR DESCRIPTION
Thought something was wrong with the example provided against the --stream option. Proved that the index of the path to "b" was incorrect by running the example on the terminal.  Instead of `[[1,0],"b"]` it should read `[[2,0],"b"]` . 

Additionally, this isn't the whole stream. Given it's a depth-first traversal, after visiting descendants, it will visit the paths of the ancestors too. However I guess these have been omitted deliberately for brevity? 

If you prefer the full sequence I'll force push a fix to this PR branch which contains the ancestor paths traversed too.  

## Example in terminal

```
echo '[[],"a",["b"]]' | jq --stream --compact-output
[[0],[]]
[[1],"a"]
[[2,0],"b"]
[[2,0]]
[[2]]
```