### PR TITLE
allow MS Windows \r\n style line endings and it's (broken) "UTF-8 BOM"

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -123,7 +123,7 @@ struct lexer_param;
 ([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*  { yylval->literal = jv_string(yytext); return IDENT;}
 \.[a-zA-Z_][a-zA-Z_0-9]*  { yylval->literal = jv_string(yytext+1); return FIELD;}
 
-[ \n\t]+  {}
+[ \r\n\t]+  {}
 
 . { return INVALID_CHARACTER; }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -125,6 +125,8 @@ struct lexer_param;
 
 [ \r\n\t]+  {}
 
+\xEF\xBB\xBF { return UTF8_BOM; }
+
 . { return INVALID_CHARACTER; }
 
 %%

--- a/src/parser.y
+++ b/src/parser.y
@@ -47,6 +47,7 @@ struct lexer_param;
 
 
 %token INVALID_CHARACTER
+%token UTF8_BOM
 %token <literal> IDENT
 %token <literal> FIELD
 %token <literal> LITERAL
@@ -303,12 +304,14 @@ static block gen_update(block object, block val, int optype) {
 
 %%
 TopLevel:
-Module Imports Exp {
-  *answer = BLOCK($1, $2, gen_op_simple(TOP), $3);
+MsBomOpt Module Imports Exp {
+  *answer = BLOCK($2, $3, gen_op_simple(TOP), $4);
 } |
-Module Imports FuncDefs {
-  *answer = BLOCK($1, $2, $3);
+MsBomOpt Module Imports FuncDefs {
+  *answer = BLOCK($2, $3, $4);
 }
+
+MsBomOpt: UTF8_BOM | %empty;
 
 Module:
 %empty {


### PR DESCRIPTION
have been bitten by this issue a few times, as apparently have a few others, see:

  https://stackoverflow.com/a/61116743/1358308

not sure if the parser/lexer are the right place to fix this, but it's an easy change and "works for me"!

if this is the right approach happy to add some tests as well, but the SO answer has a couple of examples of things that it's trying to fix (and seems to for me)

haven't included recompiled `.c` and `.h` files mostly because I've got a much newer version of Bison and it's quite a big change