### PR TITLE
Fix string multiplication with a value between 0.0 and 1.0

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -360,7 +360,8 @@ static jv f_multiply(jq_state *jq, jv input, jv a, jv b) {
       num = a;
     }
     jv res = jv_null();
-    int n = jv_number_value(num);
+    double d = jv_number_value(num);
+    int n = 0.0 < d && d < 1.0 ? 1 : d;
     if (n > 0) {
       size_t alen = jv_string_length_bytes(jv_copy(str));
       res = jv_string_empty(alen * n);

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -359,10 +359,12 @@ static jv f_multiply(jq_state *jq, jv input, jv a, jv b) {
       str = b;
       num = a;
     }
-    jv res = jv_null();
+    jv res;
     double d = jv_number_value(num);
-    int n = 0.0 < d && d < 1.0 ? 1 : d;
-    if (n > 0) {
+    if (d < 0 || isnan(d)) {
+      res = jv_null();
+    } else {
+      int n = d;
       size_t alen = jv_string_length_bytes(jv_copy(str));
       res = jv_string_empty(alen * n);
       for (; n > 0; n--) {

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1286,7 +1286,11 @@ indices(", ")
 
 [.[] * "abc"]
 [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 3.7, 10.0]
-[null,null,null,"abc","abc","abc","abcabcabc","abcabcabcabcabcabcabcabcabcabc"]
+[null,null,"","","abc","abc","abcabcabc","abcabcabcabcabcabcabcabcabcabc"]
+
+[. * (nan,-nan)]
+"abc"
+[null,null]
 
 [.[] / ","]
 ["a, bc, def, ghij, jklmn, a,b, c,d, e,f", "a,b,c,d, e,f,g,h"]

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1284,6 +1284,10 @@ indices(", ")
 ["a", "ab", "abc"]
 ["aaa", "ababab", "abcabcabc"]
 
+[.[] * "abc"]
+[-1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 3.7, 10.0]
+[null,null,null,"abc","abc","abc","abcabcabc","abcabcabcabcabcabcabcabcabcabc"]
+
 [.[] / ","]
 ["a, bc, def, ghij, jklmn, a,b, c,d, e,f", "a,b,c,d, e,f,g,h"]
 [["a"," bc"," def"," ghij"," jklmn"," a","b"," c","d"," e","f"],["a","b","c","d"," e","f","g","h"]]


### PR DESCRIPTION
This commit fixes a regression of 6306ac89667c (#2118). ~`jq -n '0.5 * "abc"'` should print `"abc"` not `null`.~ Based on the discussion, we change the behavior of `string * number` to emit `""` when `0 ≦ number < 1`.