### PR TITLE
Build out of tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 tests/*.trs
 
+# Clang junk
+.clangd
+compile_commands.json
+
 cscope.in.out
 cscope.out
 cscope.po.out

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ LIBJQ_SRC = src/builtin.c src/bytecode.c src/compile.c src/execute.c    \
         src/jv_unicode.c src/linker.c src/locfile.c src/util.c          \
         src/decNumber/decContext.c src/decNumber/decNumber.c            \
         src/jv_dtoa_tsd.c                                               \
-        ${LIBJQ_INCS}
+        $(LIBJQ_INCS)
 
 ### C build options
 
@@ -52,7 +52,7 @@ AM_YFLAGS = --warnings=all -d
 ### libjq
 
 lib_LTLIBRARIES = libjq.la
-libjq_la_SOURCES = ${LIBJQ_SRC}
+libjq_la_SOURCES = $(LIBJQ_SRC)
 libjq_la_LIBADD = -lm
 libjq_la_LDFLAGS = $(onig_LDFLAGS) -export-symbols-regex '^j[qv]_' -version-info 1:4:0
 
@@ -148,7 +148,7 @@ check_DATA = tests/man.test
 # don't care. But if you are, then you need to run the tests anyway.
 tests/man.test: $(srcdir)/docs/content/manual/manual.yml
 if ENABLE_DOCS
-	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; $(PIPENV) run python build_mantests.py ) > $@
+	$(AM_V_GEN) ( cd $(abs_srcdir)/docs; $(PIPENV) run python build_mantests.py ) > $@
 else
 	@echo Changes to the manual.yml require docs to be enabled to run the tests
 	@false
@@ -162,7 +162,7 @@ endif
 man_MANS = jq.1
 jq.1.prebuilt: $(srcdir)/docs/content/manual/manual.yml
 if ENABLE_DOCS
-	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; $(PIPENV) run python build_manpage.py ) > $@ || { rm -f $@; false; }
+	$(AM_V_GEN) ( cd $(abs_srcdir)/docs; $(PIPENV) run python build_manpage.py ) > $@ || { rm -f $@; false; }
 else
 	@echo Changes to the manual.yml require docs to be enabled to generate an updated manpage
 	@echo As a result, your manpage is out of date.
@@ -217,7 +217,7 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
 
 # README.md is expected in Github projects, good stuff in it, so we'll
 # distribute it and install it with the package in the doc directory.
-docdir = ${datadir}/doc/${PACKAGE}
+docdir = $(datadir)/doc/$(PACKAGE)
 dist_doc_DATA = README.md COPYING AUTHORS README
 
 pkgconfigdir = $(libdir)/pkgconfig
@@ -228,12 +228,12 @@ rpm: dist jq.spec
 	@echo "Packaging jq as an RPM ..."
 	mkdir -p rpm/SOURCES rpm/BUILD rpm/BUILDROOT rpm/RPMS rpm/SPECS
 	cp jq-$(VERSION).tar.gz rpm/SOURCES/
-	rpmbuild -tb --define "_topdir ${PWD}/rpm" --define "_prefix /usr" --define "myver $(VERSION)" --define "myrel ${RELEASE}" rpm/SOURCES/jq-$(VERSION).tar.gz
+	rpmbuild -tb --define "_topdir $(PWD)/rpm" --define "_prefix /usr" --define "myver $(VERSION)" --define "myrel $(RELEASE)" rpm/SOURCES/jq-$(VERSION).tar.gz
 	find rpm/RPMS/ -name "*.rpm" -exec mv {} ./ \;
 	rm -rf rpm
 
 dist-clean-local:
-	rm -f ${BUILT_SOURCES}
+	rm -f $(BUILT_SOURCES)
 
 # Not sure why this doesn't get cleaned up automatically, guess
 # automake used to man pages which are hand coded?

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+## Process this file with automake to produce Makefile.in.
 
 ### C source files to be built and distributed.
 
@@ -131,7 +132,16 @@ endif
 ### Tests (make check)
 
 TESTS = tests/optionaltest tests/mantest tests/jqtest tests/onigtest tests/shtest tests/utf8test tests/base64test
-TESTS_ENVIRONMENT = NO_VALGRIND=$(NO_VALGRIND)
+AM_TESTS_ENVIRONMENT = \
+builddir=$(builddir); export builddir; \
+abs_builddir=$(abs_builddir); export abs_builddir; \
+top_builddir=$(top_builddir); export top_builddir; \
+top_build_prefix=$(top_build_prefix); export top_build_prefix; \
+abs_top_builddir=$(abs_top_builddir); export abs_top_builddir; \
+abs_srcdir=$(abs_srcdir); export abs_srcdir; \
+top_srcdir=$(top_srcdir); export top_srcdir; \
+abs_top_srcdir=$(abs_top_srcdir); export abs_top_srcdir; \
+NO_VALGRIND=$(NO_VALGRIND); export NO_VALGRIND;
 
 # This is a magic make variable that causes it to treat tests/man.test as a
 # DATA-type dependency for the check target. As a result, it will attempt to

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ m4_define([jq_version],
 
 AC_INIT([jq], [jq_version], [https://github.com/stedolan/jq/issues],
              [jq], [https://stedolan.github.io/jq])
+AC_CONFIG_SRCDIR([src/jv_alloc.c])
 
 m4_include([m4/ax_compare_version.m4])
 m4_include([m4/ax_prog_bison_version.m4])

--- a/tests/mantest
+++ b/tests/mantest
@@ -3,4 +3,4 @@
 . "${0%/*}/setup" "$@"
 
 # We set PAGER because there's a mantest for `env` that uses it.
-env PAGER=less $VALGRIND $Q $JQ -L "$mods" --run-tests < $JQBASEDIR/tests/man.test
+env PAGER=less $VALGRIND $Q $JQ -L "$mods" --run-tests < $JQTESTDIR/man.test

--- a/tests/setup
+++ b/tests/setup
@@ -9,8 +9,8 @@ fi
 set -eu
 
 JQTESTDIR=$(cd "$(dirname "$0")" && pwd)
-JQBASEDIR=$JQTESTDIR/..
-JQ=$JQBASEDIR/jq
+JQBUILDDIR=${abs_top_builddir-$JQTESTDIR/..}
+JQ=$JQBUILDDIR/jq
 
 if [ -z "${NO_VALGRIND-}" ] && which valgrind > /dev/null; then
     VALGRIND="valgrind --error-exitcode=1 --leak-check=full \

--- a/tests/shtest
+++ b/tests/shtest
@@ -2,13 +2,13 @@
 
 . "${0%/*}/setup" "$@"
 
-PATH=$JQBASEDIR:$PATH $JQBASEDIR/tests/jq-f-test.sh > /dev/null
+PATH=$JQBUILDDIR:$PATH $JQTESTDIR/jq-f-test.sh > /dev/null
 
-if [ -f "$JQBASEDIR/.libs/libinject_errors.so" ]; then
+if [ -f "$JQBUILDDIR/.libs/libinject_errors.so" ]; then
   # Do some simple error injection tests to check that we're handling
   # I/O errors correctly.
   (
-  libinject=$JQBASEDIR/.libs/libinject_errors.so
+  libinject=$JQBUILDDIR/.libs/libinject_errors.so
   cd $d
   LD_PRELOAD=$libinject $JQ . /dev/null
   touch fail_read
@@ -200,6 +200,7 @@ fi
 ## Fuzz parser
 
 ## XXX With a $(urandom) builtin we could move this test into tests/all.test
+_clean=$clean
 clean=false
 if dd if=/dev/urandom bs=16 count=1024 > $d/rand 2>/dev/null; then
     # Have a /dev/urandom, good
@@ -212,7 +213,7 @@ if dd if=/dev/urandom bs=16 count=1024 > $d/rand 2>/dev/null; then
     $VALGRIND $Q $JQ --seq . $d/rand >/dev/null 2>&1
     $VALGRIND $Q $JQ --seq --stream . $d/rand >/dev/null 2>&1
 fi
-clean=true
+clean=$_clean
 
 ## Test library/module system
 
@@ -233,13 +234,13 @@ if ! HOME="$mods/home2" $VALGRIND $Q $JQ -n 'include "g"; empty'; then
     exit 1
 fi
 
-cd "$JQBASEDIR" # so that relative library paths are guaranteed correct
+cd "$JQTESTDIR"/.. # so that relative library paths are guaranteed correct
 if ! $VALGRIND $Q $JQ -L ./tests/modules -ne 'import "test_bind_order" as check; check::check==true'; then
     echo "Issue #817 regression?" 1>&2
     exit 1
 fi
 
-cd "$JQBASEDIR"
+cd "$JQTESTDIR"/..
 if ! $VALGRIND $Q $JQ -L tests/modules -ne 'import "test_bind_order" as check; check::check==true'; then
     echo "Issue #817 regression?" 1>&2
     exit 1
@@ -279,6 +280,7 @@ if [ "$($VALGRIND $Q $JQ -n '"xyz\n"|halt_error(1)' 2>&1)" != "jq: error: xyz" ]
 fi
 
 # Check $JQ_COLORS
+unset -v JQ_COLORS || true
 $JQ -Ccn . > $d/color
 printf '\033[1;30mnull\033[0m\n' > $d/expect
 cmp $d/color $d/expect


### PR DESCRIPTION
Tests weren't happy with a setup like `mkdir -p build && cd build && ../configure && make`. `make check` now works on out-of-tree-builds.

While I was making tests work, one of them failed for me due to Valgrind output, so that's fixed (I think with virtually no runtime costs; the biggest cost would be `strncpy()` instead of `strcpy()`, with lengths we already were computing).

While I was making that test work, I noticed a function pointer cast error, so that's also received what should be a zero-cost patch (`always_inline`d function that exists solely to cast a parameter type and tail call the actual function).

Another test failed due to my normal environment exporting `JQ_COLORS`, so that's now unset before all tests that try to use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stedolan/jq/2183)
<!-- Reviewable:end -->
