### PR TITLE
Setup path correctly after stream parsing a key:value object pair

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -299,7 +299,7 @@ static pfunc stream_token(struct jv_parser* p, char ch) {
         p->output = JV_ARRAY(jv_copy(p->path), p->next);
         p->next = jv_invalid();
       }
-      p->path = jv_array_set(p->path, p->stacklen - 1, jv_true()); // ready for another name:value pair
+      p->path = jv_array_set(p->path, p->stacklen - 1, jv_null()); // ready for another key:value pair
       p->last_seen = JV_LAST_COMMA;
     } else {
       assert(k == JV_KIND_NULL);

--- a/tests/shtest
+++ b/tests/shtest
@@ -203,6 +203,10 @@ else
     echo "Not doing torture tests"
 fi
 
+## Regression test for issue #2378 assert when stream parse broken object pair
+echo '{"a":1,"b",' | $JQ --stream  > /dev/null 2> $d/err
+grep 'Objects must consist of key:value pairs' $d/err > /dev/null
+
 ## Fuzz parser
 
 ## XXX With a $(urandom) builtin we could move this test into tests/all.test


### PR DESCRIPTION
Fixes #2378 (assert on parsing invalid object)