### PR TITLE
Fix halt_error to print message without prefix in raw mode (fix #1902)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -217,7 +217,8 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
     jv error_message = jq_get_error_message(jq);
     if (jv_get_kind(error_message) == JV_KIND_STRING) {
       // No prefix should be added to the output of `halt_error`.
-      fprintf(stderr, "%s", jv_string_value(error_message));
+      fwrite(jv_string_value(error_message), 1,
+          jv_string_length_bytes(jv_copy(error_message)), stderr);
     } else if (jv_get_kind(error_message) == JV_KIND_NULL) {
       // Halt with no output
     } else if (jv_is_valid(error_message)) {

--- a/src/main.c
+++ b/src/main.c
@@ -216,12 +216,13 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
     jv_free(exit_code);
     jv error_message = jq_get_error_message(jq);
     if (jv_get_kind(error_message) == JV_KIND_STRING) {
-      fprintf(stderr, "jq: error: %s", jv_string_value(error_message));
+      // No prefix should be added to the output of `halt_error`.
+      fprintf(stderr, "%s", jv_string_value(error_message));
     } else if (jv_get_kind(error_message) == JV_KIND_NULL) {
       // Halt with no output
     } else if (jv_is_valid(error_message)) {
       error_message = jv_dump_string(jv_copy(error_message), 0);
-      fprintf(stderr, "jq: error: %s\n", jv_string_value(error_message));
+      fprintf(stderr, "%s\n", jv_string_value(error_message));
     } // else no message on stderr; use --debug-trace to see a message
     fflush(stderr);
     jv_free(error_message);

--- a/tests/shtest
+++ b/tests/shtest
@@ -275,11 +275,15 @@ if [ -n "$($VALGRIND $Q $JQ -n 'halt_error(1)' 2>&1)" ]; then
     echo "jq halt_error(1) had unexpected output" 1>&2
     exit 1
 fi
-if [ -n "$($VALGRIND $Q $JQ -n '"xyz\n"|halt_error(1)' 2>/dev/null)" ]; then
+if [ -n "$($VALGRIND $Q $JQ -n '"xyz\n" | halt_error(1)' 2>/dev/null)" ]; then
     echo "jq halt_error(1) had unexpected output on stdout" 1>&2
     exit 1
 fi
-if [ "$($VALGRIND $Q $JQ -n '"xyz\n"|halt_error(1)' 2>&1)" != "jq: error: xyz" ]; then
+if [ "$($VALGRIND $Q $JQ -n '"xyz\n" | halt_error(1)' 2>&1)" != "xyz" ]; then
+    echo "jq halt_error(1) had unexpected output" 1>&2
+    exit 1
+fi
+if [ "$($VALGRIND $Q $JQ -n '{"a":"xyz"} | halt_error(1)' 2>&1)" != '{"a":"xyz"}' ]; then
     echo "jq halt_error(1) had unexpected output" 1>&2
     exit 1
 fi

--- a/tests/shtest
+++ b/tests/shtest
@@ -279,7 +279,11 @@ if [ -n "$($VALGRIND $Q $JQ -n '"xyz\n" | halt_error(1)' 2>/dev/null)" ]; then
     echo "jq halt_error(1) had unexpected output on stdout" 1>&2
     exit 1
 fi
-if [ "$($VALGRIND $Q $JQ -n '"xyz\n" | halt_error(1)' 2>&1)" != "xyz" ]; then
+if [ "$($VALGRIND $Q $JQ -n '"xy" | halt_error(1)' 2>&1 || echo "z")" != "xyz" ]; then
+    echo "jq halt_error(1) had unexpected output" 1>&2
+    exit 1
+fi
+if [ "$($VALGRIND $Q $JQ -n '"x\u0000y\u0000z" | halt_error(1)' 2>&1 | tr '\0' '.')" != "x.y.z" ]; then
     echo "jq halt_error(1) had unexpected output" 1>&2
     exit 1
 fi


### PR DESCRIPTION
This PR fixes #1902. The manual says that `halt_error` should print the input with no decoration . This is a regression of 2b4d51f6976f15307e70387d3e015de274589193, which is after 1.6.