### PR TITLE
Remove deprecated `--nul-output` documentation

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -199,11 +199,6 @@ sections:
 
         Like `-r` but jq won't print a newline after each output.
 
-      * `--nul-output` / `-0`:
-
-        Like `-r` but jq will print NUL instead of newline after each output.
-        This can be useful when the values being output can contain newlines.
-
       * `-f filename` / `--from-file filename`:
 
         Read filter from the file rather than from a command line, like


### PR DESCRIPTION
`--nul-output` / `-0` was removed RE: #1271 and #2350

This updates the documentation so one doesn't go crazy trying to figure out why it's not working 😂 