### PR TITLE
Fix uri format to follow RFC 3986

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -642,7 +642,7 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
     input = f_tostring(jq, input);
 
     int unreserved[128] = {0};
-    const char* p = CHARS_ALPHANUM "-_.!~*'()";
+    const char* p = CHARS_ALPHANUM "-_.~";
     while (*p) unreserved[(int)*p++] = 1;
 
     jv line = jv_string("");

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -61,17 +61,17 @@ null
 null
 "interpolation"
 
-@text,@json,([1,.] | (@csv, @tsv)),@html,@uri,@sh,@base64,(@base64 | @base64d)
-"<>&'\"\t"
-"<>&'\"\t"
-"\"<>&'\\\"\\t\""
-"1,\"<>&'\"\"\t\""
-"1\t<>&'\"\\t"
-"&lt;&gt;&amp;&apos;&quot;\t"
-"%3C%3E%26'%22%09"
-"'<>&'\\''\"\t'"
-"PD4mJyIJ"
-"<>&'\"\t"
+@text,@json,([1,.]|@csv,@tsv),@html,@uri,@sh,(@base64|.,@base64d)
+"!()<>&'\"\t"
+"!()<>&'\"\t"
+"\"!()<>&'\\\"\\t\""
+"1,\"!()<>&'\"\"\t\""
+"1\t!()<>&'\"\\t"
+"!()&lt;&gt;&amp;&apos;&quot;\t"
+"%21%28%29%3C%3E%26%27%22%09"
+"'!()<>&'\\''\"\t'"
+"ISgpPD4mJyIJ"
+"!()<>&'\"\t"
 
 # regression test for #436
 @base64


### PR DESCRIPTION
It seems that the current implementation is based on [RFC 2396 - 2.3. Unreserved Characters](https://tools.ietf.org/html/rfc2396#section-2.3). However, this RFC is obsoleted by [RFC 3986](https://tools.ietf.org/html/rfc3986). At [RFC 3986 - 2.3. Unreserved Characters](https://tools.ietf.org/html/rfc3986#section-2.3), the unreserved characters are defined as follows.

    unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"

Thus we should update the implementation to follow the RFC 3986.

```sh
 % echo "-_.~\!'()" | jq -R @uri
"-_.~!'()"
 % echo "-_.~\!'()" | ./jq  -R @uri
"-_.~%21%27%28%29"
```

Resolves  #1506.