### PR TITLE
Fix the latest manual on string multiplication by zero

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -779,7 +779,7 @@ sections:
           Division by zero raises an error. `x % y` computes x modulo y.
 
           Multiplying a string by a number produces the concatenation of
-          that string that many times. `"x" * 0` produces **null**.
+          that string that many times. `"x" * 0` produces `""`.
 
           Dividing a string by another splits the first using the second
           as separators.


### PR DESCRIPTION
Based on the discussion in #2142, we changed the behavior of `"x" * 0`. So I fixed the manual.