### PR TITLE
Tidy up nomem_handler implementations to fix SEGVs and ensure more consistency between TLS and non-TLS implementations.

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -1019,7 +1019,7 @@ jq_state *jq_init(void) {
   jq->path = jv_null();
   jq->value_at_path = jv_null();
 
-  jq->nomem_handler = NULL;
+  jq->nomem_handler = jv_default_nomem_handler;
   jq->nomem_handler_data = NULL;
   return jq;
 }

--- a/src/jv_alloc.h
+++ b/src/jv_alloc.h
@@ -15,6 +15,7 @@ static void jv_mem_invalidate(void* mem, size_t n) {
 #endif
 }
 
+void jv_default_nomem_handler(void*);
 void* jv_mem_alloc(size_t);
 void* jv_mem_alloc_unguarded(size_t);
 void* jv_mem_calloc(size_t, size_t);

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,10 @@ extern void jv_tsd_dtoa_ctx_init();
 
 int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
 
+#ifdef HAVE_PTHREAD
+void jq_mt_test();
+#endif
+
 static const char* progname;
 
 /*
@@ -540,6 +544,12 @@ int main(int argc, char* argv[]) {
         ret = JQ_OK;
         goto out;
       }
+#ifdef HAVE_PTHREAD
+      if (isoption(argv[i], 0, "run-mt-test", &short_opts)) {
+        jq_mt_test();
+        goto out;
+      }
+#endif
       if (isoption(argv[i], 0, "run-tests", &short_opts)) {
         i++;
         // XXX Pass program_arguments, even a whole jq_state *, through;


### PR DESCRIPTION
This fixes #2483 and probably #2056 by making the `nomem_handler` instance truly thread specific. 

Specifically by:
- Adding `jv_default_nomem_handler` which prints a consistent message `jq: error: cannot allocate memory` in the event of an allocation failure when the nomem handler has not been overriden. This is used as the default value for `nomem_handler` on `jq_state` instances given out by `jq_init`.
- Splitting `tsd_init` into two parts: one which is called once per-process and one which is idempotent but called per-thread (possibly many times).
  - `tsd_ensure_init_per_thread` ensures the nomem_handler block is allocated and setup for the calling thread (allocating it if it isn't).
  - `tsd_init_key` sets up the TLS key and registers `tsd_fini_per_thread` to be called `atexit` to free the `nomem_handler` block for the main thread.

Possible problems (that I can see right now):
- This currently doesn't free the `nomem_handler` blocks used by any thread other than the one the `atexit` handlers run on. I'm not sure if this is really a problem but I might be able to fix it with better bookkeeping if necessary.
- I'm not sure if you want to have the multi-threaded test integrated with `make check` or quite how it would be best to do this.
- Trailing whitespace changes - happy to remove these if they're a problem.

