### PR TITLE
Create dist and upload on release also disable docs on build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y \
-            automake \
-            autoconf \
-            bison \
-            flex \
-            gdb
+          sudo apt-get install -y automake autoconf
       - name: Build
         run: |
           autoreconf -i
@@ -54,8 +49,7 @@ jobs:
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
-            ${{ matrix.configure_flag }} \
-            YACC="$(which bison) -y"
+            ${{ matrix.configure_flag }}
           make
           strip jq
       - name: Test
@@ -97,12 +91,7 @@ jobs:
         run: |
           # brew update sometimes fails with "Fetching /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask failed!"
           brew update || brew update-reset
-          brew install \
-            autoconf \
-            automake \
-            libtool \
-            flex \
-            bison
+          brew install autoconf automake libtool
       - name: Build
         run: |
           autoreconf -i
@@ -113,8 +102,7 @@ jobs:
             --disable-valgrind \
             --with-oniguruma=builtin \
             --enable-static \
-            --enable-all-static \
-            YACC="$(brew --prefix)/opt/bison/bin/bison -y"
+            --enable-all-static
           make
           strip jq
       - name: Test
@@ -162,8 +150,6 @@ jobs:
             autoconf
             automake
             libtool
-            bison
-            flex
       - name: Build
         shell: msys2 {0}
         run: |
@@ -176,8 +162,7 @@ jobs:
             --with-oniguruma=builtin \
             --disable-shared \
             --enable-static \
-            --enable-all-static \
-            YACC="$(which bison) -y"
+            --enable-all-static
           make
           strip jq.exe
       - name: Test
@@ -211,9 +196,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y \
-            automake \
-            autoconf
+          sudo apt-get install -y automake autoconf
       - name: Create dist
         run: |
           autoreconf -i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,13 @@ jobs:
             autoconf \
             bison \
             flex \
-            gdb \
-            python3
+            gdb
       - name: Build
         run: |
-          autoreconf -fi
+          autoreconf -i
           ./configure --disable-dependency-tracking \
             --disable-silent-rules \
+            --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
@@ -105,9 +105,10 @@ jobs:
             bison
       - name: Build
         run: |
-          autoreconf -fi
+          autoreconf -i
           ./configure --disable-dependency-tracking \
             --disable-silent-rules \
+            --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
@@ -166,9 +167,10 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
-          autoreconf -fi
+          autoreconf -i
           ./configure --disable-dependency-tracking \
             --disable-silent-rules \
+            --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
@@ -199,17 +201,49 @@ jobs:
           retention-days: 7
           path: jq.exe
 
-  release:
+  dist:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [linux, macos, windows]
-    if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            automake \
+            autoconf
+      - name: Create dist
+        run: |
+          autoreconf -i
+          ./configure --disable-dependency-tracking \
+            --disable-silent-rules \
+            --disable-docs \
+            --disable-maintainer-mode \
+            --disable-valgrind \
+            --with-oniguruma=builtin
+          git diff --exit-code
+          make dist dist-zip
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: jq-dist
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            jq-*.tar.gz
+            jq-*.zip
+
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [linux, macos, windows, dist]
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
       - name: Merge built artifacts
         uses: actions/download-artifact@v3
         with:
@@ -223,6 +257,7 @@ jobs:
           cp artifacts/jq-linux-ubuntu-22.04-gcc/jq release/jq-linux-amd64
           cp artifacts/jq-macos-macos-13-gcc/jq release/jq-macos-amd64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
+          cp artifacts/jq-dist/jq-* release/
 
           gh release create $TAG_NAME --draft --title "jq ${TAG_NAME#v}" --generate-notes
           gh release upload $TAG_NAME --clobber release/jq-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Test
         run: |
           make check
+          git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
@@ -108,6 +109,7 @@ jobs:
       - name: Test
         run: |
           make check
+          git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
@@ -169,6 +171,7 @@ jobs:
         shell: msys2 {0}
         run: |
           make check
+          git diff --exit-code --ignore-submodules
       - name: Upload Test Logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
@@ -206,8 +209,8 @@ jobs:
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin
-          git diff --exit-code
           make dist dist-zip
+          git diff --exit-code
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/scanbuild.yml
+++ b/.github/workflows/scanbuild.yml
@@ -48,7 +48,7 @@ jobs:
                 CC: ${{ matrix.compiler }}
                 MAKEVARS: ${{ matrix.makevars }}
               run: |
-                autoreconf -fi
+                autoreconf -i
                 rm src/lexer.c src/lexer.h
                 rm src/parser.c src/parser.h
                 ./configure --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ tags
 jq
 !tests/modules/lib/jq/
 jq.1
+jq-*.tar.gz
+jq-*.zip
 
 # Generated source
 src/builtin.inc

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git submodule as per the instructions below.
 (note that jq's tests require regexp support to pass).  To build, run:
 
     git submodule update --init # if building from git to get oniguruma
-    autoreconf -fi              # if building from git
+    autoreconf -i               # if building from git
     ./configure --with-oniguruma=builtin
     make -j8
     make check


### PR DESCRIPTION
- I added new `dist` job to create the dist in CI, and upload the artifact on release.
- I disabled building docs because Python dependency is not correctly configured, and we also have another workflow to build the website.
- I also dropped `-f` flag from `autoreconf` because it overwrites the submodule files resulting into git diffs and -dirty suffix in dist file.
- Maybe we could build jq.1.prebuild somewhere but tackle later.

I downloaded the artifacts [here](https://github.com/jqlang/jq/actions/runs/5439907844?pr=2648) and confirmed that both .tar.gz and .zip can be built with `./configure && make`. Closes #1872, closes  #2372, also closes #2448.