### PR TITLE
revamp sub/3 to resolve most issues with gsub (and sub with "g")

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -127,17 +127,16 @@ def uniq(s):
 # If s contains capture variables, then create a capture object and pipe it to s
 def sub($re; s; $flags):
    . as $in
-   | [uniq(match($re; $flags))]
-   | if length == 0 then $in
-     else reduce .[] as $edit ({result: "", previous: 0, gap: ""};
+   | (reduce uniq(match($re; $flags)) as $edit
+        ({result: "", previous: 0, gap: ""};
             .gap = $in[ .previous: ($edit | .offset) ]
             # create the "capture" object
             | (reduce ( $edit | .captures | .[] | select(.name != null) | { (.name) : .string } ) as $pair
                  ({}; . + $pair) | s) as $insert
             | .result += .gap + $insert
 	    | .previous = ($edit | .offset + .length ) )
-          | .result + $in[.previous:]
-     end;
+          | .result + $in[.previous:] )
+      // $in;
 #
 def sub($re; s): sub($re; s; "");
 #

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -128,12 +128,12 @@ def uniq(s):
 def sub($re; s; $flags):
    . as $in
    | (reduce uniq(match($re; $flags)) as $edit
-        ({result: "", previous: 0, gap: ""};
-            .gap = $in[ .previous: ($edit | .offset) ]
+        ({result: "", previous: 0};
+            $in[ .previous: ($edit | .offset) ] as $gap
             # create the "capture" object
             | (reduce ( $edit | .captures | .[] | select(.name != null) | { (.name) : .string } ) as $pair
                  ({}; . + $pair) | s) as $insert
-            | .result += .gap + $insert
+            | .result += $gap + $insert
 	    | .previous = ($edit | .offset + .length ) )
           | .result + $in[.previous:] )
       // $in;
@@ -224,7 +224,6 @@ def tostream:
   path(def r: (.[]?|r), .; r) as $p |
   getpath($p) |
   reduce path(.[]?) as $q ([$p, .]; [$p+$q]);
-
 
 # Assuming the input array is sorted, bsearch/1 returns
 # the index of the target if the target is in the input array; and otherwise

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -102,7 +102,7 @@ def scan(re):
 def _nwise($n):
   def n: if length <= $n then . else .[0:$n] , (.[$n:] | n) end;
   n;
-def _nwise($n): _nwise(.; $n);
+def _nwise(a; $n): a | _nwise($n);
 #
 # splits/1 produces a stream; split/1 is retained for backward compatibility.
 def splits($re; flags): . as $s

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -75,6 +75,40 @@ gsub( "(.*)"; "";  "x")
 ""
 ""
 
+gsub( ""; "a";  "g")
+""
+"a"
+
+gsub( "^"; "";  "g")
+"a"
+"a"
+
+
+# The following is a regression test and should not be construed as a requirement other than that execution should terminate:
+gsub( ""; "a";  "g")
+"a"
+"aa"
+
+gsub( "$"; "a";  "g")
+"a"
+"aa"
+
+gsub( "^"; "a")
+""
+"a"
+
+gsub("(?=u)"; "u")
+"qux"
+"quux"
+
+gsub("^.*a"; "b")
+"aaa"
+"b"
+
+gsub("^.*?a"; "b")
+"aaa"
+"baa"
+
 [.[] | scan(", ")]
 ["a,b, c, d, e,f",", a,b, c, d, e,f, "]
 [", ",", ",", ",", ",", ",", ",", ",", "]
@@ -91,6 +125,14 @@ gsub( "(.*)"; "";  "x")
 gsub("(?<x>.)[^a]*"; "+\(.x)-")
 "Abcabc"
 "+A-+a-"
+
+gsub("(?<x>.)(?<y>[0-9])"; "\(.x|ascii_downcase)\(.y)")
+"A1 B2 CD"
+"a1 b2 CD"
+
+gsub("\\b(?<x>.)"; "\(.x|ascii_downcase)")
+"ABC DEF"
+"aBC dEF"
 
 # utf-8
 sub("(?<x>.)"; "\(.x)!")

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -138,3 +138,8 @@ gsub("\\b(?<x>.)"; "\(.x|ascii_downcase)")
 sub("(?<x>.)"; "\(.x)!")
 "’"
 "’!"
+
+# splits and _nwise
+[splits("")]
+"ab"
+["","a","b"]


### PR DESCRIPTION
The primary purpose of this commit is to rectify most problems with gsub (and also sub with "g"), and in particular
#1425 (\b), #2354 (lookahead), and #2532 (regex == "^(?!cd ).*$|^cd "; ""))

The revision also partly resolves #2148 and #1206 in that gsub no longer loops infinitely, but because the new gsub depends on match(_;"g"), the behavior when regex == "" is sometimes non-standard.

Since the new sub/3 relies on uniq/1, that has been added as well; this should be a non-issue as the line count of the revised builtin.jq has been significantly reduced overall.

Also, _nwise/1 has been tweaked to take advantage of TCO.