### PR TITLE
exit immediately after  halt  or  halt_error  is called

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -692,6 +692,8 @@ int main(int argc, char* argv[]) {
         ret = process(jq, value, jq_flags, dumpopts);
         if (ret <= 0 && ret != JQ_OK_NO_OUTPUT)
           last_result = (ret != JQ_OK_NULL_KIND);
+        if (jq_halted(jq))
+          break;
         continue;
       }
 


### PR DESCRIPTION
Instead of continuing to the next input, and only exiting if there are no more inputs.

Closes #2533