### PR TITLE
Fix dumping large floating numbers (fix #2367)

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -216,16 +216,11 @@ enum {
 #define JVP_FLAGS_NUMBER_NATIVE_STR   JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_NATIVE, 1))
 #define JVP_FLAGS_NUMBER_LITERAL      JVP_MAKE_FLAGS(JV_KIND_NUMBER, JVP_MAKE_PFLAGS(JVP_NUMBER_DECIMAL, 1))
 
-#define STR(x) #x
-#define XSTR(x) STR(x)
-#define DBL_MAX_STR XSTR(DBL_MAX)
-#define DBL_MIN_STR "-" XSTR(DBL_MAX)
-
 // the decimal precision of binary double
 #define BIN64_DEC_PRECISION  (17)
 #define DEC_NUMBER_STRING_GUARD (14)
 
-#include <jv_thread.h>
+#include "jv_thread.h"
 #ifdef WIN32
 /* Copied from Heimdal: thread-specific keys; see lib/base/dll.c in Heimdal */
 
@@ -658,12 +653,12 @@ static const char* jvp_literal_number_literal(jv n) {
   }
 
   if (decNumberIsInfinite(pdec)) {
-    // For backward compatibility.
-    if (decNumberIsNegative(pdec)) {
-      return DBL_MIN_STR;
-    } else {
-      return DBL_MAX_STR;
-    }
+    // We cannot preserve the literal data of numbers outside the limited
+    // range of exponent. Since `decNumberToString` returns "Infinity"
+    // (or "-Infinity"), and to reduce stack allocations as possible, we
+    // normalize infinities in the callers instead of printing the maximum
+    // (or minimum) double here.
+    return NULL;
   }
 
   if (plit->literal_data == NULL) {

--- a/tests/shtest
+++ b/tests/shtest
@@ -152,6 +152,12 @@ elif [ $? -ne 5 ]; then
   exit 1
 fi
 
+# Regression test for #2367; make sure to call jq twice
+if ! echo '{"a": 1E9999999999}' | $JQ . | $JQ -e .a; then
+  printf 'Issue #2367 is back?\n' 1>&2
+  exit 1
+fi
+
 # Regression test for #1534
 echo "[1,2,3,4]" > $d/expected
 printf "[1,2][3,4]" | $JQ -cs add > $d/out 2>&1


### PR DESCRIPTION
Due to the differences of `DBL_MAX` and `DBL_MIN` definition between compilers, large floating number literals in input JSON are dumped incorrectly as reported by #2367. This PR fixes #2367.