### PR TITLE
Document `length` for numbers and bools

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -814,16 +814,20 @@ sections:
             codepoints it contains (which will be the same as its
             JSON-encoded length in bytes if it's pure ASCII).
 
+          - The length of a **number** is its absolute value.
+
           - The length of an **array** is the number of elements.
 
           - The length of an **object** is the number of key-value pairs.
 
           - The length of **null** is zero.
 
+          - It is an error to use `length` on a **boolean**.
+
         examples:
           - program: '.[] | length'
-            input: '[[1,2], "string", {"a":2}, null]'
-            output: [2, 6, 1, 0]
+            input: '[[1,2], "string", {"a":2}, null, -5]'
+            output: [2, 6, 1, 0, 5]
 
 
       - title: "`utf8bytelength`"

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -744,7 +744,7 @@ sections:
 
           - The length of **null** is zero.
 
-          - It is an error to use `length` on a **boolean**
+          - It is an error to use `length` on a **boolean**.
 
         examples:
           - program: '.[] | length'

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -748,8 +748,8 @@ sections:
 
         examples:
           - program: '.[] | length'
-            input: '[[1,2], "string", {"a":2}, null, -6]'
-            output: [2, 6, 1, 0, 6]
+            input: '[[1,2], "string", {"a":2}, null, -5]'
+            output: [2, 6, 1, 0, 5]
 
 
       - title: "`utf8bytelength`"

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -736,6 +736,8 @@ sections:
             codepoints it contains (which will be the same as its
             JSON-encoded length in bytes if it's pure ASCII).
 
+          - The length of a **number** is its absolute value.
+
           - The length of an **array** is the number of elements.
 
           - The length of an **object** is the number of key-value pairs.

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -744,10 +744,12 @@ sections:
 
           - The length of **null** is zero.
 
+          - It is an error to use `length` on a **boolean**
+
         examples:
           - program: '.[] | length'
-            input: '[[1,2], "string", {"a":2}, null]'
-            output: [2, 6, 1, 0]
+            input: '[[1,2], "string", {"a":2}, null, -6]'
+            output: [2, 6, 1, 0, 6]
 
 
       - title: "`utf8bytelength`"


### PR DESCRIPTION
This was added in ae7a042876130c471dce28a4396abc215192eaa9 but not explicitly documented.