### PR TITLE
Added a first fuzzer for integration with OSS-Fuzz.

### DIFF
--- a/tests/jq_fuzz_parse.c
+++ b/tests/jq_fuzz_parse.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "jv.h"
+
+int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+  // Creat null-terminated string
+  char *null_terminated = (char *)malloc(size + 1);
+  memcpy(null_terminated, (char *)data, size);
+  null_terminated[size] = '\0';
+
+  // Fuzzer entrypoint
+  jv res = jv_parse(null_terminated);
+  jv_free(res);
+
+  // Free the null-terminated string
+  free(null_terminated);
+
+  return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I would like to set up continuous fuzzing of jq by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/4980 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate jq. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.
