### PR TITLE
fix handling of -0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,7 @@ static void die() {
 
 
 static int isoptish(const char* text) {
-  return text[0] == '-' && (text[1] == '-' || isalpha(text[1]));
+  return text[0] == '-' && (text[1] == '-' || isalpha(text[1]) || text[1] == '0');
 }
 
 static int isoption(const char* text, char shortopt, const char* longopt, size_t *short_opts) {

--- a/tests/shtest
+++ b/tests/shtest
@@ -150,6 +150,12 @@ cmp $d/out $d/expected
 printf "[1,2][3,4]\n" | $JQ -cs add > $d/out 2>&1
 cmp $d/out $d/expected
 
+# Regression test for -0 / --nul-output
+printf "a\0b\0" > $d/expected
+printf '["a", "b"]' | $JQ -0 .[] > $d/out 2>&1
+cmp $d/out $d/expected
+printf '["a", "b"]' | $JQ --nul-output .[] > $d/out 2>&1
+cmp $d/out $d/expected
 
 ## Test streaming parser
 


### PR DESCRIPTION
See #1373 -- this fixes the short option

I also added some tests since it didn't look like there were any for `-0` or for `--nul-output`