### PR TITLE
Fix glibc warning about _BSD_SOURCE and redefined _GNU_SOURCE (fix #1978)

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1,5 +1,6 @@
-#define _BSD_SOURCE
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #ifndef __sun__
 # define _XOPEN_SOURCE
 # define _XOPEN_SOURCE_EXTENDED 1


### PR DESCRIPTION
This PR fixes #1978, suppresses glibs warnings. Since glibc 2.19, `_GNU_SOURCE` implies `_DEFAULT_SOURCE` as well.