### PR TITLE
Fold modulo operator on constant values and raise zero remainder error quickly

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -498,6 +498,7 @@ static block constant_fold(block a, block b, int op) {
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
+    case '%': res = jv_number((intmax_t)nb == 0 ? INFINITY : (intmax_t)na % (intmax_t)nb); break;
     case EQ:  res = (cmp == 0 ? jv_true() : jv_false()); break;
     case NEQ: res = (cmp != 0 ? jv_true() : jv_false()); break;
     case '<': res = (cmp < 0 ? jv_true() : jv_false()); break;

--- a/src/parser.y
+++ b/src/parser.y
@@ -230,6 +230,7 @@ static block constant_fold(block a, block b, int op) {
     case '-': res = jv_number(na - nb); break;
     case '*': res = jv_number(na * nb); break;
     case '/': res = jv_number(na / nb); break;
+    case '%': res = jv_number((intmax_t)nb == 0 ? INFINITY : (intmax_t)na % (intmax_t)nb); break;
     case EQ:  res = (cmp == 0 ? jv_true() : jv_false()); break;
     case NEQ: res = (cmp != 0 ? jv_true() : jv_false()); break;
     case '<': res = (cmp < 0 ? jv_true() : jv_false()); break;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1655,6 +1655,10 @@ try (1%.) catch .
 1/0
 jq: error: Division by zero? at <top-level>, line 1:
 
+%%FAIL
+1%0
+jq: error: Remainder by zero? at <top-level>, line 1:
+
 # Basic numbers tests: integers, powers of two
 [range(-52;52;1)] as $powers | [$powers[]|pow(2;.)|log2|round] == $powers
 null

--- a/tests/shtest
+++ b/tests/shtest
@@ -30,47 +30,67 @@ $VALGRIND $Q $JQ -Rne '[inputs] == ["a\u0000b", "c\u0000d", "e"]' $d/input
 
 # String constant folding (addition only)
 nref=$($VALGRIND $Q $JQ -n --debug-dump-disasm '"foo"' | wc -l)
+n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '"foo" + "bar"' | wc -l)
+if [ $n -ne $nref ]; then
+  echo "Constant expression folding for strings didn't work"
+  exit 1
+fi
 
-# Numeric constant folding (not all ops yet)
+# Numeric constant folding (binary operators)
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '1+1' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '1-1' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '2*3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9/3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
+fi
+n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9%3' | wc -l)
+if [ $n -ne $nref ]; then
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9==3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9!=3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
+fi
+n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9<3' | wc -l)
+if [ $n -ne $nref ]; then
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
+fi
+n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9>3' | wc -l)
+if [ $n -ne $nref ]; then
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9<=3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 n=$($VALGRIND $Q $JQ -n --debug-dump-disasm '9>=3' | wc -l)
 if [ $n -ne $nref ]; then
-    echo "Constant expression folding for strings didn't work"
-    exit 1
+  echo "Constant expression folding for numbers didn't work"
+  exit 1
 fi
 
 ## Test JSON sequence support


### PR DESCRIPTION
Currently constant division is folded on parsing and zero division raises `Division by zero?` error quickly. There is `Remainder by zero?` error message found in `parser.y` but this will never be thrown because `constant_fold` does not fold the modulo operator. So I added folding on constant modulo and make `jq -n "1%0"` throws the `Remainder by zero?` error and exits with `3` (just like `jq -n "1/0"`). The infinity is caught by [`block_is_const_inf`](https://github.com/stedolan/jq/blob/a17dd3248a666d01be75f6b16be37e80e20b0954/src/parser.y#L464-L468). Returning infinity here may look wired (zero modulo is not infinity) but it applies to division as well; zero division in jq is not infinity but it's ok because the infinity is filtered out by `block_is_const_inf`. This follows the commit b9c2a326bae085a27b5bd01ca15c3c42c7b726a3.