### PR TITLE
Move an example to the manual and regenerate man.test

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -2301,10 +2301,12 @@ sections:
           The `?` operator, used as `EXP?`, is shorthand for `try EXP`.
 
         examples:
-          - program: '[.[]|(.a)?]'
+          - program: '[.[] | .a?]'
             input: '[{}, true, {"a":1}]'
             output: ['[null, 1]']
-
+          - program: '[.[] | tonumber?]'
+            input: '["1", "invalid", "3", 4]'
+            output: ['[1, 3, 4]']
 
   - title: Regular expressions
     body: |

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2200,10 +2200,12 @@ sections:
           The `?` operator, used as `EXP?`, is shorthand for `try EXP`.
 
         examples:
-          - program: '[.[]|(.a)?]'
+          - program: '[.[] | .a?]'
             input: '[{}, true, {"a":1}]'
             output: ['[null, 1]']
-
+          - program: '[.[] | tonumber?]'
+            input: '["1", "invalid", "3", 4]'
+            output: ['[1, 3, 4]']
 
   - title: Regular expressions
     body: |

--- a/tests/man.test
+++ b/tests/man.test
@@ -2,6 +2,18 @@
 "Hello, world!"
 "Hello, world!"
 
+. | tojson
+12345678909876543212345
+"12345678909876543212345"
+
+map([., . == 1]) | tojson
+[1, 1.000, 1.0, 100e-2]
+"[[1,true],[1.000,true],[1.0,true],[1.00,true]]"
+
+. as $big | [$big, $big + 1] | map(. > 10000000000000000000000000000000)
+10000000000000000000000000000001
+[true, false]
+
 .foo
 {"foo": 42, "bar": "less interesting data"}
 42
@@ -163,11 +175,12 @@ null
 -1
 
 .[] | length
-[[1,2], "string", {"a":2}, null]
+[[1,2], "string", {"a":2}, null, -5]
 2
 6
 1
 0
+5
 
 utf8bytelength
 "\u03bc"
@@ -343,12 +356,12 @@ flatten
 [{"foo": "bar"}, [{"foo": "baz"}]]
 [{"foo": "bar"}, {"foo": "baz"}]
 
-range(2;4)
+range(2; 4)
 null
 2
 3
 
-[range(2;4)]
+[range(2; 4)]
 null
 [2,3]
 
@@ -356,15 +369,15 @@ null
 null
 [0,1,2,3]
 
-[range(0;10;3)]
+[range(0; 10; 3)]
 null
 [0,3,6,9]
 
-[range(0;10;-1)]
+[range(0; 10; -1)]
 null
 []
 
-[range(0;-5;-1)]
+[range(0; -5; -1)]
 null
 [0,-1,-2,-3,-4]
 
@@ -551,6 +564,10 @@ join(" ")
 1
 [1,2,4,8,16,32,64]
 
+[repeat(.*2, error)?]
+1
+[2]
+
 [.,1]|until(.[0] < 1; [.[0] - 1, .[1] * .[0]])|.[1]
 4
 24
@@ -658,7 +675,7 @@ true
 false
 false
 
-if . == 0 then "zero" elif . == 1 then "one" else "many" end
+if . == 0 then   "zero" elif . == 1 then   "one" else   "many" end
 2
 "many"
 
@@ -706,9 +723,13 @@ try error("some exception") catch .
 true
 "some exception"
 
-[.[]|(.a)?]
+[.[] | .a?]
 [{}, true, {"a":1}]
 [null, 1]
+
+[.[] | tonumber?]
+["1", "invalid", "3", 4]
+[1, 3, 4]
 
 test("foo")
 "foo"
@@ -841,8 +862,21 @@ true
 {"foo": 42}
 {"foo": 43}
 
-.[]|tonumber?
-["1", "hello", "3", 4]
-1
-3
-4
+.a = .b
+{"a": {"b": 10}, "b": 20}
+{"a":20,"b":20}
+
+.a |= .b
+{"a": {"b": 10}, "b": 20}
+{"a":10,"b":20}
+
+(.a, .b) = range(3)
+null
+{"a":0,"b":0}
+{"a":1,"b":1}
+{"a":2,"b":2}
+
+(.a, .b) |= range(3)
+null
+{"a":0,"b":0}
+


### PR DESCRIPTION
The PR #2400 added a test to `man.test`, but this file is generated from the manual. There're two options; move this test to `jq.test` or to the manual. I think this is worth adding to the `?` operator section, so added there and regenerated the test file.