### PR TITLE
Adds "toboolean" builtin function for converting strings to booleans

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -1476,6 +1476,18 @@ sections:
             input: '[1, "1"]'
             output: ['1', '1']
 
+      - title: "`tobool`"
+        body: |
+
+          The `tobool` function parses its input as a boolean. It
+          will convert correctly-formatted strings to their boolean
+          equivalent, leave booleans alone, and give an error on all other input.
+
+        examples:
+          - program: '.[] | tobool'
+            input: '["true", "false", true, false]'
+            output: ['true', 'false', 'true', 'false']
+
       - title: "`tostring`"
         body: |
 

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -1476,15 +1476,15 @@ sections:
             input: '[1, "1"]'
             output: ['1', '1']
 
-      - title: "`tobool`"
+      - title: "`toboolean`"
         body: |
 
-          The `tobool` function parses its input as a boolean. It
+          The `toboolean` function parses its input as a boolean. It
           will convert correctly-formatted strings to their boolean
           equivalent, leave booleans alone, and give an error on all other input.
 
         examples:
-          - program: '.[] | tobool'
+          - program: '.[] | toboolean'
             input: '["true", "false", true, false]'
             output: ['true', 'false', 'true', 'false']
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1556,6 +1556,21 @@ jq \'\.[] | tonumber\'
 .
 .IP "" 0
 .
+.SS "tobool"
+The \fBtobool\fR function parses its input as a boolean\. It will convert correctly\-formatted strings to their boolean equivalent, leave booleans alone, and give an error on all other input\.
+.
+.IP "" 4
+.
+.nf
+
+jq \'\.[] | tobool\'
+   ["true", "false", true, false]
+=> true, false, true, false
+.
+.fi
+.
+.IP "" 0
+.
 .SS "tostring"
 The \fBtostring\fR function prints its input as a string\. Strings are left unchanged, and all other values are JSON\-encoded\.
 .

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1556,14 +1556,14 @@ jq \'\.[] | tonumber\'
 .
 .IP "" 0
 .
-.SS "tobool"
-The \fBtobool\fR function parses its input as a boolean\. It will convert correctly\-formatted strings to their boolean equivalent, leave booleans alone, and give an error on all other input\.
+.SS "toboolean"
+The \fBtoboolean\fR function parses its input as a boolean\. It will convert correctly\-formatted strings to their boolean equivalent, leave booleans alone, and give an error on all other input\.
 .
 .IP "" 4
 .
 .nf
 
-jq \'\.[] | tobool\'
+jq \'\.[] | toboolean\'
    ["true", "false", true, false]
 => true, false, true, false
 .

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -486,7 +486,7 @@ static jv f_tonumber(jq_state *jq, jv input) {
   return type_error(input, "cannot be parsed as a number");
 }
 
-static jv f_tobool(jq_state *jq, jv input) {
+static jv f_toboolean(jq_state *jq, jv input) {
   if (jv_get_kind(input) == JV_KIND_TRUE || jv_get_kind(input) == JV_KIND_FALSE) {
     return input;
   }
@@ -1867,7 +1867,7 @@ BINOPS
   CFUNC(f_dump, "tojson", 1),
   CFUNC(f_json_parse, "fromjson", 1),
   CFUNC(f_tonumber, "tonumber", 1),
-  CFUNC(f_tobool, "tobool", 1),
+  CFUNC(f_toboolean, "toboolean", 1),
   CFUNC(f_tostring, "tostring", 1),
   CFUNC(f_keys, "keys", 1),
   CFUNC(f_keys_unsorted, "keys_unsorted", 1),

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -491,11 +491,13 @@ static jv f_tobool(jq_state *jq, jv input) {
     return input;
   }
   if (jv_get_kind(input) == JV_KIND_STRING) {
-    jv parsed = jv_parse(jv_string_value(input));
-    jv_kind parsed_kind = jv_get_kind(parsed);
-    if (parsed_kind == JV_KIND_TRUE || parsed_kind == JV_KIND_FALSE) {
+    const char *s = jv_string_value(input);
+    if (strcmp(s, "true") == 0) {
       jv_free(input);
-      return parsed;
+      return jv_true();
+    } else if (strcmp(s, "false") == 0) {
+      jv_free(input);
+      return jv_false();
     }
   }
   return type_error(input, "cannot be parsed as a boolean");

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -486,6 +486,21 @@ static jv f_tonumber(jq_state *jq, jv input) {
   return type_error(input, "cannot be parsed as a number");
 }
 
+static jv f_tobool(jq_state *jq, jv input) {
+  if (jv_get_kind(input) == JV_KIND_TRUE || jv_get_kind(input) == JV_KIND_FALSE) {
+    return input;
+  }
+  if (jv_get_kind(input) == JV_KIND_STRING) {
+    jv parsed = jv_parse(jv_string_value(input));
+    jv_kind parsed_kind = jv_get_kind(parsed);
+    if (parsed_kind == JV_KIND_TRUE || parsed_kind == JV_KIND_FALSE) {
+      jv_free(input);
+      return parsed;
+    }
+  }
+  return type_error(input, "cannot be parsed as a boolean");
+}
+
 static jv f_length(jq_state *jq, jv input) {
   if (jv_get_kind(input) == JV_KIND_ARRAY) {
     return jv_number(jv_array_length(input));
@@ -1850,6 +1865,7 @@ BINOPS
   CFUNC(f_dump, "tojson", 1),
   CFUNC(f_json_parse, "fromjson", 1),
   CFUNC(f_tonumber, "tonumber", 1),
+  CFUNC(f_tobool, "tobool", 1),
   CFUNC(f_tostring, "tostring", 1),
   CFUNC(f_keys, "keys", 1),
   CFUNC(f_keys_unsorted, "keys_unsorted", 1),

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -638,11 +638,11 @@ null
 4
 15
 
-map(tobool)
+map(toboolean)
 ["false","true",false,true]
 [false,true,false,true]
 
-.[] | try tobool catch .
+.[] | try toboolean catch .
 [null,0,"tru","truee","fals","falsee",[],{}]
 "null (null) cannot be parsed as a boolean"
 "number (0) cannot be parsed as a boolean"

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -638,6 +638,21 @@ null
 4
 15
 
+map(tobool)
+["false","true",false,true]
+[false,true,false,true]
+
+.[] | try tobool catch .
+[null,0,"tru","truee","fals","falsee",[],{}]
+"null (null) cannot be parsed as a boolean"
+"number (0) cannot be parsed as a boolean"
+"string (\"tru\") cannot be parsed as a boolean"
+"string (\"truee\") cannot be parsed as a boolean"
+"string (\"fals\") cannot be parsed as a boolean"
+"string (\"falsee\") cannot be parsed as a boolean"
+"array ([]) cannot be parsed as a boolean"
+"object ({}) cannot be parsed as a boolean"
+
 [{"a":42},.object,10,.num,false,true,null,"b",[1,4]] | .[] as $x | [$x == .[]]
 {"object": {"a":42}, "num":10.0}
 [true,  true,  false, false, false, false, false, false, false]

--- a/tests/man.test
+++ b/tests/man.test
@@ -440,7 +440,7 @@ sqrt
 1
 1
 
-.[] | tobool
+.[] | toboolean
 ["true", "false", true, false]
 true
 false

--- a/tests/man.test
+++ b/tests/man.test
@@ -440,6 +440,13 @@ sqrt
 1
 1
 
+.[] | tobool
+["true", "false", true, false]
+true
+false
+true
+false
+
 .[] | tostring
 [1, "1", [1]]
 "1"


### PR DESCRIPTION
This PR adds a builtin `tobool` function which converts string values to booleans, similar to `tonumber`.

This was motivated by the need to create a boolean value based on a value provided through an environment variable. All environment variables are strings, so I needed some mechanism to convert from a string to a boolean. A contrived example of what I wanted (and what this PR implements) is:

```shell
$ TEST=true jq --null-input '{"mytest": env.TEST | tobool}'
{
  "mytest": true
}
```

This boolean conversion is already achievable using a function defined in the filter:

```shell
$ TEST=true jq --null-input 'def tobool: {"true":true, "false":false}[ . | tostring ]; {"mytest": env.TEST | tobool}'
```

The inline function definition is rather unwieldily for my use case, making the availability of the builtin function more appealing.

