### PR TITLE
Enable non-single-line mode

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -887,6 +887,9 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
 
   jv_free(modifiers);
 
+  if (!(options & ONIG_OPTION_SINGLELINE)) {
+    options |= ONIG_OPTION_NEGATE_SINGLELINE;
+  }
   onigret = onig_new(&reg, (const UChar*)jv_string_value(regex),
       (const UChar*)(jv_string_value(regex) + jv_string_length_bytes(jv_copy(regex))),
       options, ONIG_ENCODING_UTF8, ONIG_SYNTAX_PERL_NG, &einfo);

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -33,6 +33,16 @@
 "foo bar foo foo  foo"
 [{"offset": 0, "length": 11, "string": "foo bar foo", "captures":[{"offset": 4, "length": 3, "string": "bar", "name": "bar123"}]},{"offset":12, "length": 8, "string": "foo  foo", "captures":[{"offset": -1, "length": 0, "string": null, "name": "bar123"}]}]
 
+# single line mode
+[match("^x"; "s")]
+"\nx"
+[]
+
+# non-single line mode
+[match("^x")]
+"\nx"
+[{"offset": 1, "length": 1, "string": "x", "captures":[]}]
+
 #test builtin
 [test("( )*"; "gn")]
 "abc"


### PR DESCRIPTION
Regular expressions are always evaluated in single line mode. This is because Oniguruma's PERL_NG syntax defaults to single line mode and must instead be forced _out_ of it by passing ONIG_OPTION_NEGATE_SINGLELINE. By changing this we now default to non-single line mode, and can opt in to single line mode as desired.

Ref: https://github.com/stedolan/jq/issues/2562