### PR TITLE
Skip regex tests when built without regexp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ homepage and on the github release page, https://github.com/jqlang/jq/releases
 If you're building directly from the latest git, you'll need flex,
 bison (3.0 or newer), libtool, make, automake, and autoconf installed.
 To get regexp support you'll also need to install Oniguruma or clone it as a
-git submodule as per the instructions below.
-(note that jq's tests require regexp support to pass).  To build, run:
+git submodule as per the instructions below. To build, run:
 
     git submodule update --init # if building from git to get oniguruma
     autoreconf -fi              # if building from git


### PR DESCRIPTION
This PR catches the exception of regex library absence, and gracefully skip the test when built without oniguruma. This resolves #2292, but is better running all the manual tests except for regex ones.