### PR TITLE
Remove outdated CI badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ jq
 
 jq is a lightweight and flexible command-line JSON processor.
 
-[![Linux Build](https://github.com/jqlang/jq/actions/workflows/linux.yml/badge.svg?branch=master)](https://github.com/jqlang/jq/actions/workflows/linux.yml?query=branch%3Amaster)
-[![macOS Build](https://github.com/jqlang/jq/actions/workflows/macos.yml/badge.svg?branch=master)](https://github.com/jqlang/jq/actions/workflows/macos.yml?query=branch%3Amaster)
-[![Windows Build](https://github.com/jqlang/jq/actions/workflows/windows.yml/badge.svg?branch=master)](https://github.com/jqlang/jq/actions/workflows/windows.yml?query=branch%3Amaster)
-
 If you want to learn to use jq, read the documentation at
 [https://jqlang.github.io/jq](https://jqlang.github.io/jq).  This
 documentation is generated from the docs/ folder of this repository.


### PR DESCRIPTION
Since the current badges are outdated since the CI workflow unification. We could change it to a single badge, but I feel some loneliness, and also this file will be distributed, so I'll drop them all badges now.