### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# How to report security vulnerabilities in `jq`
+
+GitHub has a [mechanism for private disclosure of vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) to repository owners and authorized persons such as maintainers.  The `jqlang/jq` repository now has this feature enabled.
+
+## Reporting a Vulnerability
+
+See [Privately Reporting a Security Vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).  Click on [`jqlang/jq`](https://github.com/jqlang/jq)'s [Security page](https://github.com/jqlang/jq/security) and click on [Report a vulnerability](https://github.com/jqlang/jq/security/advisories/new).  This will notify the owners and maintainers.  After submitting you'll get an option to start a private clone of `jqlang/jq` for collaboration with the maintainers.


### PR DESCRIPTION
Supersede #2607 with a security policy that refers to GitHub's private reporting mechanism.