### PR TITLE
Fix exit code on JSON parse error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -688,12 +688,12 @@ int main(int argc, char* argv[]) {
       // Parse error
       jv msg = jv_invalid_get_msg(value);
       if (!(options & SEQ)) {
-        // --seq -> errors are not fatal
-        ret = JQ_OK_NO_OUTPUT;
+        ret = JQ_ERROR_UNKNOWN;
         fprintf(stderr, "jq: parse error: %s\n", jv_string_value(msg));
         jv_free(msg);
         break;
       }
+      // --seq -> errors are not fatal
       fprintf(stderr, "jq: ignoring parse error: %s\n", jv_string_value(msg));
       jv_free(msg);
     }

--- a/tests/shtest
+++ b/tests/shtest
@@ -143,6 +143,15 @@ if $VALGRIND $Q $JQ -e . $d/input; then
   exit 2
 fi
 
+# Regression test for #2146
+if echo "foobar" | $JQ .; then
+  printf 'Issue #2146 is back?\n' 1>&2
+  exit 1
+elif [ $? -ne 5 ]; then
+  echo "Invalid input had wrong error code" 1>&2
+  exit 1
+fi
+
 # Regression test for #1534
 echo "[1,2,3,4]" > $d/expected
 printf "[1,2][3,4]" | $JQ -cs add > $d/out 2>&1
@@ -204,7 +213,7 @@ else
 fi
 
 ## Regression test for issue #2378 assert when stream parse broken object pair
-echo '{"a":1,"b",' | $JQ --stream  > /dev/null 2> $d/err
+echo '{"a":1,"b",' | $JQ --stream  > /dev/null 2> $d/err || true
 grep 'Objects must consist of key:value pairs' $d/err > /dev/null
 
 ## Fuzz parser


### PR DESCRIPTION
This PR fixes #2146. The exit code 4, which jq 1.6 emits on invalid input, is used to indicate no valid result for `--exit-status` option. It's better to be able to distinguish no valid result and JSON parse error. I think 5 is the only appropriate exit code considering the existing exit codes of jq.