### PR TITLE
Release Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,12 +217,48 @@ jobs:
             jq-*.tar.gz
             jq-*.zip
 
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    if: startsWith(github.ref, 'refs/tags/jq-')
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Docker metadata
+        uses: docker/metadata-action@v4
+        id: metadata
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: type=match,pattern=jq-(.*),group=1,value=${{ github.ref_name }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and release Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          provenance: false
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [linux, macos, windows, dist]
-    if: startsWith(github.event.ref, 'refs/tags/jq-')
+    needs: [linux, macos, windows, dist, docker]
+    if: startsWith(github.ref, 'refs/tags/jq-')
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -240,6 +276,5 @@ jobs:
           cp artifacts/jq-macos-macos-13-gcc/jq release/jq-macos-amd64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
           cp artifacts/jq-dist/jq-* release/
-
-          gh release create $TAG_NAME --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
-          gh release upload $TAG_NAME --clobber release/jq-*
+          gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
+          gh release upload "$TAG_NAME" --clobber release/jq-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
 
   dist:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/jq-')
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR setups the release workflow to build and push Docker image to GitHub Container Registry. I have already pushed the latest image from debugging branch to https://github.com/jqlang/jq/pkgs/container/jq for anyone interested in the new home of the Docker image. In the next release, the tag `1.7` will be released and also the latest tag will be updated. Based on the request of #2187, I included 4 platforms; `amd64`, `arm64`, `ppc64le`, and `s390x`. Building the images on QEMU on GitHub Actions is extremely slow, and it took 40 minutes (see [this job](https://github.com/jqlang/jq/actions/runs/5454405857/jobs/9924482520)), but the job is triggered only on releases and we can accept this.
Resolves #2187, resolves #2209, resolves #2377, and resolves #2539.