### PR TITLE
Fix deletion using assigning empty against arrays

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -26,7 +26,7 @@ def _modify(paths; update):
           ),
           (
               $$$$dot
-            | setpath([1]; .[1] + [$p])
+            | setpath([1, (.[1] | length)]; $p)
           )
         )
     ) | . as $dot | $dot[0] | delpaths($dot[1]);

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -12,24 +12,24 @@ def add: reduce .[] as $x (null; . + $x);
 def del(f): delpaths([path(f)]);
 def _assign(paths; $value): reduce path(paths) as $p (.; setpath($p; $value));
 def _modify(paths; update):
-    reduce path(paths) as $p (.;
+    reduce path(paths) as $p ([., []];
         . as $dot
       | null
       | label $out
-      | ($dot | getpath($p)) as $v
+      | ($dot[0] | getpath($p)) as $v
       | (
           (   $$$$v
             | update
             | (., break $out) as $v
             | $$$$dot
-            | setpath($p; $v)
+            | setpath([0] + $p; $v)
           ),
           (
               $$$$dot
-            | delpaths([$p])
+            | setpath([1]; .[1] + [$p])
           )
         )
-    );
+    ) | . as $dot | $dot[0] | delpaths($dot[1]);
 def map_values(f): .[] |= f;
 
 # recurse

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1048,6 +1048,19 @@ def inc(x): x |= .+1; inc(.[].a)
 {"a":[{"b":5}]}
 {"a":[{"c":3,"b":5}]}
 
+# #2051, deletion using assigning empty against arrays
+(.[] | select(. >= 2)) |= empty
+[1,5,3,0,7]
+[1,0]
+
+.[] |= select(. % 2 == 0)
+[0,1,2,3,4,5]
+[0,2,4]
+
+.foo[1,4,2,3] |= empty
+{"foo":[0,1,2,3,4,5]}
+{"foo":[0,5]}
+
 .[2][3] = 1
 [4]
 [4, null, [null, null, null, 1]]


### PR DESCRIPTION
This pull request fixes #2051, by delaying path deletions. Also fixes #2397, fixes #2422 and fixes #2440.
```sh
 % ./jq -c '(.[] | select(. >= 2)) |= empty' <<< '[1,5,3,0,7]'
[1,0]
 % ./jq -c '.[] |= select(. >= 4)' <<< '[1,5,3,0,7]'
[5,7]
 % ./jq -c '.[] |= select(. == 2)' <<< '[1,5,3,0,7]'
[]
```