### PR TITLE
Fix for #2374

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -411,6 +411,11 @@ jv jq_util_input_next_input(jq_util_input_state *state) {
       is_last = jq_util_input_read_more(state);
       if (state->buf_valid_len == 0)
         continue;
+      if (state->current_input && feof(state->current_input))
+      {
+        state->current_line++;
+        is_last = 1;
+      }
       if (jv_is_valid(state->slurped)) {
         // Slurped raw input
         state->slurped = jv_string_concat(state->slurped, jv_string_sized(state->buf, state->buf_valid_len));

--- a/tests/shtest
+++ b/tests/shtest
@@ -150,6 +150,12 @@ cmp $d/out $d/expected
 printf "[1,2][3,4]\n" | $JQ -cs add > $d/out 2>&1
 cmp $d/out $d/expected
 
+# Regression test for #2374
+printf "Line 1\nLine 2\nLine 3" > $d/a
+printf "Line 4\nLine 5" > $d/b
+echo '{"'$d/a'":{"1":"Line 1","2":"Line 2","3":"Line 3"},"'$d/b'":{"1":"Line 4","2":"Line 5"}}' > $d/expected
+$JQ -Rnc 'reduce inputs as $line ({}; .[input_filename] += {(input_line_number|tostring): $line})' $d/a $d/b > $d/out 2>&1
+cmp $d/out $d/expected
 
 ## Test streaming parser
 


### PR DESCRIPTION
See #2374 for explanation of the issue.

I've poked around the code and found this possible fix. It's not very neat (checking `state->current_input` and modifying `state->current_line` outside of `jq_util_input_read_more`), but it works and doesn't break any other tests. Please feel free to propose a neater fix if you can see one.

I've also added a regression test. This uses a bunch of functions, so perhaps shouldn't be in `shtest`? But I don't see `input_line_number` tested anywhere else.