### PR TITLE
Remove unused function: jv_mem_invalidate, jv_mem_uninit_setup

### DIFF
--- a/src/jv_alloc.c
+++ b/src/jv_alloc.c
@@ -165,15 +165,3 @@ void* jv_mem_realloc(void* p, size_t sz) {
   }
   return p;
 }
-
-#ifndef NDEBUG
-volatile char jv_mem_uninitialised;
-__attribute__((constructor)) void jv_mem_uninit_setup(){
-  // ignore warning that this reads uninitialized memory - that's the point!
-#ifndef __clang_analyzer__
-  char* p = malloc(1);
-  jv_mem_uninitialised = *p;
-  free(p);
-#endif
-}
-#endif

--- a/src/jv_alloc.h
+++ b/src/jv_alloc.h
@@ -4,17 +4,6 @@
 #include <stddef.h>
 #include "jv.h"
 
-#ifndef NDEBUG
-extern volatile char jv_mem_uninitialised;
-#endif
-
-static void jv_mem_invalidate(void* mem, size_t n) {
-#ifndef NDEBUG
-  char* m = mem;
-  while (n--) *m++ ^= jv_mem_uninitialised ^ jv_mem_uninitialised;
-#endif
-}
-
 void* jv_mem_alloc(size_t);
 void* jv_mem_alloc_unguarded(size_t);
 void* jv_mem_calloc(size_t, size_t);


### PR DESCRIPTION
I found an unused function in jv_alloc.h. The commit e0524644f83dfa0de6365475a926d3ec558a145c removed all its usage.