### PR TITLE
Add Windows installation via scoop

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -100,6 +100,9 @@ body:
 
       ### Windows
 
+       * Use [`scoop`](https://scoop.sh/) to install latest jq version with
+         `scoop install jq`.
+
        * Use [Chocolatey NuGet](https://chocolatey.org/) to install jq 1.5 with
          `chocolatey install jq`.
 


### PR DESCRIPTION
Extended Windows installation documentation. Now we can install the latest `jq` version via scoop (https://scoop/sh).
The scoop installation manifest is automatically updated (thx to https://github.com/ScoopInstaller/Main/commit/ea40037413ac64752be74c8ff14de352bd4e45bc) to refer to the latest `jq` version each time new scoop release appears on GH.