### PR TITLE
Cross compile for Linux, MacOS and Windows on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [macos-11, macos-12, macos-13]
-        arch: [x86_64, arm64]
+        image:
+          [
+            macos-11,
+            macos-12,
+            macos-13,
+          ]
+        arch:
+          [
+            amd64,
+            arm64,
+          ]
+        include:
+          - arch: amd64
+            target: "x86_64-apple-darwin"
+          - arch: arm64
+            target: "arm64-apple-darwin"
     runs-on: ${{ matrix.image }}
     env:
       SUFFIX: macos-${{ matrix.image }}-clang-${{ matrix.arch }}
@@ -173,24 +187,24 @@ jobs:
           brew install autoconf automake libtool
       - name: "Set CC"
         run: |
-          echo "CC=clang -target ${{ matrix.arch }}-apple-darwin$(uname -r)" >> $GITHUB_ENV
+          echo "CC=clang -target ${{ matrix.target }}$(uname -r)" >> $GITHUB_ENV
       - name: Build
         run: |
           autoreconf -i
           ./configure \
+            --host=${{ matrix.target }}$(uname -r) \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
             --enable-static \
-            --enable-all-static \
-            --host=${{ matrix.arch }}-apple-darwin$(uname -r)
+            --enable-all-static
           make
           strip jq
           file ./jq
       - name: Test
-        # Only run tests for x86_64 matching the CI machine arch
-        if: ${{ matrix.arch == 'x86_64' }}
+        # Only run tests for amd64 matching the CI machine arch
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
           make check
           git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          [
-            ubuntu-22.04,
-          ]
         arch:
           [
             amd64,
@@ -99,7 +95,7 @@ jobs:
             CC: "s390x-linux-gnu"
             binutils: "binutils-s390x-linux-gnu"
             strip: "s390x-linux-gnu-strip"
-    runs-on: ${{ matrix.image }}
+    runs-on: ubuntu-22.04
     env:
       AR: ${{ matrix.CC }}-ar
       CHOST: ${{ matrix.cc }}
@@ -107,7 +103,7 @@ jobs:
       CPP: ${{ matrix.cc }}-cpp
       CXX: ${{ matrix.cc }}-g++
       LDFLAGS: -s
-      SUFFIX: linux-${{ matrix.image }}-gcc-${{ matrix.arch }}
+      SUFFIX: linux-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -130,8 +126,9 @@ jobs:
             --enable-static \
             --enable-all-static
           make -j$(nproc)
-          ${{ matrix.strip }} jq
+          ${{ matrix.strip }} ./jq
           file ./jq
+          cp ./jq jq-${{ env.SUFFIX }}
       - name: Test
         # Only run tests for amd64 matching the CI machine arch
         if: ${{ matrix.arch == 'amd64' }}
@@ -151,20 +148,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jq-${{ env.SUFFIX }}
+          path: jq-${{ env.SUFFIX }}
           if-no-files-found: error
           retention-days: 7
-          path: jq
 
   macos:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          [
-            macos-11,
-            macos-12,
-            macos-13,
-          ]
         arch:
           [
             amd64,
@@ -175,9 +166,9 @@ jobs:
             target: "x86_64-apple-darwin"
           - arch: arm64
             target: "arm64-apple-darwin"
-    runs-on: ${{ matrix.image }}
+    runs-on: macos-13
     env:
-      SUFFIX: macos-${{ matrix.image }}-clang-${{ matrix.arch }}
+      SUFFIX: macos-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -203,8 +194,9 @@ jobs:
             --enable-static \
             --enable-all-static
           make
-          strip jq
+          strip ./jq
           file ./jq
+          cp ./jq jq-${{ env.SUFFIX }}
       - name: Test
         # Only run tests for amd64 matching the CI machine arch
         if: ${{ matrix.arch == 'amd64' }}
@@ -224,18 +216,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jq-${{ env.SUFFIX }}
+          path: jq-${{ env.SUFFIX }}
           if-no-files-found: error
           retention-days: 7
-          path: jq
 
   windows:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          [
-            windows-2022,
-          ]
         arch:
           [
             amd64,
@@ -250,7 +238,7 @@ jobs:
             CC: "i686-w64-mingw32"
             toolchain: "mingw-w64-i686-toolchain"
             msystem: mingw32
-    runs-on: ${{ matrix.image }}
+    runs-on: windows-2022
     env:
       CHOST: ${{ matrix.CC }}
       CC: ${{ matrix.CC }}-gcc
@@ -287,6 +275,7 @@ jobs:
             --enable-all-static
           make
           file ./jq.exe
+          cp ./jq.exe jq-${{ env.SUFFIX }}.exe
       - name: Test
         # Only run tests for amd64 matching the CI machine arch
         if: ${{ matrix.arch == 'amd64' }}
@@ -308,9 +297,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jq-${{ env.SUFFIX }}
+          path: jq-${{ env.SUFFIX }}.exe
           if-no-files-found: error
           retention-days: 7
-          path: jq.exe
 
   dist:
     runs-on: ubuntu-latest
@@ -391,20 +380,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Merge built artifacts
         uses: actions/download-artifact@v3
-        with:
-          path: artifacts
       - name: Upload release
         env:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir release
-          cp artifacts/jq-linux-ubuntu-22.04-gcc-amd64/jq release/jq-linux-amd64
-          cp artifacts/jq-linux-ubuntu-22.04-gcc-arm64/jq release/jq-linux-arm64
-          cp artifacts/jq-macos-macos-13-clang-amd64/jq release/jq-macos-amd64
-          cp artifacts/jq-macos-macos-13-clang-arm64/jq release/jq-macos-arm64
-          cp artifacts/jq-windows-amd64/jq.exe release/jq-windows-amd64.exe
-          cp artifacts/jq-windows-i386/jq.exe release/jq-windows-i386.exe
-          cp artifacts/jq-dist/jq-* release/
+          mkdir -p "release"
+          for files in jq-*; do
+              cp -rf ${files}/* "release/"
+          done
+
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber release/jq-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,6 @@ jobs:
           name: test-logs-${{ env.SUFFIX }}
           retention-days: 7
           path: |
-            config.log
             test-suite.log
             tests/*.log
       - name: Upload Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [linux, macos, windows, dist, docker]
+    needs: [linux, macos, windows, dist]
     if: startsWith(github.ref, 'refs/tags/jq-')
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [linux, macos, windows, dist]
+    needs: [linux, macos, windows, dist, docker]
     if: startsWith(github.ref, 'refs/tags/jq-')
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,7 @@ jobs:
       CHOST: ${{ matrix.CC }}
       CC: ${{ matrix.CC }}-gcc
       LDFLAGS: -s
-      SUFFIX: windows-${{ matrix.image }}-gcc
+      SUFFIX: windows-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -285,7 +285,6 @@ jobs:
             --disable-shared \
             --enable-static \
             --enable-all-static
-          sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
           make
           file ./jq.exe
       - name: Test
@@ -404,7 +403,8 @@ jobs:
           cp artifacts/jq-linux-ubuntu-22.04-gcc-arm64/jq release/jq-linux-arm64
           cp artifacts/jq-macos-macos-13-clang-amd64/jq release/jq-macos-amd64
           cp artifacts/jq-macos-macos-13-clang-arm64/jq release/jq-macos-arm64
-          cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
+          cp artifacts/jq-windows-amd64/jq.exe release/jq-windows-amd64.exe
+          cp artifacts/jq-windows-i386/jq.exe release/jq-windows-i386.exe
           cp artifacts/jq-dist/jq-* release/
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber release/jq-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,11 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         image: [macos-11, macos-12, macos-13]
+        arch: [x86_64, arm64]
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.compiler }}
-      SUFFIX: macos-${{ matrix.image }}-${{ matrix.compiler }}
+      CC: ${{ matrix.compiler }} -arch ${{ matrix.arch}}
+      SUFFIX: macos-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -101,10 +102,13 @@ jobs:
             --disable-valgrind \
             --with-oniguruma=builtin \
             --enable-static \
-            --enable-all-static
+            --enable-all-static \
+            --host=${{ matrix.arch }}-apple-darwin$(uname -r)
           make
           strip jq
       - name: Test
+        # Only run tests for x86_64 matching the CI machine arch
+        if: ${{ matrix.arch == 'x86_64' }}
         run: |
           make check
           git diff --exit-code
@@ -274,7 +278,8 @@ jobs:
         run: |
           mkdir release
           cp artifacts/jq-linux-ubuntu-22.04-gcc/jq release/jq-linux-amd64
-          cp artifacts/jq-macos-macos-13-gcc/jq release/jq-macos-amd64
+          cp artifacts/jq-macos-macos-13-gcc-x86_64/jq release/jq-macos-amd64
+          cp artifacts/jq-macos-macos-13-gcc-arm64/jq release/jq-macos-arm64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
           cp artifacts/jq-dist/jq-* release/
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,13 +243,13 @@ jobs:
           ]
         include:
           - arch: amd64
-            CC: "x86_64-w64-mingw32"
-            toolchain: "mingw-w64-x86_64-toolchain"
-            env: mingw64
+            CC: "x86_64-pc-msys"
+            toolchain: "gcc"
+            msystem: msys
           - arch: i386
             CC: "i686-w64-mingw32"
             toolchain: "mingw-w64-i686-toolchain"
-            env: mingw32
+            msystem: mingw32
     runs-on: ${{ matrix.image }}
     env:
       CHOST: ${{ matrix.CC }}
@@ -264,7 +264,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
-          msystem: ${{ matrix.env }}
+          msystem: ${{ matrix.msystem }}
           install: >-
             base-devel
             git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,10 +232,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [windows-2019, windows-2022]
+        image:
+          [
+            windows-2022,
+          ]
+        arch:
+          [
+            amd64,
+            i386,
+          ]
+        include:
+          - arch: amd64
+            CC: "x86_64-w64-mingw32"
+            toolchain: "mingw-w64-x86_64-toolchain"
+            env: mingw64
+          - arch: i386
+            CC: "i686-w64-mingw32"
+            toolchain: "mingw-w64-i686-toolchain"
+            env: mingw32
     runs-on: ${{ matrix.image }}
     env:
-      CC: gcc
+      CHOST: ${{ matrix.CC }}
+      CC: ${{ matrix.CC }}-gcc
+      LDFLAGS: -s
       SUFFIX: windows-${{ matrix.image }}-gcc
     steps:
       - name: Clone repository
@@ -245,18 +264,20 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           update: true
+          msystem: ${{ matrix.env }}
           install: >-
             base-devel
             git
-            clang
             autoconf
             automake
             libtool
+            ${{ matrix.toolchain }}
       - name: Build
         shell: msys2 {0}
         run: |
           autoreconf -i
           ./configure \
+            --host=${{ matrix.CC }} \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
@@ -264,9 +285,12 @@ jobs:
             --disable-shared \
             --enable-static \
             --enable-all-static
+          sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
           make
-          strip jq.exe
+          file ./jq.exe
       - name: Test
+        # Only run tests for amd64 matching the CI machine arch
+        if: ${{ matrix.arch == 'amd64' }}
         shell: msys2 {0}
         run: |
           make check
@@ -278,6 +302,7 @@ jobs:
           name: test-logs-${{ env.SUFFIX }}
           retention-days: 7
           path: |
+            config.log
             test-suite.log
             tests/*.log
       - name: Upload Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
         image: [macos-11, macos-12, macos-13]
         arch: [x86_64, arm64]
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.compiler }}
-      SUFFIX: macos-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
+      SUFFIX: macos-${{ matrix.image }}-clang-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -99,6 +97,9 @@ jobs:
           # brew update sometimes fails with "Fetching /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask failed!"
           brew update || brew update-reset
           brew install autoconf automake libtool
+      - name: "Set CC"
+        run: |
+          echo "CC=clang -target ${{ matrix.arch }}-apple-darwin$(uname -r)" >> $GITHUB_ENV
       - name: Build
         run: |
           autoreconf -i
@@ -286,8 +287,8 @@ jobs:
           mkdir release
           cp artifacts/jq-linux-ubuntu-22.04-gcc-x86_64/jq release/jq-linux-amd64
           cp artifacts/jq-linux-ubuntu-22.04-gcc-aarch64/jq release/jq-linux-arm64
-          cp artifacts/jq-macos-macos-13-gcc-x86_64/jq release/jq-macos-amd64
-          cp artifacts/jq-macos-macos-13-gcc-arm64/jq release/jq-macos-arm64
+          cp artifacts/jq-macos-macos-13-clang-x86_64/jq release/jq-macos-amd64
+          cp artifacts/jq-macos-macos-13-clang-arm64/jq release/jq-macos-arm64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
           cp artifacts/jq-dist/jq-* release/
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             --with-oniguruma=builtin \
             --enable-static \
             --enable-all-static
-          make
+          make -j$(nproc)
           file ./jq
           cp ./jq jq-${{ env.SUFFIX }}
       - name: Test
@@ -241,7 +241,7 @@ jobs:
             --disable-shared \
             --enable-static \
             --enable-all-static
-          make
+          make -j$(nproc)
           file ./jq.exe
           cp ./jq.exe jq-${{ env.SUFFIX }}.exe
       - name: Test
@@ -355,7 +355,7 @@ jobs:
         run: |
           mkdir -p "release"
           for files in jq-*; do
-              cp -rf ${files}/* "release/"
+              cp -rf "${files}/*" "release/"
           done
 
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,11 @@ jobs:
           - arch: amd64
             CC: "x86_64-linux-gnu"
             binutils: "binutils-x86-64-linux-gnu"
+            strip: "x86_64-linux-gnu-strip"
           - arch: arm64
             CC: "aarch64-linux-gnu"
             binutils: "binutils-aarch64-linux-gnu"
+            strip: "aarch64-linux-gnu-strip"
           - arch: armel
             CC: "arm-linux-gnueabi"
             binutils: "binutils-aarch64-linux-gnu"
@@ -104,6 +106,7 @@ jobs:
       CC: ${{ matrix.cc }}-gcc
       CPP: ${{ matrix.cc }}-cpp
       CXX: ${{ matrix.cc }}-g++
+      LDFLAGS: -s
       SUFFIX: linux-${{ matrix.image }}-gcc-${{ matrix.arch }}
     steps:
       - name: Clone repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,99 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
-        image: [ubuntu-22.04]
-        arch: [x86_64, aarch64]
+        image:
+          [
+            ubuntu-22.04,
+          ]
+        arch:
+          [
+            amd64,
+            arm64,
+            armel,
+            armhf,
+            i386,
+            mips,
+            mips64,
+            mips64el,
+            mips64r6,
+            mips64r6el,
+            mipsel,
+            mipsr6,
+            mipsr6el,
+            powerpc,
+            ppc64el,
+            s390x,
+          ]
         include:
-          - compiler: gcc
-            arch: x86_64
-            cc: x86_64-linux-gnu-gcc
-          - compiler: gcc
-            arch: aarch64
-            cc: aarch64-linux-gnu-gcc
-          - compiler: clang
-            arch: x86_64
-            cc: clang -target x86_64-linux-gnu
-          - compiler: clang
-            arch: aarch64
-            cc: clang -target aarch64-linux-gnu
+          - arch: amd64
+            CC: "x86_64-linux-gnu"
+            binutils: "binutils-x86-64-linux-gnu"
+          - arch: arm64
+            CC: "aarch64-linux-gnu"
+            binutils: "binutils-aarch64-linux-gnu"
+          - arch: armel
+            CC: "arm-linux-gnueabi"
+            binutils: "binutils-aarch64-linux-gnu"
+          - arch: armhf
+            CC: "arm-linux-gnueabihf"
+            binutils: "binutils-arm-linux-gnueabi"
+            strip: "arm-linux-gnueabihf-strip"
+          - arch: i386
+            CC: "i686-linux-gnu"
+            binutils: "binutils-i686-linux-gnu"
+            strip: "i686-linux-gnu-strip"
+          - arch: mips
+            CC: "mips-linux-gnu"
+            binutils: "binutils-mips-linux-gnu"
+            strip: "mips-linux-gnu-strip"
+          - arch: mips64
+            CC: "mips64-linux-gnuabi64"
+            binutils: "binutils-mips64-linux-gnuabi64"
+            strip: "mips64-linux-gnuabi64-strip"
+          - arch: mips64el
+            CC: "mips64el-linux-gnuabi64"
+            binutils: "binutils-mips64el-linux-gnuabi64"
+            strip: "mips64el-linux-gnuabi64-strip"
+          - arch: mips64r6
+            CC: "mipsisa64r6-linux-gnuabi64"
+            binutils: "binutils-mipsisa64r6-linux-gnuabi64"
+            strip: "mipsisa64r6-linux-gnuabi64-strip"
+          - arch: mips64r6el
+            CC: "mipsisa64r6el-linux-gnuabi64"
+            binutils: "binutils-mipsisa64r6el-linux-gnuabi64"
+            strip: "mipsisa64r6el-linux-gnuabi64-strip"
+          - arch: mipsel
+            CC: "mipsel-linux-gnu"
+            binutils: "binutils-mipsel-linux-gnu"
+            strip: "mipsel-linux-gnu-strip"
+          - arch: mipsr6
+            CC: "mipsisa32r6-linux-gnu"
+            binutils: "binutils-mipsisa32r6-linux-gnu"
+            strip: "mipsisa32r6-linux-gnu-strip"
+          - arch: mipsr6el
+            CC: "mipsisa32r6el-linux-gnu"
+            binutils: "binutils-mipsisa32r6el-linux-gnu"
+            strip: "mipsisa32r6el-linux-gnu-strip"
+          - arch: powerpc
+            CC: "powerpc-linux-gnu"
+            binutils: "binutils-powerpc-linux-gnu"
+            strip: "powerpc-linux-gnu-strip"
+          - arch: ppc64el
+            CC: "powerpc64le-linux-gnu"
+            binutils: "binutils-powerpc64le-linux-gnu"
+            strip: "powerpc64le-linux-gnu-strip"
+          - arch: s390x
+            CC: "s390x-linux-gnu"
+            binutils: "binutils-s390x-linux-gnu"
+            strip: "s390x-linux-gnu-strip"
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.cc }}
-      SUFFIX: linux-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
-      ARCH: ${{ matrix.arch }}
+      AR: ${{ matrix.CC }}-ar
+      CHOST: ${{ matrix.cc }}
+      CC: ${{ matrix.cc }}-gcc
+      CPP: ${{ matrix.cc }}-cpp
+      CXX: ${{ matrix.cc }}-g++
+      SUFFIX: linux-${{ matrix.image }}-gcc-${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -40,24 +112,26 @@ jobs:
           submodules: true
       - name: Install packages
         run: |
-          sudo apt-get install -y automake autoconf gcc-${ARCH/_/-}-linux-gnu
+          sudo apt-get update
+          sudo apt-get upgrade
+          sudo apt-get install -y automake autoconf libtool crossbuild-essential-${{ matrix.arch }} ${{ matrix.binutils }}
       - name: Build
         run: |
           autoreconf -i
           ./configure \
+            --host=${{ matrix.CC }} \
             --disable-docs \
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
-            --host=${{ matrix.arch }}-linux-gnu \
             --enable-static \
             --enable-all-static
-          make
-          ${ARCH}-linux-gnu-strip jq
+          make -j$(nproc)
+          ${{ matrix.strip }} jq
           file ./jq
       - name: Test
-        # Only run tests for x86_64 matching the CI machine arch
-        if: ${{ matrix.arch == 'x86_64' }}
+        # Only run tests for amd64 matching the CI machine arch
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
           make check
           git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,26 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
-        image: [ubuntu-20.04, ubuntu-22.04]
+        image: [ubuntu-22.04]
+        arch: [x86_64, aarch64]
         include:
           - compiler: gcc
-            image: ubuntu-20.04
-            configure_flag: ''
+            arch: x86_64
+            cc: x86_64-linux-gnu-gcc
           - compiler: gcc
-            image: ubuntu-22.04
-            configure_flag: --enable-static --enable-all-static
+            arch: aarch64
+            cc: aarch64-linux-gnu-gcc
           - compiler: clang
-            image: ubuntu-20.04
-            configure_flag: ''
+            arch: x86_64
+            cc: clang -target x86_64-linux-gnu
           - compiler: clang
-            image: ubuntu-22.04
-            configure_flag: --enable-static --enable-all-static
+            arch: aarch64
+            cc: clang -target aarch64-linux-gnu
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.compiler }}
-      SUFFIX: linux-${{ matrix.image }}-${{ matrix.compiler }}
+      CC: ${{ matrix.cc }}
+      SUFFIX: linux-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
+      ARCH: ${{ matrix.arch }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -38,8 +40,7 @@ jobs:
           submodules: true
       - name: Install packages
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y automake autoconf
+          sudo apt-get install -y automake autoconf gcc-${ARCH/_/-}-linux-gnu
       - name: Build
         run: |
           autoreconf -i
@@ -48,10 +49,15 @@ jobs:
             --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
-            ${{ matrix.configure_flag }}
+            --host=${{ matrix.arch }}-linux-gnu \
+            --enable-static \
+            --enable-all-static
           make
-          strip jq
+          ${ARCH}-linux-gnu-strip jq
+          file ./jq
       - name: Test
+        # Only run tests for x86_64 matching the CI machine arch
+        if: ${{ matrix.arch == 'x86_64' }}
         run: |
           make check
           git diff --exit-code
@@ -81,7 +87,7 @@ jobs:
         arch: [x86_64, arm64]
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.compiler }} -arch ${{ matrix.arch}}
+      CC: ${{ matrix.compiler }}
       SUFFIX: macos-${{ matrix.image }}-${{ matrix.compiler }}-${{ matrix.arch }}
     steps:
       - name: Clone repository
@@ -106,6 +112,7 @@ jobs:
             --host=${{ matrix.arch }}-apple-darwin$(uname -r)
           make
           strip jq
+          file ./jq
       - name: Test
         # Only run tests for x86_64 matching the CI machine arch
         if: ${{ matrix.arch == 'x86_64' }}
@@ -277,7 +284,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir release
-          cp artifacts/jq-linux-ubuntu-22.04-gcc/jq release/jq-linux-amd64
+          cp artifacts/jq-linux-ubuntu-22.04-gcc-x86_64/jq release/jq-linux-amd64
+          cp artifacts/jq-linux-ubuntu-22.04-gcc-aarch64/jq release/jq-linux-arm64
           cp artifacts/jq-macos-macos-13-gcc-x86_64/jq release/jq-macos-amd64
           cp artifacts/jq-macos-macos-13-gcc-arm64/jq release/jq-macos-arm64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,12 +141,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc]
         image: [windows-2019, windows-2022]
     runs-on: ${{ matrix.image }}
     env:
-      CC: ${{ matrix.compiler }}
-      SUFFIX: windows-${{ matrix.image }}-${{ matrix.compiler }}
+      CC: gcc
+      SUFFIX: windows-${{ matrix.image }}-gcc
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,9 +372,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir release
-          cp artifacts/jq-linux-ubuntu-22.04-gcc-x86_64/jq release/jq-linux-amd64
-          cp artifacts/jq-linux-ubuntu-22.04-gcc-aarch64/jq release/jq-linux-arm64
-          cp artifacts/jq-macos-macos-13-clang-x86_64/jq release/jq-macos-amd64
+          cp artifacts/jq-linux-ubuntu-22.04-gcc-amd64/jq release/jq-linux-amd64
+          cp artifacts/jq-linux-ubuntu-22.04-gcc-arm64/jq release/jq-linux-arm64
+          cp artifacts/jq-macos-macos-13-clang-amd64/jq release/jq-macos-amd64
           cp artifacts/jq-macos-macos-13-clang-arm64/jq release/jq-macos-arm64
           cp artifacts/jq-windows-windows-2022-gcc/jq.exe release/jq-windows-amd64.exe
           cp artifacts/jq-dist/jq-* release/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,67 +34,36 @@ jobs:
         include:
           - arch: amd64
             CC: "x86_64-linux-gnu"
-            binutils: "binutils-x86-64-linux-gnu"
-            strip: "x86_64-linux-gnu-strip"
           - arch: arm64
             CC: "aarch64-linux-gnu"
-            binutils: "binutils-aarch64-linux-gnu"
-            strip: "aarch64-linux-gnu-strip"
           - arch: armel
             CC: "arm-linux-gnueabi"
-            binutils: "binutils-aarch64-linux-gnu"
           - arch: armhf
             CC: "arm-linux-gnueabihf"
-            binutils: "binutils-arm-linux-gnueabi"
-            strip: "arm-linux-gnueabihf-strip"
           - arch: i386
             CC: "i686-linux-gnu"
-            binutils: "binutils-i686-linux-gnu"
-            strip: "i686-linux-gnu-strip"
           - arch: mips
             CC: "mips-linux-gnu"
-            binutils: "binutils-mips-linux-gnu"
-            strip: "mips-linux-gnu-strip"
           - arch: mips64
             CC: "mips64-linux-gnuabi64"
-            binutils: "binutils-mips64-linux-gnuabi64"
-            strip: "mips64-linux-gnuabi64-strip"
           - arch: mips64el
             CC: "mips64el-linux-gnuabi64"
-            binutils: "binutils-mips64el-linux-gnuabi64"
-            strip: "mips64el-linux-gnuabi64-strip"
           - arch: mips64r6
             CC: "mipsisa64r6-linux-gnuabi64"
-            binutils: "binutils-mipsisa64r6-linux-gnuabi64"
-            strip: "mipsisa64r6-linux-gnuabi64-strip"
           - arch: mips64r6el
             CC: "mipsisa64r6el-linux-gnuabi64"
-            binutils: "binutils-mipsisa64r6el-linux-gnuabi64"
-            strip: "mipsisa64r6el-linux-gnuabi64-strip"
           - arch: mipsel
             CC: "mipsel-linux-gnu"
-            binutils: "binutils-mipsel-linux-gnu"
-            strip: "mipsel-linux-gnu-strip"
           - arch: mipsr6
             CC: "mipsisa32r6-linux-gnu"
-            binutils: "binutils-mipsisa32r6-linux-gnu"
-            strip: "mipsisa32r6-linux-gnu-strip"
           - arch: mipsr6el
             CC: "mipsisa32r6el-linux-gnu"
-            binutils: "binutils-mipsisa32r6el-linux-gnu"
-            strip: "mipsisa32r6el-linux-gnu-strip"
           - arch: powerpc
             CC: "powerpc-linux-gnu"
-            binutils: "binutils-powerpc-linux-gnu"
-            strip: "powerpc-linux-gnu-strip"
           - arch: ppc64el
             CC: "powerpc64le-linux-gnu"
-            binutils: "binutils-powerpc64le-linux-gnu"
-            strip: "powerpc64le-linux-gnu-strip"
           - arch: s390x
             CC: "s390x-linux-gnu"
-            binutils: "binutils-s390x-linux-gnu"
-            strip: "s390x-linux-gnu-strip"
     runs-on: ubuntu-22.04
     env:
       AR: ${{ matrix.CC }}-ar
@@ -113,7 +82,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get upgrade
-          sudo apt-get install -y automake autoconf libtool crossbuild-essential-${{ matrix.arch }} ${{ matrix.binutils }}
+          sudo apt-get install -y automake autoconf libtool crossbuild-essential-${{ matrix.arch }}
       - name: Build
         run: |
           autoreconf -i
@@ -126,7 +95,6 @@ jobs:
             --enable-static \
             --enable-all-static
           make -j$(nproc)
-          ${{ matrix.strip }} ./jq
           file ./jq
           cp ./jq jq-${{ env.SUFFIX }}
       - name: Test
@@ -168,6 +136,7 @@ jobs:
             target: "arm64-apple-darwin"
     runs-on: macos-13
     env:
+      LDFLAGS: -s
       SUFFIX: macos-${{ matrix.arch }}
     steps:
       - name: Clone repository
@@ -194,7 +163,6 @@ jobs:
             --enable-static \
             --enable-all-static
           make
-          strip ./jq
           file ./jq
           cp ./jq jq-${{ env.SUFFIX }}
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             powerpc,
             ppc64el,
             s390x,
+            riscv64,
           ]
         include:
           - arch: amd64
@@ -64,6 +65,8 @@ jobs:
             CC: "powerpc64le-linux-gnu"
           - arch: s390x
             CC: "s390x-linux-gnu"
+          - arch: riscv64
+            CC: "riscv64-linux-gnu"
     runs-on: ubuntu-22.04
     env:
       AR: ${{ matrix.CC }}-ar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
         run: |
           mkdir -p "release"
           for files in jq-*; do
-              cp -rf "${files}/*" "release/"
+              cp -rf "${files}/"* "release/"
           done
 
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes

--- a/src/jv.c
+++ b/src/jv.c
@@ -222,6 +222,7 @@ enum {
 
 #include "jv_thread.h"
 #ifdef WIN32
+#ifndef __MINGW32__
 /* Copied from Heimdal: thread-specific keys; see lib/base/dll.c in Heimdal */
 
 /*
@@ -483,6 +484,9 @@ pthread_getspecific(pthread_key_t key)
         return NULL;
     return values.values[key];
 }
+#else
+#include <pthread.h>
+#endif
 #else
 #include <pthread.h>
 #endif

--- a/src/jv_thread.h
+++ b/src/jv_thread.h
@@ -2,6 +2,7 @@
 #define JV_THREAD_H
 
 #ifdef WIN32
+#ifndef __MINGW32__
 #include <windows.h>
 #include <winnt.h>
 #include <errno.h>
@@ -66,6 +67,9 @@ typedef unsigned long pthread_key_t;
 int pthread_key_create(pthread_key_t *, void (*)(void *));
 int pthread_setspecific(pthread_key_t, void *);
 void *pthread_getspecific(pthread_key_t);
+#else
+#include <pthread.h>
+#endif
 #else
 #include <pthread.h>
 #endif


### PR DESCRIPTION
This PR includes the following changes:

* Cross compile for Linux, MacOS and Windows on CI and upload corresponding artifacts to a release ([example](https://github.com/owenthereal/jq/releases/tag/jq-0.0.22))
* Remove `ubuntu-20.04` build because
  * [A static bin couldn't be built with the gcc toolchain](https://github.com/jqlang/jq/pull/2620#discussion_r1249458361)
  * [The aarch64 clang build failed for weird reasons](https://github.com/owenthereal/jq/actions/runs/5483326592/jobs/9989546559#step:4:428)
* Remove `gcc` compile target on MacOS because it symlinks `gcc` to `clang`
* Remove compiler variant for Windows because only `gcc` is supported
* Speed up `release` job by not waiting on `docker` job because it doesn't require anything from the `docker` job

This closes https://github.com/jqlang/jq/pull/2618 https://github.com/jqlang/jq/issues/2386

cc: @wader @itchyny  