### PR TITLE
Attempt to fix gsub with zero length matches

### DIFF
--- a/tests/onig.test
+++ b/tests/onig.test
@@ -75,6 +75,14 @@ gsub( "(.*)"; "";  "x")
 ""
 ""
 
+gsub(""; "_")
+"abc"
+"_a_b_c_"
+
+gsub("\\b"; "X")
+"one two three"
+"XoneX XtwoX XthreeX"
+
 [.[] | scan(", ")]
 ["a,b, c, d, e,f",", a,b, c, d, e,f, "]
 [", ",", ",", ",", ",", ",", ",", ",", "]


### PR DESCRIPTION
Problem: If a regex given to gsub can match a zero length string, it will never terminate and eventually crash. This is because after matching once it keeps checking for the same match at the same location and finding it.

Solution: We can't skip ahead because there might be a non-zero length match at the same location. Instead, keep track of whether the last match was zero length, and when it was, ignore any zero length match at the same offset.

Remaining problem: This fails one of the new tests I added. For some reason, match doesn't seem to correctly return (some) zero length matches at the end of the input string. I'm going to report that as a separate bug, I can't see why it behaves like that.

Ref: https://github.com/stedolan/jq/issues/2148