### PR TITLE
Use autotools standard ${docdir}

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -217,7 +217,6 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
 
 # README.md is expected in Github projects, good stuff in it, so we'll
 # distribute it and install it with the package in the doc directory.
-docdir = ${datadir}/doc/${PACKAGE}
 dist_doc_DATA = README.md COPYING AUTHORS README
 
 pkgconfigdir = $(libdir)/pkgconfig


### PR DESCRIPTION
Specified with `--docdir=<path>`, the `$(docdir)` variable is already available, and has the same default as what it was being set to.

By specifying it where it was, it was overriding what the `--docdir` option specified.

With the change, the value from the configure script's `--docdir` option will be respected instead.