### PR TITLE
Show missing backslash in manual

### DIFF
--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2361,7 +2361,7 @@ sections:
           be a jq string, and may contain references to named captures. The
           named captures are, in effect, presented as a JSON object (as
           constructed by `capture`) to `tostring`, so a reference to a captured
-          variable named "x" would take the form: "\(.x)".
+          variable named "x" would take the form: `"\(.x)"`.
 
         example:
           - program: 'sub("^[^a-z]*(?<x>[a-z]*).*")'


### PR DESCRIPTION
The 1.6 manual about [`sub(regex;tostring)`](https://stedolan.github.io/jq/manual/#sub(regex;tostring)sub(regex;string;flags)) currently says:

> a reference to a captured variable named "x" would take the form: "(.x)".

Using `"(.x)"` produces this string literally rather than the captured variable. Instead, the manual should say:

> a reference to a captured variable named "x" would take the form: `"\(.x)"`.

This PR may also need to be back-ported to earlier versions of the jq manual as well as ported to the development version of the jq manual.