### PR TITLE
Fix bison warnings on incompatibilities with POSIX Yacc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,10 +44,10 @@ BUILT_SOURCES = src/builtin.inc src/version.h
 	$(AM_V_LEX) echo "NOT building lexer.c!"
 endif
 
-# Tell YACC (bison) autoconf macros that you want a header file created.
-# If the --warnings=all fails, you probably have an old version of bison
-# OSX ships an old bison, so update with homebrew or macports
-AM_YFLAGS = --warnings=all -d
+# Tell YACC (Bison) autoconf macros that you want a header file created.
+# If the --warnings=all fails, you probably have an old version of Bison
+# macOS ships an old Bison, so update with Homebrew or MacPorts.
+AM_YFLAGS = --warnings=all -Wno-yacc -d
 
 ### libjq
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -26,7 +26,7 @@ struct lexer_param;
 }
 
 %locations
-%error-verbose
+%define parse.error verbose
 %define api.pure
 %union {
   jv literal;


### PR DESCRIPTION
This PR fixes bison warnings on incompatibilities with POSIX Yacc (e.x. `warning: POSIX Yacc does not support string literals`), also fixes deprecation warning (e.x. `warning: deprecated directive: ‘ %error-verbose’ , use ‘ %define parse.error verbose’`). See https://www.gnu.org/software/bison/manual/html_node/Diagnostics.html for reference, `--warnings=all` is still important.