### PR TITLE
Remove deleted README file from jq.spec

### DIFF
--- a/jq.spec
+++ b/jq.spec
@@ -52,7 +52,6 @@ rm -rf %{buildroot}
 %endif
 %{_datadir}/doc/%{name}/AUTHORS
 %{_datadir}/doc/%{name}/COPYING
-%{_datadir}/doc/%{name}/README
 %{_datadir}/doc/%{name}/README.md
 %{_datadir}/man/man1/jq.1
 %{_includedir}/jq.h


### PR DESCRIPTION
The rerundant README was removed in #2482, which is good, but building rpm package currently fails due to this change. So I removed the entry from `jq.spec`.