### PR TITLE
Fix `--indent 0` implicitly enabling compact-output

### DIFF
--- a/src/jv.h
+++ b/src/jv.h
@@ -223,7 +223,7 @@ enum jv_print_flags {
   JV_PRINT_SPACE2   = 1024,
 };
 #define JV_PRINT_INDENT_FLAGS(n) \
-    ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? 0 : (n) << 8 | JV_PRINT_PRETTY)
+    ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? JV_PRINT_PRETTY : (n) << 8 | JV_PRINT_PRETTY)
 void jv_dumpf(jv, FILE *f, int flags);
 void jv_dump(jv, int flags);
 void jv_show(jv, int flags);


### PR DESCRIPTION
Now it will retain pretty-printing, just removing any indentation. Fixes https://github.com/stedolan/jq/issues/1465 and fixes https://github.com/jqlang/jq/issues/2498.