### PR TITLE
Improve Download page: drop versions for each package manager

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -4,9 +4,9 @@ body:
 
       jq is written in C and has no runtime dependencies, so it should be
       possible to build it for nearly any platform. Prebuilt binaries are
-      available for Linux, OS X and Windows.
+      available for Linux, macOS and Windows.
 
-      The binaries should just run, but on OS X and Linux you may need
+      The binaries should just run, but on macOS and Linux you may need
       to make them executable first using `chmod +x jq`.
 
       jq is licensed under the MIT license. For all of the gory
@@ -19,20 +19,18 @@ body:
 
       ### Linux
 
-       * jq 1.5 is in the official [Debian](https://packages.debian.org/jq) and
+       * jq is in the official [Debian](https://packages.debian.org/jq) and
          [Ubuntu](http://packages.ubuntu.com/jq) repositories. Install using
          `sudo apt-get install jq`.
 
-       * jq 1.5 is in the official
-         [Fedora](https://src.fedoraproject.org/rpms/jq) repository.
+       * jq is in the official [Fedora](https://src.fedoraproject.org/rpms/jq) repository.
          Install using `sudo dnf install jq`.
 
-       * jq 1.4 is in the official [openSUSE](https://software.opensuse.org/package/jq)
-         repository. Install using `sudo zypper install jq`.
+       * jq is in the official [openSUSE](https://software.opensuse.org/package/jq) repository.
+         Install using `sudo zypper install jq`.
 
-       * jq 1.5 is in the official
-         [Arch](https://www.archlinux.org/packages/?sort=&q=jq&maintainer=&flagged=)
-         repository.  Install using `sudo pacman -S jq`.
+       * jq is in the official [Arch](https://archlinux.org/packages/?q=jq) repository.
+         Install using `sudo pacman -S jq`.
 
        * jq 1.6 binaries for
          [64-bit](https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64)
@@ -54,16 +52,13 @@ body:
          or
          [32-bit](https://github.com/jqlang/jq/releases/download/jq-1.3/jq-linux-x86).
 
-      ### OS X
+      ### macOS
 
-       * Use [Fink](https://finkproject.org) to install jq 1.6 with
-         `fink install jq`.
+       * Use [Homebrew](http://brew.sh/) to install jq with `brew install jq`.
 
-       * Use [Homebrew](http://brew.sh/) to install jq 1.6 with
-         `brew install jq`.
+       * Use [MacPorts](https://www.macports.org) to install jq with `port install jq`.
 
-       * Use [MacPorts](https://www.macports.org) to install jq 1.6 with
-         `port install jq`.
+       * Use [Fink](https://finkproject.org) to install jq with `fink install jq`.
 
        * jq 1.6 binary for
          [64-bit](https://github.com/jqlang/jq/releases/download/jq-1.6/jq-osx-amd64).
@@ -103,12 +98,11 @@ body:
 
       ### Windows
        * Use [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
-         to install jq 1.6 with `winget install jqlang.jq`.
+         to install jq with `winget install jqlang.jq`.
 
-       * Use [`scoop`](https://scoop.sh/) to install latest jq version with
-         `scoop install jq`.
+       * Use [scoop](https://scoop.sh/) to install jq with `scoop install jq`.
 
-       * Use [Chocolatey NuGet](https://chocolatey.org/) to install jq 1.6 with
+       * Use [Chocolatey NuGet](https://chocolatey.org/) to install jq with
          `chocolatey install jq`.
 
        * jq 1.6 executables for
@@ -152,7 +146,7 @@ body:
       You can use [GnuPG](https://gnupg.org/) to verify a signature by downloading
       the signature and running `gpg --verify signature.asc`.
 
-      ### From source on Linux, OS X, Cygwin, and other POSIX-like operating systems
+      ### From source on Linux, macOS, Cygwin, and other POSIX-like operating systems
 
        * [Source tarball for jq 1.6](https://github.com/jqlang/jq/releases/download/jq-1.6/jq-1.6.tar.gz)
        * [Source tarball for jq 1.5](https://github.com/jqlang/jq/releases/download/jq-1.5/jq-1.5.tar.gz)
@@ -180,7 +174,7 @@ body:
       manager, and if you do development on the machine they're most
       likely already installed.
 
-      On OS X, these are all included in Apple's command line tools, which can
+      On macOS, these are all included in Apple's command line tools, which can
       be installed from [Xcode](https://developer.apple.com/xcode/). However,
       you may find that you need a newer version of Bison than the one provided
       by Apple. This can be found in [Homebrew](http://brew.sh) or

--- a/docs/templates/index.html.j2
+++ b/docs/templates/index.html.j2
@@ -25,7 +25,7 @@
                     </a>
                     <ul class="dropdown-menu">
                       <li><a href="https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64">Linux (64-bit)</a></li>
-                      <li><a href="https://github.com/jqlang/jq/releases/download/jq-1.6/jq-osx-amd64">OS X (64-bit)</a></li>
+                      <li><a href="https://github.com/jqlang/jq/releases/download/jq-1.6/jq-osx-amd64">macOS (64-bit)</a></li>
                       <li><a href="https://github.com/jqlang/jq/releases/download/jq-1.6/jq-win64.exe">Windows (64-bit)</a></li>
                       <li><a href="{{root}}/download/">Other platforms, older versions, and source</a></li>
                     </ul>


### PR DESCRIPTION
Mentioning latest version each package manager is less maintainable. When we cut a new release, we'll have to follow the repository updates. I think we can drop the version information here.

Fixes #1831