### PR TITLE
Make 0 divided by 0 results in NaN consistently

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -380,7 +380,7 @@ static jv f_multiply(jq_state *jq, jv input, jv a, jv b) {
 static jv f_divide(jq_state *jq, jv input, jv a, jv b) {
   jv_free(input);
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    if (jv_number_value(b) == 0.0)
+    if (jv_number_value(b) == 0.0 && jv_number_value(a) != 0.0)
       return type_error2(a, b, "cannot be divided because the divisor is zero");
     jv r = jv_number(jv_number_value(a) / jv_number_value(b));
     jv_free(a);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1556,6 +1556,11 @@ try (1/.) catch .
 0
 "number (1) and number (0) cannot be divided because the divisor is zero"
 
+0/0, (0 as $x | $x/0) | isnan
+0
+true
+true
+
 try (1%.) catch .
 0
 "number (1) and number (0) cannot be divided (remainder) because the divisor is zero"


### PR DESCRIPTION
`0/0` is folded to `nan` on parsing but `0 as $x | $x/0` throws a zero-division error so `0/0` is not equal to `0 as $x | $x/0`. This is not intuitive. I think `0 as $x | $x/0` should be `nan` as well as `0/0` is.
```
 % jq -n '0/0, (0 as $x | $x/0) | isnan'
true
jq: error (at <unknown>): number (0) and number (0) cannot be divided because the divisor is zero
```