### PR TITLE
Correct object construction with variables example

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -616,7 +616,7 @@ sections:
 
           produces
 
-              {"f o o":"f o o","b a r":"f o o"}
+              {"foo":"f o o","b a r":"f o o"}
 
         examples:
           - program: '{user, title: .titles[]}'


### PR DESCRIPTION
Trunk `jq` gives the behavior described in the manual text, but the example is wrong, using the value of `$foo` as the key instead of the name of the variable.