### PR TITLE
Fix the default search paths and documentation

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3281,8 +3281,8 @@ sections:
       For paths starting with `~/`, the user's home directory is
       substituted for `~`.
 
-      For paths starting with `$ORIGIN/`, the path of the jq executable
-      is substituted for `$ORIGIN`.
+      For paths starting with `$ORIGIN/`, the directory where the jq
+      executable is located is substituted for `$ORIGIN`.
 
       For paths starting with `./` or paths that are `.`, the path of
       the including file is substituted for `.`.  For top-level programs

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -2765,8 +2765,8 @@ sections:
       For paths starting with "~/", the user's home directory is
       substituted for "~".
 
-      For paths starting with "$ORIGIN/", the path of the jq executable
-      is substituted for "$ORIGIN".
+      For paths starting with "$ORIGIN/", the directory where the jq
+      executable is located is substituted for "$ORIGIN".
 
       For paths starting with "./" or paths that are ".", the path of
       the including file is substituted for ".".  For top-level programs

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -3150,8 +3150,8 @@ sections:
       For paths starting with "~/", the user's home directory is
       substituted for "~".
 
-      For paths starting with "$ORIGIN/", the path of the jq executable
-      is substituted for "$ORIGIN".
+      For paths starting with "$ORIGIN/", the directory where the jq
+      executable is located is substituted for "$ORIGIN".
 
       For paths starting with "./" or paths that are ".", the path of
       the including file is substituted for ".".  For top-level programs

--- a/src/main.c
+++ b/src/main.c
@@ -592,7 +592,7 @@ int main(int argc, char* argv[]) {
     // Default search path list
     lib_search_paths = JV_ARRAY(jv_string("~/.jq"),
                                 jv_string("$ORIGIN/../lib/jq"),
-                                jv_string("$ORIGIN/lib"));
+                                jv_string("$ORIGIN/../lib"));
   }
   jq_set_attr(jq, jv_string("JQ_LIBRARY_PATH"), lib_search_paths);
 


### PR DESCRIPTION
~I fixed the documentation for default search paths.~
Ref: https://github.com/jqlang/jq/blob/f88c4e5888d6d125695444d044df4bb55ad75888/src/main.c#L591-L596

EDIT: Based on the discussion, we decided to fix the implementation to comply the documentation.


Also clarify that `$ORIGIN` is replaced by the directory where the executable is located. This is the intention of `JQ_ORIGIN` in the source code.
Ref: https://github.com/jqlang/jq/blob/f88c4e5888d6d125695444d044df4bb55ad75888/src/main.c#L604