### PR TITLE
Drop comments in builtin filters on build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,7 +114,7 @@ src/main.c: src/version.h
 
 src/builtin.inc: $(srcdir)/src/builtin.jq
 	mkdir -p src
-	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $(srcdir)/src/builtin.jq > $@
+	$(AM_V_GEN) sed -e 's/^ *#.*//' -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $(srcdir)/src/builtin.jq > $@
 src/builtin.o: src/builtin.inc
 
 bin_PROGRAMS = jq


### PR DESCRIPTION
I think we can drop comments of `builtin.inc` to minimize the file for runtime performance improvement. I used `s/^ *#.*//` instead of `/^ *#/d` to keep the line numbers. What do you think?