### PR TITLE
Fix version scripts for some shallow clone situations (fix #1549)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([jq_version],
-          m4_esyscmd_s([(git rev-parse --verify -q jq-1.0 > /dev/null &&
-                        (git describe --tags --dirty --match 'jq-*'|sed 's/^jq-//')) ||
+          m4_esyscmd_s([git describe --tags --match 'jq-*' >/dev/null 2>&1 &&
+                        git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//' ||
                         echo `git rev-parse --abbrev-ref HEAD`-`git describe --always --dirty`])))
 
 AC_INIT([jq], [jq_version], [https://github.com/jqlang/jq/issues],

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,4 @@
-m4_define([jq_version],
-          m4_esyscmd_s([git describe --tags --match 'jq-*' >/dev/null 2>&1 &&
-                        git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//' ||
-                        echo `git rev-parse --abbrev-ref HEAD`-`git describe --always --dirty`])))
+m4_define([jq_version], m4_esyscmd_s([scripts/version])))
 
 AC_INIT([jq], [jq_version], [https://github.com/jqlang/jq/issues],
              [jq], [https://jqlang.github.io/jq])

--- a/scripts/version
+++ b/scripts/version
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -e
-cd `dirname "$0"`
-if git rev-parse --verify -q jq-1.0 > /dev/null 2>&1; then
+
+cd "$(dirname "$0")"
+if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
     git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
 else
-    b=`git rev-parse --abbrev-ref HEAD`
-    c=`git describe --always --dirty`
+    b=$(git rev-parse --abbrev-ref HEAD)
+    c=$(git describe --always --dirty)
     echo "${b}-${c}"
 fi

--- a/scripts/version
+++ b/scripts/version
@@ -1,11 +1,11 @@
 #!/bin/sh
-set -e
+set -eu
 
 cd "$(dirname "$0")"
 if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
-    git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+  git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
 else
-    b=$(git rev-parse --abbrev-ref HEAD)
-    c=$(git describe --always --dirty)
-    echo "${b}-${c}"
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  commit=$(git describe --always --dirty)
+  echo "${branch}-${commit}"
 fi


### PR DESCRIPTION
I noticed that in some shallow clone situations `autoreconf -fi` fails on detecting the version. In some situations tags are reachable but `git describe` fails. Further reference: https://github.com/jqlang/jq/pull/1549#issuecomment-1585987160. Resolves #1549.