### PR TITLE
Fix empty regular expression matches (fix #2565)

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1002,7 +1002,7 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
             jv_string((char*)ebuf)));
       break;
     }
-  } while (global && start != end);
+  } while (global && start <= end);
   onig_region_free(region,1);
   region = NULL;
   if (region)

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -1,11 +1,15 @@
 # match builtin
 [match("( )*"; "g")]
 "abc"
-[{"offset":0, "length":0, "string":"", "captures":[]},{"offset":1, "length":0, "string":"", "captures":[]},{"offset":2, "length":0, "string":"", "captures":[]}]
+[{"offset":0, "length":0, "string":"", "captures":[]}, {"offset":1, "length":0, "string":"", "captures":[]}, {"offset":2, "length":0, "string":"", "captures":[]}, {"offset":3, "length":0, "string":"", "captures":[]}]
 
 [match("( )*"; "gn")]
 "abc"
 []
+
+[match(""; "g")]
+"ab"
+[{"offset":0,"length":0,"string":"","captures":[]},{"offset":1,"length":0,"string":"","captures":[]},{"offset":2,"length":0,"string":"","captures":[]}]
 
 [match("a"; "gi")]
 "āáàä"
@@ -71,29 +75,27 @@ gsub("a";"b")
 "aaaaa"
 "bbbbb"
 
-gsub( "(.*)"; "";  "x")
+gsub("(.*)"; ""; "x")
 ""
 ""
 
-gsub( ""; "a";  "g")
+gsub(""; "a"; "g")
 ""
 "a"
 
-gsub( "^"; "";  "g")
+gsub("^"; ""; "g")
 "a"
 "a"
 
+gsub(""; "a"; "g")
+"a"
+"aaa"
 
-# The following is a regression test and should not be construed as a requirement other than that execution should terminate:
-gsub( ""; "a";  "g")
+gsub("$"; "a"; "g")
 "a"
 "aa"
 
-gsub( "$"; "a";  "g")
-"a"
-"aa"
-
-gsub( "^"; "a")
+gsub("^"; "a")
 ""
 "a"
 
@@ -163,5 +165,5 @@ sub("(?<x>.)"; "\(.x)!")
 # splits and _nwise
 [splits("")]
 "ab"
-["","a","b"]
+["","a","b",""]
 


### PR DESCRIPTION
As reported by #2565, `"ab" | match(""; "g")` should yield 3 matches at offset 0, 1, and 2. Fixing this behavior also fixes `"a" | gsub(""; "a")` to emit `"aaa"` not `"aa"`. Fixes #2565.