### PR TITLE
Improve Dockerfile: update base image and optimize image size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Build
         run: |
           autoreconf -i
-          ./configure --disable-dependency-tracking \
-            --disable-silent-rules \
+          ./configure \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
@@ -96,8 +95,7 @@ jobs:
       - name: Build
         run: |
           autoreconf -i
-          ./configure --disable-dependency-tracking \
-            --disable-silent-rules \
+          ./configure \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
@@ -156,8 +154,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -i
-          ./configure --disable-dependency-tracking \
-            --disable-silent-rules \
+          ./configure \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
@@ -203,8 +200,7 @@ jobs:
       - name: Create dist
         run: |
           autoreconf -i
-          ./configure --disable-dependency-tracking \
-            --disable-silent-rules \
+          ./configure \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ WORKDIR /app
 COPY . /app
 RUN autoreconf -i \
  && ./configure \
-      --disable-dependency-tracking \
-      --disable-silent-rules \
       --disable-docs \
       --disable-maintainer-mode \
       --disable-valgrind \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,38 @@
-FROM debian:9
+FROM debian:12-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
+RUN apt-get update \
+ && apt-get install -y \
+      build-essential \
+      autoconf \
+      libtool \
+      git \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 COPY . /app
+RUN autoreconf -i \
+ && ./configure \
+      --disable-dependency-tracking \
+      --disable-silent-rules \
+      --disable-docs \
+      --disable-maintainer-mode \
+      --disable-valgrind \
+      --with-oniguruma=builtin \
+      --enable-static \
+      --enable-all-static \
+      --prefix=/usr/local \
+ && make -j$(nproc) \
+ && make check \
+ && make install-strip
 
-# get dependencies, build, and remove anything we don't need for running jq.
-# valgrind seems to have trouble with pthreads TLS so it's off.
+FROM scratch
 
-RUN apt-get update && \
-    apt-get install -y \
-        build-essential \
-        autoconf \
-        libtool \
-        git \
-        bison \
-        flex \
-        python3 \
-        python3-pip \
-        wget && \
-    pip3 install pipenv && \
-    (cd /app/docs && pipenv sync) && \
-    (cd /app && \
-        git submodule init && \
-        git submodule update && \
-        autoreconf -i && \
-        ./configure --disable-valgrind --enable-all-static --prefix=/usr/local && \
-        make -j8 && \
-        make check && \
-        make install ) && \
-    (cd /app/modules/oniguruma && \
-        make uninstall ) && \
-    (cd /app && \
-        make distclean ) && \
-    apt-get purge -y \
-        build-essential \
-        autoconf \
-        libtool \
-        bison \
-        git \
-        flex \
-        python3 \
-        python3-pip && \
-    apt-get autoremove -y && \
-    rm -rf /app/modules/oniguruma/* && \
-    rm -rf /app/modules/oniguruma/.git && \
-    rm -rf /app/modules/oniguruma/.gitignore && \
-    rm -rf /var/lib/apt/lists/* /var/lib/gems
-
-ENTRYPOINT ["/usr/local/bin/jq"]
-CMD []
+COPY --from=builder /app/AUTHORS /app/COPYING /usr/local/bin/jq /
+RUN ["/jq", "--version"]
+ENTRYPOINT ["/jq"]


### PR DESCRIPTION
This PR improves Dockerfile to resolve endless reports about the Docker image in the next release. I update the base image to Debian 12, and use multi-stage build to optimize the image size. We stop re-building the parser/lexer codes since that's what we do on building the release executables. We no longer re-build docs and manpage in this image, so drop dependency on Python. Releasing multi-arch image to GHCR will be in the next PR.
This PR closes #845, closes #1631, closes #1900, closes #2004, and closes #2617.