### PR TITLE
Remove undefined behavior caught by LLVM 10 UBSAN.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ endif
 include_HEADERS = src/jv.h src/jq.h
 
 if ENABLE_UBSAN
-AM_CFLAGS += -fsanitize=undefined
+AM_CFLAGS += -fsanitize=undefined -fno-sanitize-recover=undefined
 endif
 
 AM_CPPFLAGS = -I$(srcdir)/src

--- a/src/exec_stack.h
+++ b/src/exec_stack.h
@@ -61,8 +61,10 @@ static void stack_init(struct stack* s) {
 
 static void stack_reset(struct stack* s) {
   assert(s->limit == 0 && "stack freed while not empty");
-  char* mem_start = s->mem_end - ( -s->bound + ALIGNMENT);
-  free(mem_start);
+  if(s->mem_end != NULL) {
+    char* mem_start = s->mem_end - ( -s->bound + ALIGNMENT);
+    free(mem_start);
+  }
   stack_init(s);
 }
 
@@ -80,7 +82,7 @@ static stack_ptr* stack_block_next(struct stack* s, stack_ptr p) {
 
 static void stack_reallocate(struct stack* s, size_t sz) {
   int old_mem_length = -(s->bound) + ALIGNMENT;
-  char* old_mem_start = s->mem_end - old_mem_length;
+  char* old_mem_start = (s->mem_end != NULL) ? (s->mem_end - old_mem_length) : NULL;
 
   int new_mem_length = align_round_up((old_mem_length + sz + 256) * 2);
   char* new_mem_start = jv_mem_realloc(old_mem_start, new_mem_length);

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <limits.h>
 #include "jv_alloc.h"
 #include "jv_type_private.h"
 
@@ -73,12 +74,17 @@ jv jv_get(jv t, jv k) {
     }
   } else if (jv_get_kind(t) == JV_KIND_ARRAY && jv_get_kind(k) == JV_KIND_NUMBER) {
     if(jv_is_integer(k)){
-      int idx = (int)jv_number_value(k);
-      if (idx < 0)
-        idx += jv_array_length(jv_copy(t));
-      v = jv_array_get(t, idx);
-      if (!jv_is_valid(v)) {
-        jv_free(v);
+      double idx_raw = jv_number_value(k);
+      if (idx_raw < INT_MAX && idx_raw > INT_MIN) {
+        int idx = (int)jv_number_value(k);
+        if (idx < 0)
+          idx += jv_array_length(jv_copy(t));
+        v = jv_array_get(t, idx);
+        if (!jv_is_valid(v)) {
+          jv_free(v);
+          v = jv_null();
+        }
+      } else {
         v = jv_null();
       }
       jv_free(k);

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -422,61 +422,65 @@ static int unhex4(char* hex) {
 }
 
 static pfunc found_string(struct jv_parser* p) {
-  char* in = p->tokenbuf;
-  char* out = p->tokenbuf;
-  char* end = p->tokenbuf + p->tokenpos;
+  if (p->tokenbuf != NULL) {
+    char* in = p->tokenbuf;
+    char* out = p->tokenbuf;
+    char* end = p->tokenbuf + p->tokenpos;
 
-  while (in < end) {
-    char c = *in++;
-    if (c == '\\') {
-      if (in >= end)
-        return "Expected escape character at end of string";
-      c = *in++;
-      switch (c) {
-      case '\\':
-      case '"':
-      case '/': *out++ = c;    break;
-      case 'b': *out++ = '\b'; break;
-      case 'f': *out++ = '\f'; break;
-      case 't': *out++ = '\t'; break;
-      case 'n': *out++ = '\n'; break;
-      case 'r': *out++ = '\r'; break;
+    while (in < end) {
+      char c = *in++;
+      if (c == '\\') {
+        if (in >= end)
+          return "Expected escape character at end of string";
+        c = *in++;
+        switch (c) {
+        case '\\':
+        case '"':
+        case '/': *out++ = c;    break;
+        case 'b': *out++ = '\b'; break;
+        case 'f': *out++ = '\f'; break;
+        case 't': *out++ = '\t'; break;
+        case 'n': *out++ = '\n'; break;
+        case 'r': *out++ = '\r'; break;
 
-      case 'u':
-        /* ahh, the complicated case */
-        if (in + 4 > end)
-          return "Invalid \\uXXXX escape";
-        int hexvalue = unhex4(in);
-        if (hexvalue < 0)
-          return "Invalid characters in \\uXXXX escape";
-        unsigned long codepoint = (unsigned long)hexvalue;
-        in += 4;
-        if (0xD800 <= codepoint && codepoint <= 0xDBFF) {
-          /* who thought UTF-16 surrogate pairs were a good idea? */
-          if (in + 6 > end || in[0] != '\\' || in[1] != 'u')
-            return "Invalid \\uXXXX\\uXXXX surrogate pair escape";
-          unsigned long surrogate = unhex4(in+2);
-          if (!(0xDC00 <= surrogate && surrogate <= 0xDFFF))
-            return "Invalid \\uXXXX\\uXXXX surrogate pair escape";
-          in += 6;
-          codepoint = 0x10000 + (((codepoint - 0xD800) << 10)
-                                 |(surrogate - 0xDC00));
+        case 'u':
+          /* ahh, the complicated case */
+          if (in + 4 > end)
+            return "Invalid \\uXXXX escape";
+          int hexvalue = unhex4(in);
+          if (hexvalue < 0)
+            return "Invalid characters in \\uXXXX escape";
+          unsigned long codepoint = (unsigned long)hexvalue;
+          in += 4;
+          if (0xD800 <= codepoint && codepoint <= 0xDBFF) {
+            /* who thought UTF-16 surrogate pairs were a good idea? */
+            if (in + 6 > end || in[0] != '\\' || in[1] != 'u')
+              return "Invalid \\uXXXX\\uXXXX surrogate pair escape";
+            unsigned long surrogate = unhex4(in+2);
+            if (!(0xDC00 <= surrogate && surrogate <= 0xDFFF))
+              return "Invalid \\uXXXX\\uXXXX surrogate pair escape";
+            in += 6;
+            codepoint = 0x10000 + (((codepoint - 0xD800) << 10)
+                                  |(surrogate - 0xDC00));
+          }
+          if (codepoint > 0x10FFFF)
+            codepoint = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
+          out += jvp_utf8_encode(codepoint, out);
+          break;
+
+        default:
+          return "Invalid escape";
         }
-        if (codepoint > 0x10FFFF)
-          codepoint = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
-        out += jvp_utf8_encode(codepoint, out);
-        break;
-
-      default:
-        return "Invalid escape";
+      } else {
+        if (c > 0 && c < 0x001f)
+          return "Invalid string: control characters from U+0000 through U+001F must be escaped";
+        *out++ = c;
       }
-    } else {
-      if (c > 0 && c < 0x001f)
-        return "Invalid string: control characters from U+0000 through U+001F must be escaped";
-      *out++ = c;
     }
+    TRY(value(p, jv_string_sized(p->tokenbuf, out - p->tokenbuf)));
+  } else {
+    TRY(value(p, jv_string_empty(0)));
   }
-  TRY(value(p, jv_string_sized(p->tokenbuf, out - p->tokenbuf)));
   p->tokenpos = 0;
   return 0;
 }


### PR DESCRIPTION
LLVM 10's UBSAN catches several cases of undefined behavior when running the test suite:

* `jv_get` cast array indices to an int, even if the index is out of range. I added a bounds check.
* Several places do pointer math on null pointers, which is undefined behavior. I fixed this by special casing null.

Additionally, I added `-fno-sanitize-recover=undefined` to the CFLAGS, which is necessary to make UBSAN actually crash the program (and therefore fail the tests) instead of just logging an error.