### PR TITLE
Fix overflow exception of the modulo operator (fix #1176)

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -396,9 +396,11 @@ static jv f_divide(jq_state *jq, jv input, jv a, jv b) {
 static jv f_mod(jq_state *jq, jv input, jv a, jv b) {
   jv_free(input);
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    if ((intmax_t)jv_number_value(b) == 0)
+    intmax_t bi = (intmax_t)jv_number_value(b);
+    if (bi == 0)
       return type_error2(a, b, "cannot be divided (remainder) because the divisor is zero");
-    jv r = jv_number((intmax_t)jv_number_value(a) % (intmax_t)jv_number_value(b));
+    // Check if the divisor is -1 to avoid overflow when the dividend is INTMAX_MIN.
+    jv r = jv_number(bi == -1 ? 0 : (intmax_t)jv_number_value(a) % bi);
     jv_free(a);
     jv_free(b);
     return r;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -540,6 +540,10 @@ null
 null
 172
 
+[(infinite, -infinite) % (1, -1)]
+null
+[0,0,0,0]
+
 1 + tonumber + ("10" | tonumber)
 4
 15


### PR DESCRIPTION
This PR fixes #1176. Overflow happens for `INTMAX_MIN % (-1)`.