### PR TITLE
Lex $foo as a single token, instead of using '$' IDENT

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -281,7 +281,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -446,7 +445,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -523,7 +522,7 @@ static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner 
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -570,12 +569,12 @@ static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-#define YY_NUM_RULES 50
-#define YY_END_OF_BUFFER 51
+#define YY_NUM_RULES 51
+#define YY_END_OF_BUFFER 52
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -583,25 +582,26 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[158] =
+static const flex_int16_t yy_accept[163] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,   51,   49,   48,   48,   49,   40,    1,   35,
-       35,   36,   37,   35,   35,   35,   35,   35,   39,   35,
-       35,   35,   35,   49,   46,   46,   46,   46,   46,   46,
+        0,    0,   52,   50,   49,   49,   50,   40,    1,   35,
+       35,   36,   37,   35,   35,   35,   35,   35,   35,   39,
+       35,   35,   35,   35,   50,   46,   46,   46,   46,   46,
        46,   46,   46,   46,   46,   46,   46,   46,   35,   44,
-       44,   42,   45,   48,    2,    1,   29,   27,   25,   26,
-       33,   39,   47,   18,   28,   39,   39,    0,   31,    3,
-       32,    0,   38,   46,    0,   46,   46,    4,   46,   46,
-       46,   46,   46,   46,    9,   46,   46,   46,   46,   14,
-       46,   46,   46,   24,   44,   43,   41,   43,   47,   30,
+       44,   42,   45,   49,    2,    1,   48,   48,   29,   27,
+       25,   26,   33,   39,   47,   18,   28,   39,   39,    0,
+       31,    3,   32,    0,   38,   46,    0,   46,    4,   46,
+       46,   46,   46,   46,   46,    9,   46,   46,   46,   46,
+       14,   46,   46,   46,   24,   44,   43,   41,   43,   48,
 
-       39,    0,   39,   34,    0,   46,   13,   46,   46,    8,
-       46,   46,   15,   46,   46,   46,   46,   46,   46,   46,
-       19,    0,   43,   46,   46,   46,   46,   12,   11,   46,
-       46,   46,   46,   46,   46,   10,   43,   46,   22,   20,
-       46,   46,   46,   21,   46,   46,   43,   46,   46,    5,
-       46,    7,   16,   23,   17,    6,    0
+        0,   48,   47,   30,   39,    0,   39,   34,    0,   13,
+       46,   46,    8,   46,   46,   15,   46,   46,   46,   46,
+       46,   46,   46,   19,    0,   43,    0,   48,   46,   46,
+       46,   12,   11,   46,   46,   46,   46,   46,   46,   10,
+       43,   48,   22,   20,   46,   46,   46,   21,   46,   46,
+       43,   48,   46,    5,   46,    7,   16,   48,   17,    6,
+       23,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -646,96 +646,99 @@ static const YY_CHAR yy_meta[54] =
         1,    1,    1
     } ;
 
-static const flex_int16_t yy_base[171] =
+static const flex_int16_t yy_base[178] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-       51,   52,  319,  320,   57,   59,  296,  320,    0,  320,
-      295,  320,  320,  294,  293,  292,   47,   47,   50,  291,
-      290,  289,  293,    0,  290,   48,   51,   37,   52,   53,
-       54,   55,   59,   56,   63,   57,   68,   71,  286,    0,
-        0,  320,   75,   89,  320,    0,  320,  320,  320,  320,
-      320,   87,    0,  285,  320,   92,   95,  103,  320,  320,
-      320,  289,    0,  286,  285,   74,  101,  284,   89,   81,
-       93,   87,  108,  113,  283,  116,  114,  118,  119,  282,
-      120,  121,  122,  320,    0,  271,  320,  270,    0,  320,
+       51,   52,  329,  330,   57,   59,  306,  330,    0,  296,
+      304,  330,  330,  303,  302,  330,  301,   47,   47,   50,
+      300,  299,  298,  302,    0,  299,   48,   37,   52,   51,
+       53,   54,   60,   56,   55,   59,   57,   63,  295,    0,
+        0,  330,   75,   87,  330,    0,  297,   73,  330,  330,
+      330,  330,  330,   89,    0,  293,  330,   90,   94,  100,
+      330,  330,  330,  297,    0,  294,  291,   87,  287,   92,
+       81,   95,  100,  101,  104,  283,  108,  112,  115,  114,
+      280,  116,  118,  119,  330,    0,  266,  330,  263,  271,
 
-      126,  280,  279,  320,    0,  123,  277,  126,  130,  274,
-      128,  127,  270,  133,  131,  137,  141,  147,  149,  151,
-      266,  161,  253,  259,  154,  155,  161,  256,  254,  157,
-      160,  162,  163,  164,  166,  242,  227,  171,  233,  228,
-      167,  165,  168,  226,  172,  173,  213,  188,  174,  221,
-      178,  211,  199,  198,  197,  196,  320,  219,  228,  234,
-      239,  244,  253,  262,  267,  272,  274,  279,  283,  287
+      268,  121,    0,  330,  125,  255,  250,  330,    0,  245,
+      123,  122,  240,  126,  138,  238,  139,  140,  125,  141,
+      145,  146,  148,  235,  158,  223,    0,  152,  229,  153,
+      151,  220,  208,  154,  157,  159,  160,  161,  163,  207,
+      196,  164,  204,  203,  166,  162,  169,  202,  173,  180,
+      191,  186,  168,  200,  192,  199,  196,  193,  195,  194,
+      171,  330,  228,  237,  240,  246,  251,  256,  265,  274,
+      279,  284,  289,  291,  296,  300,  304
     } ;
 
-static const flex_int16_t yy_def[171] =
+static const flex_int16_t yy_def[178] =
     {   0,
-      157,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-      158,  158,  157,  157,  157,  157,  157,  157,  159,  157,
-      157,  157,  157,  157,  157,  157,  160,  157,  157,  157,
-      157,  157,  157,  161,  162,  162,  162,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,  162,  162,  157,  163,
-      163,  157,  164,  157,  157,  159,  157,  157,  157,  157,
-      157,  157,  165,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  161,  162,  157,  162,  162,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
-      162,  162,  162,  157,  163,  157,  157,  166,  165,  157,
+      162,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+      163,  163,  162,  162,  162,  162,  162,  162,  164,  165,
+      162,  162,  162,  162,  162,  162,  162,  166,  162,  162,
+      162,  162,  162,  162,  167,  168,  168,  168,  168,  168,
+      168,  168,  168,  168,  168,  168,  168,  168,  162,  169,
+      169,  162,  170,  162,  162,  164,  171,  171,  162,  162,
+      162,  162,  162,  162,  172,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  167,  168,  162,  168,  168,  168,
+      168,  168,  168,  168,  168,  168,  168,  168,  168,  168,
+      168,  168,  168,  168,  162,  169,  162,  162,  173,  171,
 
-      157,  157,  157,  157,  167,  162,  162,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
-      162,  164,  168,  162,  162,  162,  162,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,  169,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,  170,  162,  162,  162,
-      162,  162,  162,  162,  162,  162,    0,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157
+      162,  171,  172,  162,  162,  162,  162,  162,  174,  168,
+      168,  168,  168,  168,  168,  168,  168,  168,  168,  168,
+      168,  168,  168,  168,  170,  175,  165,  171,  168,  168,
+      168,  168,  168,  168,  168,  168,  168,  168,  168,  168,
+      176,  171,  168,  168,  168,  168,  168,  168,  168,  168,
+      177,  171,  168,  168,  168,  168,  168,  171,  168,  168,
+      171,    0,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162
     } ;
 
-static const flex_int16_t yy_nxt[374] =
+static const flex_int16_t yy_nxt[384] =
     {   0,
        14,   15,   16,   14,   17,   18,   19,   20,   21,   22,
-       23,   24,   25,   20,   26,   27,   28,   29,   20,   20,
-       30,   31,   32,   33,   34,   35,   35,   22,   14,   23,
-       36,   37,   38,   39,   40,   41,   42,   35,   43,   35,
-       44,   45,   35,   46,   35,   47,   35,   48,   35,   35,
-       22,   49,   23,   51,   51,   75,   52,   52,   54,   54,
-       54,   54,   61,   64,   62,   66,   75,   67,   65,   75,
-       75,   75,   75,   75,   75,   75,   68,   75,   76,   53,
-       53,   75,   79,   80,   97,   68,   75,   88,   81,   75,
-       54,   54,   75,   77,   82,   85,   83,   78,   84,   75,
+       23,   24,   25,   26,   27,   28,   29,   30,   26,   26,
+       31,   32,   33,   34,   35,   36,   36,   22,   14,   23,
+       36,   37,   38,   39,   40,   41,   42,   36,   43,   36,
+       44,   45,   36,   46,   36,   47,   36,   48,   36,   36,
+       22,   49,   23,   51,   51,   77,   52,   52,   54,   54,
+       54,   54,   63,   66,   64,   68,   77,   69,   67,   77,
+       77,   77,   77,   77,   77,   77,   70,   77,   77,   53,
+       53,   77,   80,   81,   98,   70,   82,   89,   54,   54,
+       78,  101,   92,   83,   79,   84,   86,   85,   90,   77,
 
-       86,   87,   90,   91,   62,   75,   89,   75,   92,  101,
-       66,   75,   67,   68,  106,  102,   93,  102,   68,   75,
-      103,   68,   68,   98,  108,  111,   75,   68,  109,  110,
-       68,   75,   75,  112,   75,  107,   75,   75,   75,   75,
-       75,   75,  113,  101,   75,   75,   75,  116,   75,   75,
-      117,   75,   68,  118,  119,   75,  120,  126,  114,   75,
-      115,   68,  129,  127,  128,   75,  125,   75,  130,   75,
-      157,  121,   75,   75,  131,   75,  133,  132,   75,   75,
-       75,   75,   75,   75,   75,   75,   75,  138,  141,   75,
-       75,   75,   75,  136,  139,  134,   75,  135,  140,  146,
+       93,   87,   88,  102,   91,   77,   64,  105,   94,   68,
+       77,   69,  106,   77,  106,   70,   70,  107,   77,   77,
+       70,  110,   77,   99,   70,   70,   77,  111,  112,   70,
+       77,  113,   77,   77,   77,  116,   77,   77,  114,  101,
+       77,   77,  105,   77,   77,  119,  115,  120,  121,  117,
+      122,   70,  118,  123,  130,  131,   77,   77,   77,   77,
+       70,  128,  132,   77,   77,  136,   77,  162,  124,   77,
+      101,   77,   77,  133,  134,   77,  137,   77,   77,   77,
+       77,   77,  101,  135,   77,  145,   77,   77,  144,  101,
+      140,   77,  143,  138,  139,  142,  150,  152,   77,  153,
 
-      149,  148,  151,  144,  145,  142,   75,  152,  153,   98,
-      143,  155,  150,  156,   75,   75,   75,   75,  154,   50,
-       50,   50,   50,   50,   50,   50,   50,   50,   56,   75,
-       56,   56,   56,   56,   56,   56,   56,   63,   63,   75,
-       63,  122,   63,   73,   75,   73,   75,   73,   74,   74,
-       74,   75,   74,   95,   95,  122,   95,   95,   95,   95,
-       75,   95,   96,   96,   96,   96,   96,   96,   96,   96,
-       96,   99,   75,   99,   75,   99,  123,   75,  123,  123,
-      124,  122,  124,  137,   75,  137,  137,  147,   75,  147,
-      147,   96,   75,   96,   96,   75,  103,  103,  122,  122,
+      148,  149,  146,  155,  101,  159,   99,  147,  156,  154,
+       77,  101,   77,   77,   77,  157,  158,   77,   77,  125,
+       77,   77,   77,  161,  125,   77,   77,  160,   50,   50,
+       50,   50,   50,   50,   50,   50,   50,   56,   77,   56,
+       56,   56,   56,   56,   56,   56,   57,   77,   57,   65,
+       65,  125,   65,   77,   65,   75,   77,   75,   77,   75,
+       76,   76,   76,   77,   76,   96,   96,  107,   96,   96,
+       96,   96,  107,   96,   97,   97,   97,   97,   97,   97,
+       97,   97,   97,  100,  100,  100,  127,  100,  103,  101,
+      103,  125,  103,  126,  125,  126,  126,  129,   77,  129,
 
-       75,   75,   75,  105,   75,  104,  100,   94,   75,   72,
-       71,   70,   69,   60,   59,   58,   57,   55,  157,   13,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157
+      141,   77,  141,  141,  151,   77,  151,  151,   97,  109,
+       97,   97,   77,  108,  104,  101,   95,   77,   74,   73,
+       72,   71,   62,   61,   60,   59,   58,   55,  162,   13,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162
     } ;
 
-static const flex_int16_t yy_chk[374] =
+static const flex_int16_t yy_chk[384] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -743,41 +746,42 @@ static const flex_int16_t yy_chk[374] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,   11,   12,   38,   11,   12,   15,   15,
-       16,   16,   27,   28,   27,   29,   36,   29,   28,   37,
-       39,   40,   41,   42,   44,   46,   29,   43,   36,   11,
-       12,   45,   38,   39,   53,   29,   47,   44,   40,   48,
-       54,   54,   76,   37,   41,   43,   41,   37,   42,   80,
+       16,   16,   28,   29,   28,   30,   37,   30,   29,   40,
+       39,   41,   42,   45,   44,   47,   30,   46,   43,   11,
+       12,   48,   38,   39,   53,   30,   40,   44,   54,   54,
+       37,   58,   47,   41,   37,   41,   43,   42,   45,   81,
 
-       43,   43,   46,   47,   62,   82,   45,   79,   48,   66,
-       67,   81,   67,   62,   76,   68,   48,   68,   66,   77,
-       68,   67,   62,   53,   79,   82,   83,   66,   80,   81,
-       67,   84,   87,   82,   86,   77,   88,   89,   91,   92,
-       93,  106,   83,  101,  108,  112,  111,   87,  109,  115,
-       88,  114,  101,   89,   91,  116,   92,  108,   84,  117,
-       86,  101,  112,  109,  111,  118,  106,  119,  114,  120,
-      122,   93,  125,  126,  115,  130,  117,  116,  131,  127,
-      132,  133,  134,  142,  135,  141,  143,  125,  130,  138,
-      145,  146,  149,  120,  126,  118,  151,  119,  127,  135,
+       48,   43,   43,   58,   46,   78,   64,   68,   48,   69,
+       80,   69,   70,   82,   70,   64,   68,   70,   83,   84,
+       69,   78,   85,   53,   64,   68,   87,   80,   81,   69,
+       88,   82,   90,   89,   92,   84,   93,   94,   83,  102,
+      112,  111,  105,  119,  114,   88,   83,   89,   90,   85,
+       92,  105,   87,   93,  111,  112,  115,  117,  118,  120,
+      105,  102,  114,  121,  122,  119,  123,  125,   94,  131,
+      128,  130,  134,  115,  117,  135,  120,  136,  137,  138,
+      146,  139,  142,  118,  145,  134,  153,  147,  131,  161,
+      123,  149,  130,  121,  122,  128,  139,  142,  150,  145,
 
-      141,  138,  143,  133,  134,  131,  148,  145,  146,  122,
-      132,  149,  142,  151,  156,  155,  154,  153,  148,  158,
-      158,  158,  158,  158,  158,  158,  158,  158,  159,  152,
-      159,  159,  159,  159,  159,  159,  159,  160,  160,  150,
-      160,  147,  160,  161,  144,  161,  140,  161,  162,  162,
-      162,  139,  162,  163,  163,  137,  163,  163,  163,  163,
-      136,  163,  164,  164,  164,  164,  164,  164,  164,  164,
-      164,  165,  129,  165,  128,  165,  166,  124,  166,  166,
-      167,  123,  167,  168,  121,  168,  168,  169,  113,  169,
-      169,  170,  110,  170,  170,  107,  103,  102,   98,   96,
+      137,  138,  135,  147,  152,  153,  125,  136,  149,  146,
+      155,  158,  160,  159,  157,  150,  152,  156,  154,  151,
+      148,  144,  143,  158,  141,  140,  133,  155,  163,  163,
+      163,  163,  163,  163,  163,  163,  163,  164,  132,  164,
+      164,  164,  164,  164,  164,  164,  165,  129,  165,  166,
+      166,  126,  166,  124,  166,  167,  116,  167,  113,  167,
+      168,  168,  168,  110,  168,  169,  169,  107,  169,  169,
+      169,  169,  106,  169,  170,  170,  170,  170,  170,  170,
+      170,  170,  170,  171,  171,  171,  101,  171,  172,  100,
+      172,   99,  172,  173,   97,  173,  173,  174,   91,  174,
 
-       90,   85,   78,   75,   74,   72,   64,   49,   35,   33,
-       32,   31,   30,   26,   25,   24,   21,   17,   13,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157,  157,  157,  157,  157,  157,  157,  157,
-      157,  157,  157
+      175,   86,  175,  175,  176,   79,  176,  176,  177,   77,
+      177,  177,   76,   74,   66,   57,   49,   36,   34,   33,
+       32,   31,   27,   25,   24,   21,   20,   17,   13,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162,  162,  162,  162,  162,  162,  162,  162,
+      162,  162,  162
     } ;
 
 /* The intent behind this definition is that it'll catch
@@ -804,14 +808,14 @@ struct lexer_param;
     yyset_extra(yylloc->end, yyscanner);         \
   } while (0);
 
-#line 807 "src/lexer.c"
+#line 811 "src/lexer.c"
 
 #line 25 "src/lexer.l"
   static int enter(int opening, int state, yyscan_t yyscanner);
   static int try_exit(int closing, int state, yyscan_t yyscanner);
-#line 812 "src/lexer.c"
+#line 816 "src/lexer.c"
 #define YY_NO_INPUT 1
-#line 814 "src/lexer.c"
+#line 818 "src/lexer.c"
 
 #define INITIAL 0
 #define IN_PAREN 1
@@ -843,8 +847,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    yy_size_t yy_n_chars;
-    yy_size_t yyleng_r;
+    int yy_n_chars;
+    int yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -901,7 +905,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -986,7 +990,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1105,7 +1109,7 @@ YY_DECL
 #line 38 "src/lexer.l"
 
 
-#line 1108 "src/lexer.c"
+#line 1112 "src/lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1132,13 +1136,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 158 )
+				if ( yy_current_state >= 163 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 320 );
+		while ( yy_base[yy_current_state] != 330 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1429,22 +1433,27 @@ YY_RULE_SETUP
 { yylval->literal = jv_string(yytext+1); return FIELD;}
 	YY_BREAK
 case 48:
-/* rule 48 can match eol */
 YY_RULE_SETUP
-#line 126 "src/lexer.l"
-{}
+#line 125 "src/lexer.l"
+{ yylval->literal = jv_string(yytext+1); return BINDING;}
 	YY_BREAK
 case 49:
+/* rule 49 can match eol */
 YY_RULE_SETUP
-#line 128 "src/lexer.l"
-{ return INVALID_CHARACTER; }
+#line 127 "src/lexer.l"
+{}
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 130 "src/lexer.l"
+#line 129 "src/lexer.l"
+{ return INVALID_CHARACTER; }
+	YY_BREAK
+case 51:
+YY_RULE_SETUP
+#line 131 "src/lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1447 "src/lexer.c"
+#line 1456 "src/lexer.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(IN_PAREN):
 case YY_STATE_EOF(IN_BRACKET):
@@ -1637,7 +1646,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1651,7 +1660,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1709,7 +1718,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
 			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1748,7 +1757,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 158 )
+			if ( yy_current_state >= 163 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1777,11 +1786,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 158 )
+		if ( yy_current_state >= 163 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 157);
+	yy_is_jam = (yy_current_state == 162);
 
 	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
@@ -1816,7 +1825,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
+			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2194,12 +2203,12 @@ YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
 	n = (yy_size_t) (_yybytes_len + 2);
@@ -2284,7 +2293,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        yy_size_t yyless_macro_arg = (n); \
+        int yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = yyg->yy_hold_char; \
 		yyg->yy_c_buf_p = yytext + yyless_macro_arg; \
@@ -2352,7 +2361,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -2616,7 +2625,7 @@ static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 
 #define YYTABLES_NAME "yytables"
 
-#line 130 "src/lexer.l"
+#line 131 "src/lexer.l"
 
 /* perhaps these should be calls... */
 /*

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -285,7 +285,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -399,7 +398,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -443,7 +442,7 @@ void yypop_buffer_state ( yyscan_t yyscanner );
 
 YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
 YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, yy_size_t len , yyscan_t yyscanner );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
 
 void *yyalloc ( yy_size_t , yyscan_t yyscanner );
 void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
@@ -501,7 +500,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -732,9 +731,9 @@ extern int yylex \
 #undef yyTABLES_NAME
 #endif
 
-#line 130 "src/lexer.l"
+#line 131 "src/lexer.l"
 
 
-#line 738 "src/lexer.h"
+#line 737 "src/lexer.h"
 #undef jq_yyIN_HEADER
 #endif /* jq_yyHEADER_H */

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -60,7 +60,7 @@ struct lexer_param;
 "catch" { return CATCH; }
 "label" { return LABEL; }
 "break" { return BREAK; }
-"__loc__" { return LOC; }
+"$__loc__" { return LOC; }
 "|=" { return SETPIPE; }
 "+=" { return SETPLUS; }
 "-=" { return SETMINUS; }
@@ -122,6 +122,7 @@ struct lexer_param;
 
 ([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*  { yylval->literal = jv_string(yytext); return IDENT;}
 \.[a-zA-Z_][a-zA-Z_0-9]*  { yylval->literal = jv_string(yytext+1); return FIELD;}
+\$([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*  { yylval->literal = jv_string(yytext+1); return BINDING;}
 
 [ \n\t]+  {}
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -144,48 +144,49 @@ struct lexer_param;
     INVALID_CHARACTER = 258,       /* INVALID_CHARACTER  */
     IDENT = 259,                   /* IDENT  */
     FIELD = 260,                   /* FIELD  */
-    LITERAL = 261,                 /* LITERAL  */
-    FORMAT = 262,                  /* FORMAT  */
-    REC = 263,                     /* ".."  */
-    SETMOD = 264,                  /* "%="  */
-    EQ = 265,                      /* "=="  */
-    NEQ = 266,                     /* "!="  */
-    DEFINEDOR = 267,               /* "//"  */
-    AS = 268,                      /* "as"  */
-    DEF = 269,                     /* "def"  */
-    MODULE = 270,                  /* "module"  */
-    IMPORT = 271,                  /* "import"  */
-    INCLUDE = 272,                 /* "include"  */
-    IF = 273,                      /* "if"  */
-    THEN = 274,                    /* "then"  */
-    ELSE = 275,                    /* "else"  */
-    ELSE_IF = 276,                 /* "elif"  */
-    REDUCE = 277,                  /* "reduce"  */
-    FOREACH = 278,                 /* "foreach"  */
-    END = 279,                     /* "end"  */
-    AND = 280,                     /* "and"  */
-    OR = 281,                      /* "or"  */
-    TRY = 282,                     /* "try"  */
-    CATCH = 283,                   /* "catch"  */
-    LABEL = 284,                   /* "label"  */
-    BREAK = 285,                   /* "break"  */
-    LOC = 286,                     /* "__loc__"  */
-    SETPIPE = 287,                 /* "|="  */
-    SETPLUS = 288,                 /* "+="  */
-    SETMINUS = 289,                /* "-="  */
-    SETMULT = 290,                 /* "*="  */
-    SETDIV = 291,                  /* "/="  */
-    SETDEFINEDOR = 292,            /* "//="  */
-    LESSEQ = 293,                  /* "<="  */
-    GREATEREQ = 294,               /* ">="  */
-    ALTERNATION = 295,             /* "?//"  */
-    QQSTRING_START = 296,          /* QQSTRING_START  */
-    QQSTRING_TEXT = 297,           /* QQSTRING_TEXT  */
-    QQSTRING_INTERP_START = 298,   /* QQSTRING_INTERP_START  */
-    QQSTRING_INTERP_END = 299,     /* QQSTRING_INTERP_END  */
-    QQSTRING_END = 300,            /* QQSTRING_END  */
-    FUNCDEF = 301,                 /* FUNCDEF  */
-    NONOPT = 302                   /* NONOPT  */
+    BINDING = 261,                 /* BINDING  */
+    LITERAL = 262,                 /* LITERAL  */
+    FORMAT = 263,                  /* FORMAT  */
+    REC = 264,                     /* ".."  */
+    SETMOD = 265,                  /* "%="  */
+    EQ = 266,                      /* "=="  */
+    NEQ = 267,                     /* "!="  */
+    DEFINEDOR = 268,               /* "//"  */
+    AS = 269,                      /* "as"  */
+    DEF = 270,                     /* "def"  */
+    MODULE = 271,                  /* "module"  */
+    IMPORT = 272,                  /* "import"  */
+    INCLUDE = 273,                 /* "include"  */
+    IF = 274,                      /* "if"  */
+    THEN = 275,                    /* "then"  */
+    ELSE = 276,                    /* "else"  */
+    ELSE_IF = 277,                 /* "elif"  */
+    REDUCE = 278,                  /* "reduce"  */
+    FOREACH = 279,                 /* "foreach"  */
+    END = 280,                     /* "end"  */
+    AND = 281,                     /* "and"  */
+    OR = 282,                      /* "or"  */
+    TRY = 283,                     /* "try"  */
+    CATCH = 284,                   /* "catch"  */
+    LABEL = 285,                   /* "label"  */
+    BREAK = 286,                   /* "break"  */
+    LOC = 287,                     /* "$__loc__"  */
+    SETPIPE = 288,                 /* "|="  */
+    SETPLUS = 289,                 /* "+="  */
+    SETMINUS = 290,                /* "-="  */
+    SETMULT = 291,                 /* "*="  */
+    SETDIV = 292,                  /* "/="  */
+    SETDEFINEDOR = 293,            /* "//="  */
+    LESSEQ = 294,                  /* "<="  */
+    GREATEREQ = 295,               /* ">="  */
+    ALTERNATION = 296,             /* "?//"  */
+    QQSTRING_START = 297,          /* QQSTRING_START  */
+    QQSTRING_TEXT = 298,           /* QQSTRING_TEXT  */
+    QQSTRING_INTERP_START = 299,   /* QQSTRING_INTERP_START  */
+    QQSTRING_INTERP_END = 300,     /* QQSTRING_INTERP_END  */
+    QQSTRING_END = 301,            /* QQSTRING_END  */
+    FUNCDEF = 302,                 /* FUNCDEF  */
+    NONOPT = 303                   /* NONOPT  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -197,48 +198,49 @@ struct lexer_param;
 #define INVALID_CHARACTER 258
 #define IDENT 259
 #define FIELD 260
-#define LITERAL 261
-#define FORMAT 262
-#define REC 263
-#define SETMOD 264
-#define EQ 265
-#define NEQ 266
-#define DEFINEDOR 267
-#define AS 268
-#define DEF 269
-#define MODULE 270
-#define IMPORT 271
-#define INCLUDE 272
-#define IF 273
-#define THEN 274
-#define ELSE 275
-#define ELSE_IF 276
-#define REDUCE 277
-#define FOREACH 278
-#define END 279
-#define AND 280
-#define OR 281
-#define TRY 282
-#define CATCH 283
-#define LABEL 284
-#define BREAK 285
-#define LOC 286
-#define SETPIPE 287
-#define SETPLUS 288
-#define SETMINUS 289
-#define SETMULT 290
-#define SETDIV 291
-#define SETDEFINEDOR 292
-#define LESSEQ 293
-#define GREATEREQ 294
-#define ALTERNATION 295
-#define QQSTRING_START 296
-#define QQSTRING_TEXT 297
-#define QQSTRING_INTERP_START 298
-#define QQSTRING_INTERP_END 299
-#define QQSTRING_END 300
-#define FUNCDEF 301
-#define NONOPT 302
+#define BINDING 261
+#define LITERAL 262
+#define FORMAT 263
+#define REC 264
+#define SETMOD 265
+#define EQ 266
+#define NEQ 267
+#define DEFINEDOR 268
+#define AS 269
+#define DEF 270
+#define MODULE 271
+#define IMPORT 272
+#define INCLUDE 273
+#define IF 274
+#define THEN 275
+#define ELSE 276
+#define ELSE_IF 277
+#define REDUCE 278
+#define FOREACH 279
+#define END 280
+#define AND 281
+#define OR 282
+#define TRY 283
+#define CATCH 284
+#define LABEL 285
+#define BREAK 286
+#define LOC 287
+#define SETPIPE 288
+#define SETPLUS 289
+#define SETMINUS 290
+#define SETMULT 291
+#define SETDIV 292
+#define SETDEFINEDOR 293
+#define LESSEQ 294
+#define GREATEREQ 295
+#define ALTERNATION 296
+#define QQSTRING_START 297
+#define QQSTRING_TEXT 298
+#define QQSTRING_INTERP_START 299
+#define QQSTRING_INTERP_END 300
+#define QQSTRING_END 301
+#define FUNCDEF 302
+#define NONOPT 303
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
@@ -249,7 +251,7 @@ union YYSTYPE
   jv literal;
   block blk;
 
-#line 253 "src/parser.c"
+#line 255 "src/parser.c"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -288,105 +290,106 @@ enum yysymbol_kind_t
   YYSYMBOL_INVALID_CHARACTER = 3,          /* INVALID_CHARACTER  */
   YYSYMBOL_IDENT = 4,                      /* IDENT  */
   YYSYMBOL_FIELD = 5,                      /* FIELD  */
-  YYSYMBOL_LITERAL = 6,                    /* LITERAL  */
-  YYSYMBOL_FORMAT = 7,                     /* FORMAT  */
-  YYSYMBOL_REC = 8,                        /* ".."  */
-  YYSYMBOL_SETMOD = 9,                     /* "%="  */
-  YYSYMBOL_EQ = 10,                        /* "=="  */
-  YYSYMBOL_NEQ = 11,                       /* "!="  */
-  YYSYMBOL_DEFINEDOR = 12,                 /* "//"  */
-  YYSYMBOL_AS = 13,                        /* "as"  */
-  YYSYMBOL_DEF = 14,                       /* "def"  */
-  YYSYMBOL_MODULE = 15,                    /* "module"  */
-  YYSYMBOL_IMPORT = 16,                    /* "import"  */
-  YYSYMBOL_INCLUDE = 17,                   /* "include"  */
-  YYSYMBOL_IF = 18,                        /* "if"  */
-  YYSYMBOL_THEN = 19,                      /* "then"  */
-  YYSYMBOL_ELSE = 20,                      /* "else"  */
-  YYSYMBOL_ELSE_IF = 21,                   /* "elif"  */
-  YYSYMBOL_REDUCE = 22,                    /* "reduce"  */
-  YYSYMBOL_FOREACH = 23,                   /* "foreach"  */
-  YYSYMBOL_END = 24,                       /* "end"  */
-  YYSYMBOL_AND = 25,                       /* "and"  */
-  YYSYMBOL_OR = 26,                        /* "or"  */
-  YYSYMBOL_TRY = 27,                       /* "try"  */
-  YYSYMBOL_CATCH = 28,                     /* "catch"  */
-  YYSYMBOL_LABEL = 29,                     /* "label"  */
-  YYSYMBOL_BREAK = 30,                     /* "break"  */
-  YYSYMBOL_LOC = 31,                       /* "__loc__"  */
-  YYSYMBOL_SETPIPE = 32,                   /* "|="  */
-  YYSYMBOL_SETPLUS = 33,                   /* "+="  */
-  YYSYMBOL_SETMINUS = 34,                  /* "-="  */
-  YYSYMBOL_SETMULT = 35,                   /* "*="  */
-  YYSYMBOL_SETDIV = 36,                    /* "/="  */
-  YYSYMBOL_SETDEFINEDOR = 37,              /* "//="  */
-  YYSYMBOL_LESSEQ = 38,                    /* "<="  */
-  YYSYMBOL_GREATEREQ = 39,                 /* ">="  */
-  YYSYMBOL_ALTERNATION = 40,               /* "?//"  */
-  YYSYMBOL_QQSTRING_START = 41,            /* QQSTRING_START  */
-  YYSYMBOL_QQSTRING_TEXT = 42,             /* QQSTRING_TEXT  */
-  YYSYMBOL_QQSTRING_INTERP_START = 43,     /* QQSTRING_INTERP_START  */
-  YYSYMBOL_QQSTRING_INTERP_END = 44,       /* QQSTRING_INTERP_END  */
-  YYSYMBOL_QQSTRING_END = 45,              /* QQSTRING_END  */
-  YYSYMBOL_FUNCDEF = 46,                   /* FUNCDEF  */
-  YYSYMBOL_47_ = 47,                       /* '|'  */
-  YYSYMBOL_48_ = 48,                       /* ','  */
-  YYSYMBOL_49_ = 49,                       /* '='  */
-  YYSYMBOL_50_ = 50,                       /* '<'  */
-  YYSYMBOL_51_ = 51,                       /* '>'  */
-  YYSYMBOL_52_ = 52,                       /* '+'  */
-  YYSYMBOL_53_ = 53,                       /* '-'  */
-  YYSYMBOL_54_ = 54,                       /* '*'  */
-  YYSYMBOL_55_ = 55,                       /* '/'  */
-  YYSYMBOL_56_ = 56,                       /* '%'  */
-  YYSYMBOL_NONOPT = 57,                    /* NONOPT  */
-  YYSYMBOL_58_ = 58,                       /* '?'  */
-  YYSYMBOL_59_ = 59,                       /* ';'  */
-  YYSYMBOL_60_ = 60,                       /* '('  */
-  YYSYMBOL_61_ = 61,                       /* ')'  */
-  YYSYMBOL_62_ = 62,                       /* '$'  */
+  YYSYMBOL_BINDING = 6,                    /* BINDING  */
+  YYSYMBOL_LITERAL = 7,                    /* LITERAL  */
+  YYSYMBOL_FORMAT = 8,                     /* FORMAT  */
+  YYSYMBOL_REC = 9,                        /* ".."  */
+  YYSYMBOL_SETMOD = 10,                    /* "%="  */
+  YYSYMBOL_EQ = 11,                        /* "=="  */
+  YYSYMBOL_NEQ = 12,                       /* "!="  */
+  YYSYMBOL_DEFINEDOR = 13,                 /* "//"  */
+  YYSYMBOL_AS = 14,                        /* "as"  */
+  YYSYMBOL_DEF = 15,                       /* "def"  */
+  YYSYMBOL_MODULE = 16,                    /* "module"  */
+  YYSYMBOL_IMPORT = 17,                    /* "import"  */
+  YYSYMBOL_INCLUDE = 18,                   /* "include"  */
+  YYSYMBOL_IF = 19,                        /* "if"  */
+  YYSYMBOL_THEN = 20,                      /* "then"  */
+  YYSYMBOL_ELSE = 21,                      /* "else"  */
+  YYSYMBOL_ELSE_IF = 22,                   /* "elif"  */
+  YYSYMBOL_REDUCE = 23,                    /* "reduce"  */
+  YYSYMBOL_FOREACH = 24,                   /* "foreach"  */
+  YYSYMBOL_END = 25,                       /* "end"  */
+  YYSYMBOL_AND = 26,                       /* "and"  */
+  YYSYMBOL_OR = 27,                        /* "or"  */
+  YYSYMBOL_TRY = 28,                       /* "try"  */
+  YYSYMBOL_CATCH = 29,                     /* "catch"  */
+  YYSYMBOL_LABEL = 30,                     /* "label"  */
+  YYSYMBOL_BREAK = 31,                     /* "break"  */
+  YYSYMBOL_LOC = 32,                       /* "$__loc__"  */
+  YYSYMBOL_SETPIPE = 33,                   /* "|="  */
+  YYSYMBOL_SETPLUS = 34,                   /* "+="  */
+  YYSYMBOL_SETMINUS = 35,                  /* "-="  */
+  YYSYMBOL_SETMULT = 36,                   /* "*="  */
+  YYSYMBOL_SETDIV = 37,                    /* "/="  */
+  YYSYMBOL_SETDEFINEDOR = 38,              /* "//="  */
+  YYSYMBOL_LESSEQ = 39,                    /* "<="  */
+  YYSYMBOL_GREATEREQ = 40,                 /* ">="  */
+  YYSYMBOL_ALTERNATION = 41,               /* "?//"  */
+  YYSYMBOL_QQSTRING_START = 42,            /* QQSTRING_START  */
+  YYSYMBOL_QQSTRING_TEXT = 43,             /* QQSTRING_TEXT  */
+  YYSYMBOL_QQSTRING_INTERP_START = 44,     /* QQSTRING_INTERP_START  */
+  YYSYMBOL_QQSTRING_INTERP_END = 45,       /* QQSTRING_INTERP_END  */
+  YYSYMBOL_QQSTRING_END = 46,              /* QQSTRING_END  */
+  YYSYMBOL_FUNCDEF = 47,                   /* FUNCDEF  */
+  YYSYMBOL_48_ = 48,                       /* '|'  */
+  YYSYMBOL_49_ = 49,                       /* ','  */
+  YYSYMBOL_50_ = 50,                       /* '='  */
+  YYSYMBOL_51_ = 51,                       /* '<'  */
+  YYSYMBOL_52_ = 52,                       /* '>'  */
+  YYSYMBOL_53_ = 53,                       /* '+'  */
+  YYSYMBOL_54_ = 54,                       /* '-'  */
+  YYSYMBOL_55_ = 55,                       /* '*'  */
+  YYSYMBOL_56_ = 56,                       /* '/'  */
+  YYSYMBOL_57_ = 57,                       /* '%'  */
+  YYSYMBOL_NONOPT = 58,                    /* NONOPT  */
+  YYSYMBOL_59_ = 59,                       /* '?'  */
+  YYSYMBOL_60_ = 60,                       /* ';'  */
+  YYSYMBOL_61_ = 61,                       /* '('  */
+  YYSYMBOL_62_ = 62,                       /* ')'  */
   YYSYMBOL_63_ = 63,                       /* ':'  */
   YYSYMBOL_64_ = 64,                       /* '.'  */
   YYSYMBOL_65_ = 65,                       /* '['  */
   YYSYMBOL_66_ = 66,                       /* ']'  */
   YYSYMBOL_67_ = 67,                       /* '{'  */
   YYSYMBOL_68_ = 68,                       /* '}'  */
-  YYSYMBOL_YYACCEPT = 69,                  /* $accept  */
-  YYSYMBOL_TopLevel = 70,                  /* TopLevel  */
-  YYSYMBOL_Module = 71,                    /* Module  */
-  YYSYMBOL_Imports = 72,                   /* Imports  */
-  YYSYMBOL_FuncDefs = 73,                  /* FuncDefs  */
-  YYSYMBOL_Exp = 74,                       /* Exp  */
-  YYSYMBOL_Import = 75,                    /* Import  */
-  YYSYMBOL_ImportWhat = 76,                /* ImportWhat  */
-  YYSYMBOL_ImportFrom = 77,                /* ImportFrom  */
-  YYSYMBOL_FuncDef = 78,                   /* FuncDef  */
-  YYSYMBOL_Params = 79,                    /* Params  */
-  YYSYMBOL_Param = 80,                     /* Param  */
-  YYSYMBOL_String = 81,                    /* String  */
-  YYSYMBOL_82_1 = 82,                      /* @1  */
-  YYSYMBOL_83_2 = 83,                      /* @2  */
-  YYSYMBOL_QQString = 84,                  /* QQString  */
-  YYSYMBOL_ElseBody = 85,                  /* ElseBody  */
-  YYSYMBOL_ExpD = 86,                      /* ExpD  */
-  YYSYMBOL_Term = 87,                      /* Term  */
-  YYSYMBOL_Args = 88,                      /* Args  */
-  YYSYMBOL_Arg = 89,                       /* Arg  */
-  YYSYMBOL_RepPatterns = 90,               /* RepPatterns  */
-  YYSYMBOL_Patterns = 91,                  /* Patterns  */
-  YYSYMBOL_Pattern = 92,                   /* Pattern  */
-  YYSYMBOL_ArrayPats = 93,                 /* ArrayPats  */
-  YYSYMBOL_ObjPats = 94,                   /* ObjPats  */
-  YYSYMBOL_ObjPat = 95,                    /* ObjPat  */
-  YYSYMBOL_Keyword = 96,                   /* Keyword  */
-  YYSYMBOL_MkDict = 97,                    /* MkDict  */
-  YYSYMBOL_MkDictPair = 98                 /* MkDictPair  */
+  YYSYMBOL_69_ = 69,                       /* '$'  */
+  YYSYMBOL_YYACCEPT = 70,                  /* $accept  */
+  YYSYMBOL_TopLevel = 71,                  /* TopLevel  */
+  YYSYMBOL_Module = 72,                    /* Module  */
+  YYSYMBOL_Imports = 73,                   /* Imports  */
+  YYSYMBOL_FuncDefs = 74,                  /* FuncDefs  */
+  YYSYMBOL_Exp = 75,                       /* Exp  */
+  YYSYMBOL_Import = 76,                    /* Import  */
+  YYSYMBOL_ImportWhat = 77,                /* ImportWhat  */
+  YYSYMBOL_ImportFrom = 78,                /* ImportFrom  */
+  YYSYMBOL_FuncDef = 79,                   /* FuncDef  */
+  YYSYMBOL_Params = 80,                    /* Params  */
+  YYSYMBOL_Param = 81,                     /* Param  */
+  YYSYMBOL_String = 82,                    /* String  */
+  YYSYMBOL_83_1 = 83,                      /* @1  */
+  YYSYMBOL_84_2 = 84,                      /* @2  */
+  YYSYMBOL_QQString = 85,                  /* QQString  */
+  YYSYMBOL_ElseBody = 86,                  /* ElseBody  */
+  YYSYMBOL_ExpD = 87,                      /* ExpD  */
+  YYSYMBOL_Term = 88,                      /* Term  */
+  YYSYMBOL_Args = 89,                      /* Args  */
+  YYSYMBOL_Arg = 90,                       /* Arg  */
+  YYSYMBOL_RepPatterns = 91,               /* RepPatterns  */
+  YYSYMBOL_Patterns = 92,                  /* Patterns  */
+  YYSYMBOL_Pattern = 93,                   /* Pattern  */
+  YYSYMBOL_ArrayPats = 94,                 /* ArrayPats  */
+  YYSYMBOL_ObjPats = 95,                   /* ObjPats  */
+  YYSYMBOL_ObjPat = 96,                    /* ObjPat  */
+  YYSYMBOL_Keyword = 97,                   /* Keyword  */
+  YYSYMBOL_MkDict = 98,                    /* MkDict  */
+  YYSYMBOL_MkDictPair = 99                 /* MkDictPair  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
 /* Second part of user prologue.  */
-#line 124 "src/parser.y"
+#line 125 "src/parser.y"
 
 #include "lexer.h"
 struct lexer_param {
@@ -566,7 +569,7 @@ static block gen_update(block object, block val, int optype) {
 }
 
 
-#line 570 "src/parser.c"
+#line 573 "src/parser.c"
 
 
 #ifdef short
@@ -891,21 +894,21 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  27
+#define YYFINAL  29
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   2159
+#define YYLAST   2034
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  69
+#define YYNTOKENS  70
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  30
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  172
+#define YYNRULES  169
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  328
+#define YYNSTATES  317
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK   302
+#define YYMAXUTOK   303
 
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
@@ -922,16 +925,16 @@ static const yytype_int8 yytranslate[] =
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,    62,    56,     2,     2,
-      60,    61,    54,    52,    48,    53,    64,    55,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,    63,    59,
-      50,    49,    51,    58,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,    69,    57,     2,     2,
+      61,    62,    55,    53,    49,    54,    64,    56,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,    63,    60,
+      51,    50,    52,    59,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,    65,     2,    66,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,    67,    47,    68,     2,     2,     2,     2,
+       2,     2,     2,    67,    48,    68,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -949,31 +952,30 @@ static const yytype_int8 yytranslate[] =
       15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
       25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
       35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
-      45,    46,    57
+      45,    46,    47,    58
 };
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   306,   306,   309,   314,   317,   332,   335,   340,   343,
-     348,   352,   355,   359,   363,   367,   370,   375,   379,   383,
-     388,   395,   399,   403,   407,   411,   415,   419,   423,   427,
-     431,   435,   439,   443,   447,   451,   455,   459,   465,   471,
-     475,   479,   483,   487,   491,   495,   499,   503,   508,   511,
-     528,   537,   544,   552,   563,   568,   574,   577,   582,   586,
-     590,   597,   597,   601,   601,   608,   611,   614,   620,   623,
-     626,   631,   634,   637,   643,   646,   649,   657,   661,   664,
-     667,   670,   673,   676,   679,   682,   685,   689,   695,   698,
+       0,   307,   307,   310,   315,   318,   333,   336,   341,   344,
+     349,   353,   356,   360,   364,   368,   371,   376,   380,   384,
+     389,   396,   400,   404,   408,   412,   416,   420,   424,   428,
+     432,   436,   440,   444,   448,   452,   456,   460,   466,   472,
+     476,   480,   484,   488,   492,   496,   500,   504,   509,   512,
+     529,   538,   545,   553,   564,   569,   575,   578,   583,   587,
+     594,   594,   598,   598,   605,   608,   611,   617,   620,   623,
+     628,   631,   634,   640,   643,   646,   654,   658,   661,   664,
+     667,   670,   673,   676,   679,   682,   686,   692,   695,   698,
      701,   704,   707,   710,   713,   716,   719,   722,   725,   728,
-     731,   734,   737,   740,   743,   746,   749,   752,   755,   777,
-     781,   785,   794,   806,   811,   812,   813,   814,   817,   820,
-     825,   830,   833,   838,   841,   846,   850,   853,   858,   861,
-     866,   869,   874,   877,   880,   883,   886,   889,   897,   903,
-     906,   909,   912,   915,   918,   921,   924,   927,   930,   933,
-     936,   939,   942,   945,   948,   951,   954,   957,   962,   965,
-     966,   967,   970,   973,   976,   979,   983,   987,   991,   995,
-     999,  1003,  1011
+     731,   734,   737,   740,   743,   746,   749,   752,   774,   778,
+     782,   786,   798,   803,   804,   805,   806,   809,   812,   817,
+     822,   825,   830,   833,   838,   842,   845,   850,   853,   858,
+     861,   866,   869,   872,   875,   878,   881,   889,   895,   898,
+     901,   904,   907,   910,   913,   916,   919,   922,   925,   928,
+     931,   934,   937,   940,   943,   946,   951,   954,   955,   956,
+     959,   962,   965,   968,   972,   976,   980,   984,   988,   996
 };
 #endif
 
@@ -990,21 +992,21 @@ static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
 static const char *const yytname[] =
 {
   "\"end of file\"", "error", "\"invalid token\"", "INVALID_CHARACTER",
-  "IDENT", "FIELD", "LITERAL", "FORMAT", "\"..\"", "\"%=\"", "\"==\"",
-  "\"!=\"", "\"//\"", "\"as\"", "\"def\"", "\"module\"", "\"import\"",
-  "\"include\"", "\"if\"", "\"then\"", "\"else\"", "\"elif\"",
-  "\"reduce\"", "\"foreach\"", "\"end\"", "\"and\"", "\"or\"", "\"try\"",
-  "\"catch\"", "\"label\"", "\"break\"", "\"__loc__\"", "\"|=\"", "\"+=\"",
-  "\"-=\"", "\"*=\"", "\"/=\"", "\"//=\"", "\"<=\"", "\">=\"", "\"?//\"",
-  "QQSTRING_START", "QQSTRING_TEXT", "QQSTRING_INTERP_START",
-  "QQSTRING_INTERP_END", "QQSTRING_END", "FUNCDEF", "'|'", "','", "'='",
-  "'<'", "'>'", "'+'", "'-'", "'*'", "'/'", "'%'", "NONOPT", "'?'", "';'",
-  "'('", "')'", "'$'", "':'", "'.'", "'['", "']'", "'{'", "'}'", "$accept",
-  "TopLevel", "Module", "Imports", "FuncDefs", "Exp", "Import",
-  "ImportWhat", "ImportFrom", "FuncDef", "Params", "Param", "String", "@1",
-  "@2", "QQString", "ElseBody", "ExpD", "Term", "Args", "Arg",
-  "RepPatterns", "Patterns", "Pattern", "ArrayPats", "ObjPats", "ObjPat",
-  "Keyword", "MkDict", "MkDictPair", YY_NULLPTR
+  "IDENT", "FIELD", "BINDING", "LITERAL", "FORMAT", "\"..\"", "\"%=\"",
+  "\"==\"", "\"!=\"", "\"//\"", "\"as\"", "\"def\"", "\"module\"",
+  "\"import\"", "\"include\"", "\"if\"", "\"then\"", "\"else\"",
+  "\"elif\"", "\"reduce\"", "\"foreach\"", "\"end\"", "\"and\"", "\"or\"",
+  "\"try\"", "\"catch\"", "\"label\"", "\"break\"", "\"$__loc__\"",
+  "\"|=\"", "\"+=\"", "\"-=\"", "\"*=\"", "\"/=\"", "\"//=\"", "\"<=\"",
+  "\">=\"", "\"?//\"", "QQSTRING_START", "QQSTRING_TEXT",
+  "QQSTRING_INTERP_START", "QQSTRING_INTERP_END", "QQSTRING_END",
+  "FUNCDEF", "'|'", "','", "'='", "'<'", "'>'", "'+'", "'-'", "'*'", "'/'",
+  "'%'", "NONOPT", "'?'", "';'", "'('", "')'", "':'", "'.'", "'['", "']'",
+  "'{'", "'}'", "'$'", "$accept", "TopLevel", "Module", "Imports",
+  "FuncDefs", "Exp", "Import", "ImportWhat", "ImportFrom", "FuncDef",
+  "Params", "Param", "String", "@1", "@2", "QQString", "ElseBody", "ExpD",
+  "Term", "Args", "Arg", "RepPatterns", "Patterns", "Pattern", "ArrayPats",
+  "ObjPats", "ObjPat", "Keyword", "MkDict", "MkDictPair", YY_NULLPTR
 };
 
 static const char *
@@ -1014,12 +1016,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-118)
+#define YYPACT_NINF (-161)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-159)
+#define YYTABLE_NINF (-157)
 
 #define yytable_value_is_error(Yyn) \
   ((Yyn) == YYTABLE_NINF)
@@ -1028,39 +1030,38 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-     -10,   841,    14,    94,    -8,   -16,  -118,    23,  -118,    51,
-     841,   510,   510,   841,     4,     1,  -118,   841,   527,   953,
-     294,   460,   360,  1457,   841,  -118,     6,  -118,    -3,    -3,
-     841,    94,   685,   841,  -118,  -118,   -24,  1813,     8,    10,
-      31,    65,  -118,   104,  -118,    67,    56,  1287,  -118,  -118,
-    -118,  -118,  -118,  -118,  -118,  -118,  -118,  -118,  -118,  -118,
-    -118,  -118,  -118,  -118,  -118,  -118,  -118,  -118,    50,  -118,
-    -118,   123,    23,    68,    61,  -118,  1034,   -22,    69,   841,
-    2100,    71,    72,    60,    83,   841,   841,   841,   841,   841,
-     841,   841,   841,   841,   841,   841,   841,   841,   841,   841,
-     841,   841,   841,   841,   841,   841,   841,   841,   841,  -118,
-    -118,  1981,    78,   -11,    -4,   169,   124,  -118,  -118,  -118,
-    1981,   841,  -118,  -118,  1508,  1981,   -14,  -118,  -118,    18,
-     841,   592,   -11,   -11,   657,    91,  -118,    15,  -118,  -118,
-      77,  -118,  -118,  -118,  -118,   417,   445,  -118,   445,  1321,
-      79,  -118,   445,   445,  -118,   417,  2015,   355,   355,   214,
-     573,  2047,  2015,  2015,  2015,  2015,  2015,  2015,   355,   355,
-    1981,   214,  2015,   355,   355,    67,    67,    82,    82,    82,
-    -118,   140,   -11,   903,   105,    99,   109,   749,    93,    87,
-     841,    98,   984,    20,  -118,  -118,   841,  -118,    34,  -118,
-    2128,    22,  -118,  1559,  -118,  1763,    97,   106,  -118,  -118,
-     841,  -118,   841,  -118,   155,   -20,  -118,   445,   117,     3,
-     117,   108,   445,   117,   117,  -118,  -118,  -118,   -13,   115,
-     116,   841,   163,   118,   -38,  -118,   122,   -11,   841,   110,
-    1084,  -118,  -118,  1134,  -118,   777,   111,  -118,   168,  -118,
-    -118,  -118,  -118,    18,   127,  -118,   841,   841,  -118,  -118,
-     841,   841,  1981,  1847,  -118,  -118,   445,   445,   117,   -11,
-    -118,   -11,   -11,  1355,   130,   -11,   903,  -118,   -11,   154,
-    1981,  -118,   142,   143,   144,  1184,  -118,  -118,  -118,   841,
-    1897,  1947,  1610,  1661,  -118,   117,   117,  -118,  -118,  -118,
-     141,   -11,  -118,  -118,  -118,  -118,  -118,  -118,   145,  1712,
-    -118,   841,   841,   841,   -11,  -118,  -118,  -118,  1763,  1389,
-    1234,  -118,  -118,  -118,   841,  -118,  1423,  -118
+     -14,   863,    29,    34,    14,    20,  -161,  -161,    21,  -161,
+      78,   863,   448,   448,   863,   103,    39,  -161,  -161,   863,
+     417,   284,   350,   581,    50,  1351,   863,  -161,     2,  -161,
+       7,     7,   863,    34,   665,   863,  -161,  -161,   -22,  1707,
+       9,    51,    97,    82,  -161,  -161,  -161,    -2,    69,  1181,
+    -161,   133,    21,    81,    77,  -161,   992,   -46,    83,    85,
+    -161,  -161,  -161,  -161,  -161,  -161,  -161,  -161,  -161,  -161,
+    -161,  -161,  -161,  -161,  -161,  -161,  -161,  -161,   863,    86,
+      87,    76,    96,    84,   863,   863,   863,   863,   863,   863,
+     863,   863,   863,   863,   863,   863,   863,   863,   863,   863,
+     863,   863,   863,   863,   863,   863,   863,   863,  -161,  -161,
+    1875,    92,    -5,    -4,   165,   140,  -161,  -161,  -161,  1875,
+     863,  -161,  -161,  1402,  1875,    10,  -161,  -161,    74,   863,
+     468,    -5,    -5,   519,   863,     4,  -161,  -161,  -161,  -161,
+    -161,  -161,   637,   206,  -161,   206,   206,  1215,   206,   206,
+    -161,   637,   149,  1943,   580,   580,  1909,   779,  1975,  1943,
+    1943,  1943,  1943,  1943,  1943,   580,   580,  1875,  1909,  1943,
+     580,   580,    -2,    -2,    98,    98,    98,  -161,  -161,    -5,
+     925,   117,   111,   119,   731,   102,    99,   863,   104,   958,
+     121,  -161,  -161,   863,  -161,    25,  -161,  -161,    75,  -161,
+    1453,  -161,  1657,   101,   106,  -161,  -161,  1875,  -161,   863,
+    -161,   -19,  -161,   206,   116,    59,   116,   116,   105,   116,
+     116,  -161,  -161,  -161,   -24,   112,   113,   114,   863,   115,
+     -25,  -161,   118,    -5,   863,   120,  1026,  -161,  -161,  1060,
+    -161,   797,   123,  -161,  -161,  -161,  -161,    74,   124,  -161,
+     863,   863,  -161,  -161,   863,   863,  1741,  -161,   206,   206,
+      -5,  -161,    -5,    -5,    -5,  1249,    -5,   925,  -161,    -5,
+     150,  1875,  -161,   131,   135,   139,  1094,  -161,  -161,   863,
+    1791,  1841,  1504,  1555,  -161,   116,   116,  -161,  -161,  -161,
+    -161,   136,  -161,  -161,  -161,  -161,  -161,  -161,   141,  1606,
+    -161,   863,   863,   863,    -5,  -161,  -161,  1657,  1283,  1128,
+    -161,  -161,  -161,   863,  -161,  1317,  -161
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -1068,55 +1069,54 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       4,     0,     0,     6,   112,    83,   102,   104,    75,     0,
-       0,     0,     0,     0,     0,     0,    61,     0,     0,     0,
-       0,     0,     0,     0,     0,   103,    47,     1,     0,     0,
-       8,     6,     0,     0,    79,    63,     0,     0,     0,     0,
-      18,     0,    77,     0,    65,    32,     0,     0,   110,   139,
-     140,   141,   142,   143,   144,   145,   146,   147,   148,   149,
-     150,   151,   152,   153,   154,   155,   156,   157,     0,   111,
-      86,     0,     0,    85,     0,   107,     0,     0,   169,     0,
-       0,   165,   170,     0,   159,     0,     0,     0,     0,     0,
+       4,     0,     0,     6,   111,    82,   109,   101,   103,    74,
+       0,     0,     0,     0,     0,     0,     0,   110,    60,     0,
+       0,     0,     0,     0,     0,     0,     0,   102,    47,     1,
+       0,     0,     8,     6,     0,     0,    78,    62,     0,     0,
+       0,     0,    18,     0,    76,    75,    64,    32,     0,     0,
+      85,     0,     0,    84,     0,   106,     0,     0,   166,   165,
+     138,   139,   140,   141,   142,   143,   144,   145,   146,   147,
+     148,   149,   150,   151,   152,   153,   154,   155,     0,   163,
+     167,     0,   157,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    21,
-       5,    10,    82,     0,     0,     0,     0,    53,    52,     3,
-       2,     8,     7,    48,     0,   120,     0,   118,    65,     0,
-       0,     0,     0,     0,     0,     0,    76,     0,   114,   105,
-       0,    87,    81,   115,   106,     0,     0,   117,     0,     0,
-     167,   168,     0,     0,   108,     0,    40,    41,    42,    25,
-      24,    23,    27,    31,    34,    36,    39,    26,    45,    46,
-      28,    29,    22,    43,    44,    30,    33,    35,    37,    38,
-      78,     0,     0,     0,     0,     0,   124,     0,    84,     0,
-       0,    93,     0,     0,     9,    49,     0,   113,     0,    60,
-       0,     0,    56,     0,    16,     0,     0,     0,    19,    17,
-       0,    66,     0,    62,     0,     0,   161,     0,   172,    73,
-     162,     0,     0,   164,   163,   160,   125,   128,     0,     0,
-       0,     0,     0,     0,     0,   130,     0,     0,     0,    95,
-       0,    80,   116,     0,    92,     0,    89,    51,     0,   119,
-      64,    58,    59,     0,     0,    54,     0,     0,    70,    15,
-       0,     0,    20,     0,   109,    72,     0,     0,   166,     0,
-     126,     0,     0,     0,   132,     0,     0,   127,     0,   123,
-      11,    94,    91,   101,   100,     0,    88,    50,    57,     0,
-       0,     0,     0,     0,    67,    71,   171,   129,   138,   134,
-       0,     0,   136,   131,   135,    90,    98,    97,    99,     0,
-      69,     0,     0,     0,     0,   133,    96,    55,     0,     0,
-       0,   137,    68,    12,     0,    14,     0,    13
+       0,     0,     0,     0,     0,     0,     0,     0,    21,     5,
+      10,    81,     0,     0,     0,     0,    53,    52,     3,     2,
+       8,     7,    48,     0,   119,     0,   117,    64,     0,     0,
+       0,     0,     0,     0,     0,     0,   113,   104,    86,    80,
+     114,   105,     0,     0,   116,     0,     0,     0,     0,     0,
+     107,     0,     0,    40,    41,    42,    25,    24,    23,    27,
+      31,    34,    36,    39,    26,    45,    46,    28,    29,    22,
+      43,    44,    30,    33,    35,    37,    38,    77,   124,     0,
+       0,     0,     0,   123,     0,    83,     0,     0,    92,     0,
+       0,     9,    49,     0,   112,     0,    59,    58,     0,    56,
+       0,    16,     0,     0,     0,    19,    17,    20,    65,     0,
+      61,     0,   159,     0,   169,    72,   160,   164,     0,   162,
+     161,   158,   108,   127,     0,     0,     0,   131,     0,     0,
+       0,   129,     0,     0,     0,    94,     0,    79,   115,     0,
+      91,     0,    88,    51,    50,   118,    63,     0,     0,    54,
+       0,     0,    69,    15,     0,     0,     0,    71,     0,     0,
+       0,   125,     0,     0,     0,     0,     0,     0,   126,     0,
+     122,    11,    93,    90,   100,    99,     0,    87,    57,     0,
+       0,     0,     0,     0,    66,    70,   168,   128,   137,   133,
+     132,     0,   135,   130,   134,    89,    97,    96,    98,     0,
+      68,     0,     0,     0,     0,    95,    55,     0,     0,     0,
+     136,    67,    12,     0,    14,     0,    13
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -118,  -118,  -118,   149,    84,    -1,  -118,  -118,   177,   -12,
-    -118,   -46,     5,  -118,  -118,    80,  -103,  -104,    -5,  -118,
-      17,  -118,   -17,  -117,  -118,  -118,   -62,   -18,  -105,  -118
+    -161,  -161,  -161,   168,    89,    -1,  -161,  -161,   171,     0,
+    -161,   -44,     5,  -161,  -161,    90,  -103,  -137,    -7,  -161,
+      12,  -161,   -73,  -152,  -161,  -161,   -51,  -160,  -105,  -161
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
+static const yytype_uint8 yydefgoto[] =
 {
-       0,     2,     3,    30,   119,   111,    31,    32,   116,    24,
-     201,   202,    25,    44,   128,   137,   259,   218,    26,   126,
-     127,   184,   185,   186,   228,   234,   235,    82,    83,    84
+       0,     2,     3,    32,   118,   110,    33,    34,   115,    26,
+     198,   199,    27,    46,   127,   135,   253,   214,    28,   125,
+     126,   181,   182,   183,   224,   230,   231,    80,    81,    82
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -1124,504 +1124,478 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      23,    69,    42,    72,    72,     1,    38,    39,   112,    37,
-     276,   112,    40,   112,    27,   112,    45,    47,   121,   113,
-      76,   132,   199,   133,   247,    73,   145,    81,   145,   120,
-     277,   124,   125,   117,   117,   269,   129,    16,    16,   130,
-     216,   146,    34,   146,   220,   196,   147,   197,   223,   224,
-     225,   181,    33,   270,   182,    36,   183,   211,   212,   134,
-     213,   187,   151,    43,    35,   227,    41,   114,   115,   135,
-     114,   115,   114,   115,   114,   115,   211,   212,   149,   250,
-     200,   253,   248,   254,   156,   157,   158,   159,   160,   161,
-     162,   163,   164,   165,   166,   167,   168,   169,   170,   171,
-     172,   173,   174,   175,   176,   177,   178,   179,   136,   121,
-      28,    29,   140,   265,   192,   206,   207,   138,   268,   188,
-     279,   106,   107,   108,   141,   109,   142,   143,   154,   203,
-     205,   155,   148,   209,   152,   153,   180,   193,   210,   214,
-     109,   219,   222,   219,   226,   237,   238,   219,   219,  -122,
-      81,   241,   297,   242,   298,   299,   244,   260,   302,   264,
-      81,   304,   295,   296,   266,   236,   261,   274,   281,   286,
-     189,   267,   287,     4,     5,     6,     7,     8,   271,   272,
-     122,   275,   252,     9,   315,   278,   240,    10,   233,   243,
-     289,    11,    12,   301,  -121,   125,    13,   321,    14,    15,
-     305,   306,   307,   316,   314,   194,   118,   288,   198,   262,
-      16,   263,   219,   249,   303,   322,     0,   219,     0,     0,
-       0,     0,    17,    85,    86,    87,    88,     0,     0,    18,
-     273,    19,   190,    20,    21,   191,    22,   280,     0,    89,
-      90,     0,     0,     0,   285,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,   290,   291,     0,   236,   292,
-     293,   219,   219,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,     0,     0,     0,     0,     0,     0,     0,
-       0,   233,     0,     0,     0,     0,     0,     0,   309,     0,
-       0,     0,     0,     0,   -74,    70,     0,     0,    71,   -74,
-       0,    72,     0,   -74,   -74,   -74,   -74,   -74,     0,     0,
-     318,   319,   320,   -74,   -74,   -74,     0,     0,   -74,   -74,
-     -74,     0,   -74,   326,     0,     0,   -74,   -74,   -74,   -74,
-     -74,   -74,   -74,   -74,     0,    16,     0,     0,   -74,     0,
-       0,   -74,   -74,   -74,   -74,   -74,   -74,   -74,   -74,   -74,
-     -74,     0,   -74,   -74,     0,   -74,     0,   -74,   -74,   -74,
-     -74,    77,   -74,     0,    78,  -159,  -159,    72,     0,     0,
-       0,     0,     0,    49,    50,    51,    52,    53,    54,    55,
-      56,    57,    58,    59,    60,    61,    62,    63,    64,    65,
-      66,    67,     0,  -159,  -159,     0,     0,     0,     0,     0,
-       0,    16,     0,     0,     0,  -159,  -159,   104,   105,   106,
-     107,   108,     0,   109,     0,     0,     0,     0,   215,     0,
-      79,    78,    80,     0,    72,     0,     0,     0,  -158,     0,
-      49,    50,    51,    52,    53,    54,    55,    56,    57,    58,
-      59,    60,    61,    62,    63,    64,    65,    66,    67,     4,
-       5,     6,     7,     8,     0,     0,     0,     0,    16,     0,
-       0,    74,     0,     0,     4,     5,     6,     7,     8,     0,
-       0,     0,     0,     0,     9,    15,     0,    79,    10,    80,
-       0,     0,    11,    12,     0,  -158,    16,    13,     0,    14,
-      15,     0,     0,     0,     0,     0,     0,     0,   217,     0,
-       0,    16,     0,     0,     0,    18,     0,    19,     0,    20,
-      21,     0,    22,    17,     4,     5,     6,     7,     8,     0,
-      18,     0,    19,     0,    20,    21,    75,    22,    46,     0,
-       0,     4,     5,     6,     7,     8,     0,     0,     0,     0,
-      15,     9,     0,     0,     0,    10,     0,     0,     0,    11,
-      12,    16,     0,     0,    13,     0,    14,    15,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    16,     0,
-      18,     0,    19,     0,    20,    21,     0,    22,     0,     0,
-      17,     0,     0,    86,    87,     0,     0,    18,     0,    19,
-       0,    20,    21,   204,    22,     0,     4,     5,     6,     7,
-       8,     0,     0,     0,     0,     0,     9,     0,     0,     0,
-      10,    97,    98,     0,    11,    12,     0,     0,     0,    13,
-       0,    14,    15,   102,   103,   104,   105,   106,   107,   108,
-       0,   109,     0,    16,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    17,     0,     0,     0,     0,
-       0,     0,    18,     0,    19,     0,    20,    21,   208,    22,
-       0,     4,     5,     6,     7,     8,     0,     0,     0,     0,
-       0,     9,     0,     0,     0,    10,     0,     0,     0,    11,
-      12,     0,     0,     0,    13,     0,    14,    15,     0,     4,
-       5,     6,     7,     8,     0,     0,     0,     0,    16,     9,
-       0,     0,     0,    10,     0,     0,     0,    11,    12,     0,
-      17,     0,    13,     0,    14,    15,     0,    18,     0,    19,
-       0,    20,    21,     0,    22,     0,    16,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,    17,     0,
-       0,     0,     0,     0,   123,    18,     0,    19,     0,    20,
-      21,     0,    22,     4,     5,     6,     7,     8,     0,     0,
-       0,     0,     0,     9,     0,     0,     0,    10,     0,     0,
-       0,    11,    12,     0,     0,     0,    13,     0,    14,    15,
-       0,     4,     5,     6,     7,     8,     0,     0,     0,     0,
-      16,     9,     0,     0,     0,    10,     0,     0,     0,    11,
-      12,     0,    17,     0,    13,     0,    14,    15,     0,    18,
-       0,    19,     0,    20,    21,   239,    22,     0,    16,     0,
+      25,   178,     1,   142,    52,    40,    41,   111,   216,   217,
+      39,   219,   220,    42,   111,    52,   112,   143,    47,    49,
+     232,    56,   144,   131,   267,   260,    53,   223,    79,    29,
+     142,   119,   120,   123,   124,   116,   116,   212,    18,   128,
+      44,   129,   261,   268,   143,    45,   221,   208,   209,    18,
+     210,    30,    31,   105,   106,   107,   111,   108,   203,   204,
+     179,   184,   180,    37,   111,   132,   113,   114,   208,   209,
+     193,   246,   194,   113,   114,    35,   257,   147,   196,    36,
+     197,   270,    38,   153,   154,   155,   156,   157,   158,   159,
+     160,   161,   162,   163,   164,   165,   166,   167,   168,   169,
+     170,   171,   172,   173,   174,   175,   176,   232,   287,    43,
+     288,   289,   290,   189,   292,   113,   114,   294,   185,    83,
+     120,   285,   286,   113,   114,   243,   133,   244,   200,   202,
+     134,   136,   206,   207,   138,   247,   215,   248,   215,   215,
+     139,   215,   215,   140,   150,   151,   145,    79,   146,   148,
+     149,   177,   310,   152,   190,   222,    79,   108,   233,   234,
+    -121,   237,   254,   240,   258,   238,   186,   255,   259,     4,
+       5,     6,     7,     8,     9,   262,   263,   264,   266,   272,
+      10,   269,   277,   236,    11,   229,   239,   279,    12,    13,
+     295,  -120,   124,    14,   296,    15,    16,    17,   297,   304,
+     305,   121,   117,   278,   311,   245,   215,    18,   256,   191,
+       4,     5,     6,     7,     8,     9,   293,   195,     0,    19,
+       0,     0,     0,     0,     0,     0,    20,   265,   187,    21,
+      22,   188,    23,   271,    24,     0,     0,    16,    17,     0,
+     276,     0,     0,     0,     0,     0,     0,     0,    18,   280,
+     281,   215,   215,   282,   283,     0,     0,     0,     0,     0,
+     213,     0,     0,     0,     0,     0,     0,    20,     0,     0,
+      21,    22,   229,    23,     0,    24,     0,     0,   299,     0,
+       0,     0,     0,     0,   -73,    50,     0,     0,    51,   -73,
+       0,     0,    52,     0,   -73,   -73,   -73,   -73,   -73,     0,
+     307,   308,   309,     0,   -73,   -73,   -73,     0,     0,   -73,
+     -73,   -73,   315,   -73,     0,     0,     0,   -73,   -73,   -73,
+     -73,   -73,   -73,   -73,   -73,     0,    18,     0,     0,   -73,
+       0,     0,   -73,   -73,   -73,   -73,   -73,   -73,   -73,   -73,
+     -73,   -73,     0,   -73,   -73,     0,   -73,   -73,   -73,   -73,
+     -73,    54,   -73,     0,     4,     5,     6,     7,     8,     9,
+       0,     0,     0,     0,     0,    10,     0,     0,     0,    11,
+       0,     0,     0,    12,    13,     0,     0,     0,    14,     0,
+      15,    16,    17,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    18,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    19,     0,     0,     0,     0,     0,
+       0,    20,     0,     0,    21,    22,    55,    23,    48,    24,
+       0,     4,     5,     6,     7,     8,     9,     0,     0,     0,
+       0,     0,    10,     0,     0,     0,    11,     0,     0,     0,
+      12,    13,     0,     0,     0,    14,     0,    15,    16,    17,
+       0,     0,     4,     5,     6,     7,     8,     9,     0,    18,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   201,
+       0,    19,     4,     5,     6,     7,     8,     9,    20,    16,
+      17,    21,    22,    10,    23,     0,    24,    11,     0,     0,
+      18,    12,    13,     0,     0,     0,    14,     0,    15,    16,
+      17,     0,     0,     0,     0,     0,     0,     0,     0,    20,
+      18,     0,    21,    22,     0,    23,     0,    24,     0,     0,
+     205,     0,    19,     4,     5,     6,     7,     8,     9,    20,
+       0,     0,    21,    22,    10,    23,     0,    24,    11,     0,
+       0,     0,    12,    13,     0,     0,     0,    14,     0,    15,
+      16,    17,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,    18,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    19,     0,     0,     0,     0,     0,     0,
+      20,     0,    57,    21,    22,    58,    23,    59,    24,    52,
+       0,  -157,  -157,     0,     0,    60,    61,    62,    63,    64,
+      65,    66,    67,    68,    69,    70,    71,    72,    73,    74,
+      75,    76,    77,     0,     0,     0,     0,     0,     0,  -157,
+    -157,     0,     0,    18,     0,     0,     0,     0,     0,     0,
+       0,  -157,  -157,   103,   104,   105,   106,   107,   211,   108,
+       0,    58,    78,    59,     0,    52,     0,     0,     0,  -156,
+       0,    60,    61,    62,    63,    64,    65,    66,    67,    68,
+      69,    70,    71,    72,    73,    74,    75,    76,    77,     4,
+       5,     6,     7,     8,     9,     0,     0,     0,     0,    18,
+      10,     0,     0,     0,    11,     0,     0,     0,    12,    13,
+       0,     0,     0,    14,     0,    15,    16,    17,    78,     0,
+       0,     0,     0,     0,     0,  -156,     0,    18,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    19,
+       0,     0,     0,     0,     0,   122,    20,     0,     0,    21,
+      22,     0,    23,     0,    24,     4,     5,     6,     7,     8,
+       9,     0,     0,     0,     0,     0,    10,     0,     0,     0,
+      11,     0,     0,     0,    12,    13,     0,     0,     0,    14,
+       0,    15,    16,    17,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,    18,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    19,     0,     0,     0,     0,
+      85,    86,    20,     0,     0,    21,    22,   235,    23,     0,
+      24,     4,     5,     6,     7,     8,     9,     0,     0,     0,
+       0,     0,    10,     0,     0,     0,    11,     0,    96,    97,
+      12,    13,     0,     0,     0,    14,     0,    15,    16,    17,
+     101,   102,   103,   104,   105,   106,   107,     0,   108,    18,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      17,     0,     0,     0,     0,     0,     0,    18,     0,    19,
-       0,    20,    21,   284,    22,     4,     5,     6,     7,     8,
-       0,     0,     0,     0,     0,     9,     0,     0,     0,    10,
-       0,     0,     0,    11,    12,     0,     0,     0,    13,     0,
-      14,    15,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    16,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    17,     0,     0,     0,     0,     0,
-       0,    18,     0,    19,   229,    20,    21,   230,    22,     0,
-      72,     0,     0,     0,     0,     0,    49,    50,    51,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,    61,    62,
-      63,    64,    65,    66,    67,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    16,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    48,     0,     0,
-       0,     0,     0,   231,     0,   232,    49,    50,    51,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,    61,    62,
-      63,    64,    65,    66,    67,     0,     0,     0,     0,     0,
-       0,     0,     0,    85,    86,    87,    88,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,    68,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,    85,    86,    87,    88,   245,     0,     0,
-     246,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,    85,    86,    87,    88,     0,     0,     0,
-     144,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,    85,    86,    87,    88,     0,     0,     0,
-     282,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,    85,    86,    87,    88,     0,     0,     0,
-     283,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,    85,    86,    87,    88,     0,     0,     0,
-     308,     0,     0,     0,     0,     0,     0,     0,     0,    89,
-      90,     0,     0,     0,     0,     0,    91,    92,    93,    94,
-      95,    96,    97,    98,     0,     0,     0,     0,     0,     0,
-       0,    99,   100,   101,   102,   103,   104,   105,   106,   107,
-     108,     0,   109,   324,     0,   325,    85,    86,    87,    88,
+       0,    19,     0,     0,     0,     0,     0,     0,    20,     0,
+       0,    21,    22,   275,    23,     0,    24,     4,     5,     6,
+       7,     8,     9,     0,     0,     0,     0,     0,    10,     0,
+       0,     0,    11,     0,     0,     0,    12,    13,     0,     0,
+       0,    14,     0,    15,    16,    17,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,    18,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    19,     0,     0,
+       0,     0,     0,     0,    20,     0,   225,    21,    22,   226,
+      23,   227,    24,    52,     0,     0,     0,     0,     0,    60,
+      61,    62,    63,    64,    65,    66,    67,    68,    69,    70,
+      71,    72,    73,    74,    75,    76,    77,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    18,    84,    85,
+      86,    87,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    88,    89,   228,     0,     0,     0,
+       0,    90,    91,    92,    93,    94,    95,    96,    97,     0,
+       0,     0,    84,    85,    86,    87,    98,    99,   100,   101,
+     102,   103,   104,   105,   106,   107,     0,   108,    88,    89,
+       0,   241,     0,     0,   242,    90,    91,    92,    93,    94,
+      95,    96,    97,     0,     0,     0,    84,    85,    86,    87,
+      98,    99,   100,   101,   102,   103,   104,   105,   106,   107,
+       0,   108,    88,    89,     0,     0,     0,     0,   141,    90,
+      91,    92,    93,    94,    95,    96,    97,     0,     0,     0,
+      84,    85,    86,    87,    98,    99,   100,   101,   102,   103,
+     104,   105,   106,   107,     0,   108,    88,    89,     0,     0,
+       0,     0,   273,    90,    91,    92,    93,    94,    95,    96,
+      97,     0,     0,     0,    84,    85,    86,    87,    98,    99,
+     100,   101,   102,   103,   104,   105,   106,   107,     0,   108,
+      88,    89,     0,     0,     0,     0,   274,    90,    91,    92,
+      93,    94,    95,    96,    97,     0,     0,     0,    84,    85,
+      86,    87,    98,    99,   100,   101,   102,   103,   104,   105,
+     106,   107,     0,   108,    88,    89,     0,     0,     0,     0,
+     298,    90,    91,    92,    93,    94,    95,    96,    97,     0,
+       0,     0,     0,     0,     0,     0,    98,    99,   100,   101,
+     102,   103,   104,   105,   106,   107,     0,   108,   313,     0,
+     314,    84,    85,    86,    87,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    88,    89,     0,
+       0,     0,     0,     0,    90,    91,    92,    93,    94,    95,
+      96,    97,     0,     0,     0,    84,    85,    86,    87,    98,
+      99,   100,   101,   102,   103,   104,   105,   106,   107,     0,
+     108,    88,    89,   137,     0,     0,     0,     0,    90,    91,
+      92,    93,    94,    95,    96,    97,     0,     0,     0,    84,
+      85,    86,    87,    98,    99,   100,   101,   102,   103,   104,
+     105,   106,   107,     0,   108,    88,    89,   218,     0,     0,
+       0,     0,    90,    91,    92,    93,    94,    95,    96,    97,
+       0,     0,     0,    84,    85,    86,    87,    98,    99,   100,
+     101,   102,   103,   104,   105,   106,   107,     0,   108,    88,
+      89,   291,     0,     0,     0,     0,    90,    91,    92,    93,
+      94,    95,    96,    97,     0,     0,     0,    84,    85,    86,
+      87,    98,    99,   100,   101,   102,   103,   104,   105,   106,
+     107,     0,   108,    88,    89,   312,     0,     0,     0,     0,
+      90,    91,    92,    93,    94,    95,    96,    97,     0,     0,
+       0,    84,    85,    86,    87,    98,    99,   100,   101,   102,
+     103,   104,   105,   106,   107,     0,   108,    88,    89,   316,
+       0,     0,     0,     0,    90,    91,    92,    93,    94,    95,
+      96,    97,     0,     0,     0,     0,     0,     0,     0,    98,
+      99,   100,   101,   102,   103,   104,   105,   106,   107,     0,
+     108,   109,    84,    85,    86,    87,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    88,    89,
+       0,     0,     0,     0,     0,    90,    91,    92,    93,    94,
+      95,    96,    97,     0,     0,     0,     0,     0,     0,     0,
+      98,    99,   100,   101,   102,   103,   104,   105,   106,   107,
+       0,   108,   192,    84,    85,    86,    87,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,    88,
+      89,     0,     0,     0,     0,     0,    90,    91,    92,    93,
+      94,    95,    96,    97,     0,     0,     0,     0,     0,     0,
+       0,    98,    99,   100,   101,   102,   103,   104,   105,   106,
+     107,     0,   108,   249,    84,    85,    86,    87,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    89,    90,     0,     0,     0,     0,     0,    91,
-      92,    93,    94,    95,    96,    97,    98,     0,     0,     0,
-      85,    86,    87,    88,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,     0,   109,    89,    90,   139,     0,
-       0,     0,     0,    91,    92,    93,    94,    95,    96,    97,
-      98,     0,     0,     0,    85,    86,    87,    88,    99,   100,
-     101,   102,   103,   104,   105,   106,   107,   108,     0,   109,
-      89,    90,   221,     0,     0,     0,     0,    91,    92,    93,
-      94,    95,    96,    97,    98,     0,     0,     0,    85,    86,
-      87,    88,    99,   100,   101,   102,   103,   104,   105,   106,
-     107,   108,     0,   109,    89,    90,   300,     0,     0,     0,
-       0,    91,    92,    93,    94,    95,    96,    97,    98,     0,
-       0,     0,    85,    86,    87,    88,    99,   100,   101,   102,
-     103,   104,   105,   106,   107,   108,     0,   109,    89,    90,
-     323,     0,     0,     0,     0,    91,    92,    93,    94,    95,
-      96,    97,    98,     0,     0,     0,    85,    86,    87,    88,
-      99,   100,   101,   102,   103,   104,   105,   106,   107,   108,
-       0,   109,    89,    90,   327,     0,     0,     0,     0,    91,
-      92,    93,    94,    95,    96,    97,    98,     0,     0,     0,
-       0,     0,     0,     0,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,     0,   109,   110,    85,    86,    87,
-      88,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    89,    90,     0,     0,     0,     0,     0,
-      91,    92,    93,    94,    95,    96,    97,    98,     0,     0,
-       0,     0,     0,     0,     0,    99,   100,   101,   102,   103,
-     104,   105,   106,   107,   108,     0,   109,   195,    85,    86,
-      87,    88,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,    89,    90,     0,     0,     0,     0,
-       0,    91,    92,    93,    94,    95,    96,    97,    98,     0,
-       0,     0,     0,     0,     0,     0,    99,   100,   101,   102,
-     103,   104,   105,   106,   107,   108,     0,   109,   255,    85,
-      86,    87,    88,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    89,    90,     0,     0,     0,
-       0,     0,    91,    92,    93,    94,    95,    96,    97,    98,
-       0,     0,     0,     0,     0,     0,     0,    99,   100,   101,
-     102,   103,   104,   105,   106,   107,   108,     0,   109,   312,
-      85,    86,    87,    88,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,    89,    90,     0,     0,
-       0,     0,     0,    91,    92,    93,    94,    95,    96,    97,
-      98,     0,     0,     0,     0,     0,     0,     0,    99,   100,
-     101,   102,   103,   104,   105,   106,   107,   108,     0,   109,
-     313,    85,    86,    87,    88,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    89,    90,     0,
-       0,     0,     0,     0,    91,    92,    93,    94,    95,    96,
-      97,    98,     0,     0,     0,     0,     0,     0,     0,    99,
-     100,   101,   102,   103,   104,   105,   106,   107,   108,     0,
-     109,   317,    85,    86,    87,    88,     0,     0,     0,     0,
-       0,     0,     0,   256,   257,     0,     0,   258,    89,    90,
-       0,     0,     0,     0,     0,    91,    92,    93,    94,    95,
-      96,    97,    98,     0,     0,     0,     0,     0,     0,     0,
-      99,   100,   101,   102,   103,   104,   105,   106,   107,   108,
-       0,   109,    85,    86,    87,    88,     0,     0,     0,     0,
-       0,     0,   131,     0,     0,     0,     0,     0,    89,    90,
-       0,     0,     0,     0,     0,    91,    92,    93,    94,    95,
-      96,    97,    98,     0,     0,     0,    85,    86,    87,    88,
-      99,   100,   101,   102,   103,   104,   105,   106,   107,   108,
-       0,   109,    89,    90,     0,     0,     0,     0,     0,    91,
-      92,    93,    94,    95,    96,    97,    98,     0,     0,     0,
-       0,   294,     0,     0,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,     0,   109,    85,    86,    87,    88,
+      88,    89,     0,     0,     0,     0,     0,    90,    91,    92,
+      93,    94,    95,    96,    97,     0,     0,     0,     0,     0,
+       0,     0,    98,    99,   100,   101,   102,   103,   104,   105,
+     106,   107,     0,   108,   302,    84,    85,    86,    87,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   310,    89,    90,     0,     0,     0,     0,     0,    91,
-      92,    93,    94,    95,    96,    97,    98,     0,     0,     0,
-       0,     0,     0,     0,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,     0,   109,    85,    86,    87,    88,
-       0,     0,     0,     0,     0,     0,   311,     0,     0,     0,
-       0,     0,    89,    90,     0,     0,     0,     0,     0,    91,
-      92,    93,    94,    95,    96,    97,    98,     0,     0,     0,
-      85,    86,    87,    88,    99,   100,   101,   102,   103,   104,
-     105,   106,   107,   108,     0,   109,    89,    90,     0,     0,
-       0,     0,     0,    91,    92,    93,    94,    95,    96,    97,
-      98,     0,     0,     0,  -159,    86,    87,     0,    99,   100,
-     101,   102,   103,   104,   105,   106,   107,   108,     0,   109,
-      89,    90,     0,     0,     0,     0,     0,  -159,  -159,  -159,
-    -159,  -159,  -159,    97,    98,     0,     0,    86,    87,     0,
-       0,     0,     0,     0,  -159,   102,   103,   104,   105,   106,
-     107,   108,    89,   109,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    97,    98,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   102,   103,   104,
-     105,   106,   107,   108,   150,   109,     0,     0,     0,     0,
-       0,     0,     0,    49,    50,    51,    52,    53,    54,    55,
-      56,    57,    58,    59,    60,    61,    62,    63,    64,    65,
-      66,    67,   251,     0,     0,     0,     0,     0,     0,     0,
-       0,    49,    50,    51,    52,    53,    54,    55,    56,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67
+       0,    88,    89,     0,     0,     0,     0,     0,    90,    91,
+      92,    93,    94,    95,    96,    97,     0,     0,     0,     0,
+       0,     0,     0,    98,    99,   100,   101,   102,   103,   104,
+     105,   106,   107,     0,   108,   303,    84,    85,    86,    87,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    88,    89,     0,     0,     0,     0,     0,    90,
+      91,    92,    93,    94,    95,    96,    97,     0,     0,     0,
+       0,     0,     0,     0,    98,    99,   100,   101,   102,   103,
+     104,   105,   106,   107,     0,   108,   306,    84,    85,    86,
+      87,     0,     0,     0,     0,     0,     0,     0,   250,   251,
+       0,     0,   252,    88,    89,     0,     0,     0,     0,     0,
+      90,    91,    92,    93,    94,    95,    96,    97,     0,     0,
+       0,     0,     0,     0,     0,    98,    99,   100,   101,   102,
+     103,   104,   105,   106,   107,     0,   108,    84,    85,    86,
+      87,     0,     0,     0,     0,     0,     0,   130,     0,     0,
+       0,     0,     0,    88,    89,     0,     0,     0,     0,     0,
+      90,    91,    92,    93,    94,    95,    96,    97,     0,     0,
+       0,    84,    85,    86,    87,    98,    99,   100,   101,   102,
+     103,   104,   105,   106,   107,     0,   108,    88,    89,     0,
+       0,     0,     0,     0,    90,    91,    92,    93,    94,    95,
+      96,    97,     0,     0,     0,     0,   284,     0,     0,    98,
+      99,   100,   101,   102,   103,   104,   105,   106,   107,     0,
+     108,    84,    85,    86,    87,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   300,    88,    89,     0,
+       0,     0,     0,     0,    90,    91,    92,    93,    94,    95,
+      96,    97,     0,     0,     0,     0,     0,     0,     0,    98,
+      99,   100,   101,   102,   103,   104,   105,   106,   107,     0,
+     108,    84,    85,    86,    87,     0,     0,     0,     0,     0,
+       0,   301,     0,     0,     0,     0,     0,    88,    89,     0,
+       0,     0,     0,     0,    90,    91,    92,    93,    94,    95,
+      96,    97,     0,     0,     0,    84,    85,    86,    87,    98,
+      99,   100,   101,   102,   103,   104,   105,   106,   107,     0,
+     108,    88,    89,     0,     0,     0,     0,     0,    90,    91,
+      92,    93,    94,    95,    96,    97,     0,     0,     0,    84,
+      85,    86,    87,    98,    99,   100,   101,   102,   103,   104,
+     105,   106,   107,     0,   108,    88,    89,     0,     0,     0,
+       0,     0,    90,    91,    92,    93,    94,    95,    96,    97,
+       0,     0,     0,  -157,    85,    86,     0,     0,     0,   100,
+     101,   102,   103,   104,   105,   106,   107,     0,   108,    88,
+      89,     0,     0,     0,     0,     0,  -157,  -157,  -157,  -157,
+    -157,  -157,    96,    97,     0,     0,    85,    86,     0,     0,
+       0,     0,     0,  -157,   101,   102,   103,   104,   105,   106,
+     107,    88,   108,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    96,    97,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   101,   102,   103,   104,
+     105,   106,   107,     0,   108
 };
 
 static const yytype_int16 yycheck[] =
 {
-       1,    19,     1,     7,     7,    15,    11,    12,     5,    10,
-      48,     5,    13,     5,     0,     5,    17,    18,    30,    13,
-      21,    13,     4,    13,     4,    20,    48,    22,    48,    30,
-      68,    32,    33,    28,    29,    48,    60,    41,    41,    63,
-     145,    63,    58,    63,   148,    59,    68,    61,   152,   153,
-     155,    62,    60,    66,    65,     4,    67,    42,    43,    28,
-      45,    65,    80,    62,    41,   182,    62,    64,    65,     4,
-      64,    65,    64,    65,    64,    65,    42,    43,    79,    45,
-      62,    59,    62,    61,    85,    86,    87,    88,    89,    90,
+       1,     6,    16,    49,     8,    12,    13,     5,   145,   146,
+      11,   148,   149,    14,     5,     8,    14,    63,    19,    20,
+     180,    22,    68,    14,    49,    49,    21,   179,    23,     0,
+      49,    32,    32,    34,    35,    30,    31,   142,    42,    61,
+       1,    63,    66,    68,    63,     6,   151,    43,    44,    42,
+      46,    17,    18,    55,    56,    57,     5,    59,   131,   132,
+      65,    65,    67,    42,     5,    14,    64,    65,    43,    44,
+      60,    46,    62,    64,    65,    61,   213,    78,     4,    59,
+       6,   233,     4,    84,    85,    86,    87,    88,    89,    90,
       91,    92,    93,    94,    95,    96,    97,    98,    99,   100,
-     101,   102,   103,   104,   105,   106,   107,   108,     4,   121,
-      16,    17,    62,   217,   115,   132,   133,    61,   222,   114,
-     237,    54,    55,    56,     1,    58,    58,    66,    68,   130,
-     131,    48,    63,   134,    63,    63,    58,    13,    47,    62,
-      58,   146,    63,   148,     4,    40,    47,   152,   153,    40,
-     145,    58,   269,    66,   271,   272,    58,    60,   275,     4,
-     155,   278,   266,   267,    47,   183,    60,     4,    58,    58,
-       1,    63,     4,     4,     5,     6,     7,     8,    63,    63,
-      31,    63,   200,    14,   301,    63,   187,    18,   183,   190,
-      63,    22,    23,    63,    40,   196,    27,   314,    29,    30,
-      58,    58,    58,    58,    63,   121,    29,   253,   128,   210,
-      41,   212,   217,   196,   276,   318,    -1,   222,    -1,    -1,
-      -1,    -1,    53,     9,    10,    11,    12,    -1,    -1,    60,
-     231,    62,    63,    64,    65,    66,    67,   238,    -1,    25,
-      26,    -1,    -1,    -1,   245,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,   256,   257,    -1,   276,   260,
-     261,   266,   267,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,   276,    -1,    -1,    -1,    -1,    -1,    -1,   289,    -1,
+     101,   102,   103,   104,   105,   106,   107,   267,   260,     6,
+     262,   263,   264,   114,   266,    64,    65,   269,   113,    69,
+     120,   258,   259,    64,    65,     4,    29,     6,   129,   130,
+      48,    62,   133,   134,     1,    60,   143,    62,   145,   146,
+      59,   148,   149,    66,    68,    49,    63,   142,    63,    63,
+      63,    59,   304,    69,    14,     6,   151,    59,    41,    48,
+      41,    59,    61,    59,    48,    66,     1,    61,    63,     4,
+       5,     6,     7,     8,     9,    63,    63,    63,    63,    59,
+      15,    63,    59,   184,    19,   180,   187,    63,    23,    24,
+      59,    41,   193,    28,    59,    30,    31,    32,    59,    63,
+      59,    33,    31,   247,   307,   193,   213,    42,   209,   120,
+       4,     5,     6,     7,     8,     9,   267,   127,    -1,    54,
+      -1,    -1,    -1,    -1,    -1,    -1,    61,   228,    63,    64,
+      65,    66,    67,   234,    69,    -1,    -1,    31,    32,    -1,
+     241,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    42,   250,
+     251,   258,   259,   254,   255,    -1,    -1,    -1,    -1,    -1,
+      54,    -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,    -1,
+      64,    65,   267,    67,    -1,    69,    -1,    -1,   279,    -1,
       -1,    -1,    -1,    -1,     0,     1,    -1,    -1,     4,     5,
-      -1,     7,    -1,     9,    10,    11,    12,    13,    -1,    -1,
-     311,   312,   313,    19,    20,    21,    -1,    -1,    24,    25,
-      26,    -1,    28,   324,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    41,    -1,    -1,    44,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,    59,    -1,    61,    -1,    63,    64,    65,
-      66,     1,    68,    -1,     4,    10,    11,     7,    -1,    -1,
-      -1,    -1,    -1,    13,    14,    15,    16,    17,    18,    19,
-      20,    21,    22,    23,    24,    25,    26,    27,    28,    29,
-      30,    31,    -1,    38,    39,    -1,    -1,    -1,    -1,    -1,
-      -1,    41,    -1,    -1,    -1,    50,    51,    52,    53,    54,
-      55,    56,    -1,    58,    -1,    -1,    -1,    -1,     1,    -1,
-      60,     4,    62,    -1,     7,    -1,    -1,    -1,    68,    -1,
-      13,    14,    15,    16,    17,    18,    19,    20,    21,    22,
+      -1,    -1,     8,    -1,    10,    11,    12,    13,    14,    -1,
+     301,   302,   303,    -1,    20,    21,    22,    -1,    -1,    25,
+      26,    27,   313,    29,    -1,    -1,    -1,    33,    34,    35,
+      36,    37,    38,    39,    40,    -1,    42,    -1,    -1,    45,
+      -1,    -1,    48,    49,    50,    51,    52,    53,    54,    55,
+      56,    57,    -1,    59,    60,    -1,    62,    63,    64,    65,
+      66,     1,    68,    -1,     4,     5,     6,     7,     8,     9,
+      -1,    -1,    -1,    -1,    -1,    15,    -1,    -1,    -1,    19,
+      -1,    -1,    -1,    23,    24,    -1,    -1,    -1,    28,    -1,
+      30,    31,    32,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    42,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    54,    -1,    -1,    -1,    -1,    -1,
+      -1,    61,    -1,    -1,    64,    65,    66,    67,     1,    69,
+      -1,     4,     5,     6,     7,     8,     9,    -1,    -1,    -1,
+      -1,    -1,    15,    -1,    -1,    -1,    19,    -1,    -1,    -1,
+      23,    24,    -1,    -1,    -1,    28,    -1,    30,    31,    32,
+      -1,    -1,     4,     5,     6,     7,     8,     9,    -1,    42,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     1,
+      -1,    54,     4,     5,     6,     7,     8,     9,    61,    31,
+      32,    64,    65,    15,    67,    -1,    69,    19,    -1,    -1,
+      42,    23,    24,    -1,    -1,    -1,    28,    -1,    30,    31,
+      32,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    61,
+      42,    -1,    64,    65,    -1,    67,    -1,    69,    -1,    -1,
+       1,    -1,    54,     4,     5,     6,     7,     8,     9,    61,
+      -1,    -1,    64,    65,    15,    67,    -1,    69,    19,    -1,
+      -1,    -1,    23,    24,    -1,    -1,    -1,    28,    -1,    30,
+      31,    32,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    42,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    54,    -1,    -1,    -1,    -1,    -1,    -1,
+      61,    -1,     1,    64,    65,     4,    67,     6,    69,     8,
+      -1,    11,    12,    -1,    -1,    14,    15,    16,    17,    18,
+      19,    20,    21,    22,    23,    24,    25,    26,    27,    28,
+      29,    30,    31,    -1,    -1,    -1,    -1,    -1,    -1,    39,
+      40,    -1,    -1,    42,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    51,    52,    53,    54,    55,    56,    57,     1,    59,
+      -1,     4,    61,     6,    -1,     8,    -1,    -1,    -1,    68,
+      -1,    14,    15,    16,    17,    18,    19,    20,    21,    22,
       23,    24,    25,    26,    27,    28,    29,    30,    31,     4,
-       5,     6,     7,     8,    -1,    -1,    -1,    -1,    41,    -1,
-      -1,     1,    -1,    -1,     4,     5,     6,     7,     8,    -1,
-      -1,    -1,    -1,    -1,    14,    30,    -1,    60,    18,    62,
-      -1,    -1,    22,    23,    -1,    68,    41,    27,    -1,    29,
-      30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    53,    -1,
-      -1,    41,    -1,    -1,    -1,    60,    -1,    62,    -1,    64,
-      65,    -1,    67,    53,     4,     5,     6,     7,     8,    -1,
-      60,    -1,    62,    -1,    64,    65,    66,    67,     1,    -1,
-      -1,     4,     5,     6,     7,     8,    -1,    -1,    -1,    -1,
-      30,    14,    -1,    -1,    -1,    18,    -1,    -1,    -1,    22,
-      23,    41,    -1,    -1,    27,    -1,    29,    30,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    41,    -1,
-      60,    -1,    62,    -1,    64,    65,    -1,    67,    -1,    -1,
-      53,    -1,    -1,    10,    11,    -1,    -1,    60,    -1,    62,
-      -1,    64,    65,     1,    67,    -1,     4,     5,     6,     7,
-       8,    -1,    -1,    -1,    -1,    -1,    14,    -1,    -1,    -1,
-      18,    38,    39,    -1,    22,    23,    -1,    -1,    -1,    27,
-      -1,    29,    30,    50,    51,    52,    53,    54,    55,    56,
-      -1,    58,    -1,    41,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    53,    -1,    -1,    -1,    -1,
-      -1,    -1,    60,    -1,    62,    -1,    64,    65,     1,    67,
-      -1,     4,     5,     6,     7,     8,    -1,    -1,    -1,    -1,
-      -1,    14,    -1,    -1,    -1,    18,    -1,    -1,    -1,    22,
-      23,    -1,    -1,    -1,    27,    -1,    29,    30,    -1,     4,
-       5,     6,     7,     8,    -1,    -1,    -1,    -1,    41,    14,
-      -1,    -1,    -1,    18,    -1,    -1,    -1,    22,    23,    -1,
-      53,    -1,    27,    -1,    29,    30,    -1,    60,    -1,    62,
-      -1,    64,    65,    -1,    67,    -1,    41,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    53,    -1,
-      -1,    -1,    -1,    -1,    59,    60,    -1,    62,    -1,    64,
-      65,    -1,    67,     4,     5,     6,     7,     8,    -1,    -1,
-      -1,    -1,    -1,    14,    -1,    -1,    -1,    18,    -1,    -1,
-      -1,    22,    23,    -1,    -1,    -1,    27,    -1,    29,    30,
-      -1,     4,     5,     6,     7,     8,    -1,    -1,    -1,    -1,
-      41,    14,    -1,    -1,    -1,    18,    -1,    -1,    -1,    22,
-      23,    -1,    53,    -1,    27,    -1,    29,    30,    -1,    60,
-      -1,    62,    -1,    64,    65,    66,    67,    -1,    41,    -1,
+       5,     6,     7,     8,     9,    -1,    -1,    -1,    -1,    42,
+      15,    -1,    -1,    -1,    19,    -1,    -1,    -1,    23,    24,
+      -1,    -1,    -1,    28,    -1,    30,    31,    32,    61,    -1,
+      -1,    -1,    -1,    -1,    -1,    68,    -1,    42,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    54,
+      -1,    -1,    -1,    -1,    -1,    60,    61,    -1,    -1,    64,
+      65,    -1,    67,    -1,    69,     4,     5,     6,     7,     8,
+       9,    -1,    -1,    -1,    -1,    -1,    15,    -1,    -1,    -1,
+      19,    -1,    -1,    -1,    23,    24,    -1,    -1,    -1,    28,
+      -1,    30,    31,    32,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    42,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    54,    -1,    -1,    -1,    -1,
+      11,    12,    61,    -1,    -1,    64,    65,    66,    67,    -1,
+      69,     4,     5,     6,     7,     8,     9,    -1,    -1,    -1,
+      -1,    -1,    15,    -1,    -1,    -1,    19,    -1,    39,    40,
+      23,    24,    -1,    -1,    -1,    28,    -1,    30,    31,    32,
+      51,    52,    53,    54,    55,    56,    57,    -1,    59,    42,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      53,    -1,    -1,    -1,    -1,    -1,    -1,    60,    -1,    62,
-      -1,    64,    65,    66,    67,     4,     5,     6,     7,     8,
-      -1,    -1,    -1,    -1,    -1,    14,    -1,    -1,    -1,    18,
-      -1,    -1,    -1,    22,    23,    -1,    -1,    -1,    27,    -1,
-      29,    30,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    41,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    53,    -1,    -1,    -1,    -1,    -1,
-      -1,    60,    -1,    62,     1,    64,    65,     4,    67,    -1,
-       7,    -1,    -1,    -1,    -1,    -1,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
-      27,    28,    29,    30,    31,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    41,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,     4,    -1,    -1,
-      -1,    -1,    -1,    60,    -1,    62,    13,    14,    15,    16,
-      17,    18,    19,    20,    21,    22,    23,    24,    25,    26,
-      27,    28,    29,    30,    31,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,     9,    10,    11,    12,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    62,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,     9,    10,    11,    12,    63,    -1,    -1,
-      66,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,     9,    10,    11,    12,    -1,    -1,    -1,
-      66,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,     9,    10,    11,    12,    -1,    -1,    -1,
-      66,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,     9,    10,    11,    12,    -1,    -1,    -1,
-      66,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,     9,    10,    11,    12,    -1,    -1,    -1,
-      66,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,
-      26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,
-      36,    37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    58,    59,    -1,    61,     9,    10,    11,    12,
+      -1,    54,    -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,
+      -1,    64,    65,    66,    67,    -1,    69,     4,     5,     6,
+       7,     8,     9,    -1,    -1,    -1,    -1,    -1,    15,    -1,
+      -1,    -1,    19,    -1,    -1,    -1,    23,    24,    -1,    -1,
+      -1,    28,    -1,    30,    31,    32,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    42,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    54,    -1,    -1,
+      -1,    -1,    -1,    -1,    61,    -1,     1,    64,    65,     4,
+      67,     6,    69,     8,    -1,    -1,    -1,    -1,    -1,    14,
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,    26,    27,    28,    29,    30,    31,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    42,    10,    11,
+      12,    13,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    26,    27,    61,    -1,    -1,    -1,
+      -1,    33,    34,    35,    36,    37,    38,    39,    40,    -1,
+      -1,    -1,    10,    11,    12,    13,    48,    49,    50,    51,
+      52,    53,    54,    55,    56,    57,    -1,    59,    26,    27,
+      -1,    63,    -1,    -1,    66,    33,    34,    35,    36,    37,
+      38,    39,    40,    -1,    -1,    -1,    10,    11,    12,    13,
+      48,    49,    50,    51,    52,    53,    54,    55,    56,    57,
+      -1,    59,    26,    27,    -1,    -1,    -1,    -1,    66,    33,
+      34,    35,    36,    37,    38,    39,    40,    -1,    -1,    -1,
+      10,    11,    12,    13,    48,    49,    50,    51,    52,    53,
+      54,    55,    56,    57,    -1,    59,    26,    27,    -1,    -1,
+      -1,    -1,    66,    33,    34,    35,    36,    37,    38,    39,
+      40,    -1,    -1,    -1,    10,    11,    12,    13,    48,    49,
+      50,    51,    52,    53,    54,    55,    56,    57,    -1,    59,
+      26,    27,    -1,    -1,    -1,    -1,    66,    33,    34,    35,
+      36,    37,    38,    39,    40,    -1,    -1,    -1,    10,    11,
+      12,    13,    48,    49,    50,    51,    52,    53,    54,    55,
+      56,    57,    -1,    59,    26,    27,    -1,    -1,    -1,    -1,
+      66,    33,    34,    35,    36,    37,    38,    39,    40,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    48,    49,    50,    51,
+      52,    53,    54,    55,    56,    57,    -1,    59,    60,    -1,
+      62,    10,    11,    12,    13,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,    27,    -1,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    -1,    -1,    -1,    10,    11,    12,    13,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    -1,
+      59,    26,    27,    62,    -1,    -1,    -1,    -1,    33,    34,
+      35,    36,    37,    38,    39,    40,    -1,    -1,    -1,    10,
+      11,    12,    13,    48,    49,    50,    51,    52,    53,    54,
+      55,    56,    57,    -1,    59,    26,    27,    62,    -1,    -1,
+      -1,    -1,    33,    34,    35,    36,    37,    38,    39,    40,
+      -1,    -1,    -1,    10,    11,    12,    13,    48,    49,    50,
+      51,    52,    53,    54,    55,    56,    57,    -1,    59,    26,
+      27,    62,    -1,    -1,    -1,    -1,    33,    34,    35,    36,
+      37,    38,    39,    40,    -1,    -1,    -1,    10,    11,    12,
+      13,    48,    49,    50,    51,    52,    53,    54,    55,    56,
+      57,    -1,    59,    26,    27,    62,    -1,    -1,    -1,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    -1,    -1,
+      -1,    10,    11,    12,    13,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    -1,    59,    26,    27,    62,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    -1,
+      59,    60,    10,    11,    12,    13,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,    27,
+      -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,
+      38,    39,    40,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      48,    49,    50,    51,    52,    53,    54,    55,    56,    57,
+      -1,    59,    60,    10,    11,    12,    13,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    26,
+      27,    -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,
+      37,    38,    39,    40,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    48,    49,    50,    51,    52,    53,    54,    55,    56,
+      57,    -1,    59,    60,    10,    11,    12,    13,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    25,    26,    -1,    -1,    -1,    -1,    -1,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
-       9,    10,    11,    12,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    58,    25,    26,    61,    -1,
-      -1,    -1,    -1,    32,    33,    34,    35,    36,    37,    38,
-      39,    -1,    -1,    -1,     9,    10,    11,    12,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    -1,    58,
-      25,    26,    61,    -1,    -1,    -1,    -1,    32,    33,    34,
-      35,    36,    37,    38,    39,    -1,    -1,    -1,     9,    10,
-      11,    12,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    -1,    58,    25,    26,    61,    -1,    -1,    -1,
-      -1,    32,    33,    34,    35,    36,    37,    38,    39,    -1,
-      -1,    -1,     9,    10,    11,    12,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    -1,    58,    25,    26,
-      61,    -1,    -1,    -1,    -1,    32,    33,    34,    35,    36,
-      37,    38,    39,    -1,    -1,    -1,     9,    10,    11,    12,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      -1,    58,    25,    26,    61,    -1,    -1,    -1,    -1,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    58,    59,     9,    10,    11,
-      12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    25,    26,    -1,    -1,    -1,    -1,    -1,
-      32,    33,    34,    35,    36,    37,    38,    39,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    47,    48,    49,    50,    51,
-      52,    53,    54,    55,    56,    -1,    58,    59,     9,    10,
-      11,    12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    25,    26,    -1,    -1,    -1,    -1,
-      -1,    32,    33,    34,    35,    36,    37,    38,    39,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    -1,    58,    59,     9,
-      10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    25,    26,    -1,    -1,    -1,
-      -1,    -1,    32,    33,    34,    35,    36,    37,    38,    39,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    47,    48,    49,
-      50,    51,    52,    53,    54,    55,    56,    -1,    58,    59,
-       9,    10,    11,    12,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    25,    26,    -1,    -1,
-      -1,    -1,    -1,    32,    33,    34,    35,    36,    37,    38,
-      39,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    -1,    58,
-      59,     9,    10,    11,    12,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    25,    26,    -1,
-      -1,    -1,    -1,    -1,    32,    33,    34,    35,    36,    37,
-      38,    39,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    47,
-      48,    49,    50,    51,    52,    53,    54,    55,    56,    -1,
-      58,    59,     9,    10,    11,    12,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    20,    21,    -1,    -1,    24,    25,    26,
-      -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,    36,
-      37,    38,    39,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      -1,    58,     9,    10,    11,    12,    -1,    -1,    -1,    -1,
-      -1,    -1,    19,    -1,    -1,    -1,    -1,    -1,    25,    26,
-      -1,    -1,    -1,    -1,    -1,    32,    33,    34,    35,    36,
-      37,    38,    39,    -1,    -1,    -1,     9,    10,    11,    12,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      -1,    58,    25,    26,    -1,    -1,    -1,    -1,    -1,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
-      -1,    44,    -1,    -1,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    58,     9,    10,    11,    12,
+      26,    27,    -1,    -1,    -1,    -1,    -1,    33,    34,    35,
+      36,    37,    38,    39,    40,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    48,    49,    50,    51,    52,    53,    54,    55,
+      56,    57,    -1,    59,    60,    10,    11,    12,    13,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    24,    25,    26,    -1,    -1,    -1,    -1,    -1,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    58,     9,    10,    11,    12,
-      -1,    -1,    -1,    -1,    -1,    -1,    19,    -1,    -1,    -1,
-      -1,    -1,    25,    26,    -1,    -1,    -1,    -1,    -1,    32,
-      33,    34,    35,    36,    37,    38,    39,    -1,    -1,    -1,
-       9,    10,    11,    12,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    58,    25,    26,    -1,    -1,
-      -1,    -1,    -1,    32,    33,    34,    35,    36,    37,    38,
-      39,    -1,    -1,    -1,     9,    10,    11,    -1,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    -1,    58,
-      25,    26,    -1,    -1,    -1,    -1,    -1,    32,    33,    34,
-      35,    36,    37,    38,    39,    -1,    -1,    10,    11,    -1,
-      -1,    -1,    -1,    -1,    49,    50,    51,    52,    53,    54,
-      55,    56,    25,    58,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    38,    39,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,    51,    52,
-      53,    54,    55,    56,     4,    58,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    13,    14,    15,    16,    17,    18,    19,
-      20,    21,    22,    23,    24,    25,    26,    27,    28,    29,
-      30,    31,     4,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    13,    14,    15,    16,    17,    18,    19,    20,    21,
-      22,    23,    24,    25,    26,    27,    28,    29,    30,    31
+      -1,    26,    27,    -1,    -1,    -1,    -1,    -1,    33,    34,
+      35,    36,    37,    38,    39,    40,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    48,    49,    50,    51,    52,    53,    54,
+      55,    56,    57,    -1,    59,    60,    10,    11,    12,    13,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    26,    27,    -1,    -1,    -1,    -1,    -1,    33,
+      34,    35,    36,    37,    38,    39,    40,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    48,    49,    50,    51,    52,    53,
+      54,    55,    56,    57,    -1,    59,    60,    10,    11,    12,
+      13,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    21,    22,
+      -1,    -1,    25,    26,    27,    -1,    -1,    -1,    -1,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    -1,    59,    10,    11,    12,
+      13,    -1,    -1,    -1,    -1,    -1,    -1,    20,    -1,    -1,
+      -1,    -1,    -1,    26,    27,    -1,    -1,    -1,    -1,    -1,
+      33,    34,    35,    36,    37,    38,    39,    40,    -1,    -1,
+      -1,    10,    11,    12,    13,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    -1,    59,    26,    27,    -1,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    -1,    -1,    -1,    -1,    45,    -1,    -1,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    -1,
+      59,    10,    11,    12,    13,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    25,    26,    27,    -1,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    -1,
+      59,    10,    11,    12,    13,    -1,    -1,    -1,    -1,    -1,
+      -1,    20,    -1,    -1,    -1,    -1,    -1,    26,    27,    -1,
+      -1,    -1,    -1,    -1,    33,    34,    35,    36,    37,    38,
+      39,    40,    -1,    -1,    -1,    10,    11,    12,    13,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    -1,
+      59,    26,    27,    -1,    -1,    -1,    -1,    -1,    33,    34,
+      35,    36,    37,    38,    39,    40,    -1,    -1,    -1,    10,
+      11,    12,    13,    48,    49,    50,    51,    52,    53,    54,
+      55,    56,    57,    -1,    59,    26,    27,    -1,    -1,    -1,
+      -1,    -1,    33,    34,    35,    36,    37,    38,    39,    40,
+      -1,    -1,    -1,    10,    11,    12,    -1,    -1,    -1,    50,
+      51,    52,    53,    54,    55,    56,    57,    -1,    59,    26,
+      27,    -1,    -1,    -1,    -1,    -1,    33,    34,    35,    36,
+      37,    38,    39,    40,    -1,    -1,    11,    12,    -1,    -1,
+      -1,    -1,    -1,    50,    51,    52,    53,    54,    55,    56,
+      57,    26,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    39,    40,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    51,    52,    53,    54,
+      55,    56,    57,    -1,    59
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,    15,    70,    71,     4,     5,     6,     7,     8,    14,
-      18,    22,    23,    27,    29,    30,    41,    53,    60,    62,
-      64,    65,    67,    74,    78,    81,    87,     0,    16,    17,
-      72,    75,    76,    60,    58,    41,     4,    74,    87,    87,
-      74,    62,     1,    62,    82,    74,     1,    74,     4,    13,
+       0,    16,    71,    72,     4,     5,     6,     7,     8,     9,
+      15,    19,    23,    24,    28,    30,    31,    32,    42,    54,
+      61,    64,    65,    67,    69,    75,    79,    82,    88,     0,
+      17,    18,    73,    76,    77,    61,    59,    42,     4,    75,
+      88,    88,    75,     6,     1,     6,    83,    75,     1,    75,
+       1,     4,     8,    82,     1,    66,    75,     1,     4,     6,
       14,    15,    16,    17,    18,    19,    20,    21,    22,    23,
-      24,    25,    26,    27,    28,    29,    30,    31,    62,    96,
-       1,     4,     7,    81,     1,    66,    74,     1,     4,    60,
-      62,    81,    96,    97,    98,     9,    10,    11,    12,    25,
-      26,    32,    33,    34,    35,    36,    37,    38,    39,    47,
-      48,    49,    50,    51,    52,    53,    54,    55,    56,    58,
-      59,    74,     5,    13,    64,    65,    77,    81,    77,    73,
-      74,    78,    72,    59,    74,    74,    88,    89,    83,    60,
-      63,    19,    13,    13,    28,     4,     4,    84,    61,    61,
-      62,     1,    58,    66,    66,    48,    63,    68,    63,    74,
-       4,    96,    63,    63,    68,    48,    74,    74,    74,    74,
-      74,    74,    74,    74,    74,    74,    74,    74,    74,    74,
-      74,    74,    74,    74,    74,    74,    74,    74,    74,    74,
-      58,    62,    65,    67,    90,    91,    92,    65,    81,     1,
-      63,    66,    74,    13,    73,    59,    59,    61,    84,     4,
-      62,    79,    80,    74,     1,    74,    91,    91,     1,    74,
-      47,    42,    43,    45,    62,     1,    97,    53,    86,    87,
-      86,    61,    63,    86,    86,    97,     4,    92,    93,     1,
-       4,    60,    62,    81,    94,    95,    96,    40,    47,    66,
-      74,    58,    66,    74,    58,    63,    66,     4,    62,    89,
-      45,     4,    96,    59,    61,    59,    20,    21,    24,    85,
-      60,    60,    74,    74,     4,    86,    47,    63,    86,    48,
-      66,    63,    63,    74,     4,    63,    48,    68,    63,    92,
-      74,    58,    66,    66,    66,    74,    58,     4,    80,    63,
-      74,    74,    74,    74,    44,    86,    86,    92,    92,    92,
-      61,    63,    92,    95,    92,    58,    58,    58,    66,    74,
-      24,    19,    59,    59,    63,    92,    58,    59,    74,    74,
-      74,    92,    85,    61,    59,    61,    74,    61
+      24,    25,    26,    27,    28,    29,    30,    31,    61,    82,
+      97,    98,    99,    69,    10,    11,    12,    13,    26,    27,
+      33,    34,    35,    36,    37,    38,    39,    40,    48,    49,
+      50,    51,    52,    53,    54,    55,    56,    57,    59,    60,
+      75,     5,    14,    64,    65,    78,    82,    78,    74,    75,
+      79,    73,    60,    75,    75,    89,    90,    84,    61,    63,
+      20,    14,    14,    29,    48,    85,    62,    62,     1,    59,
+      66,    66,    49,    63,    68,    63,    63,    75,    63,    63,
+      68,    49,    69,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    75,    59,     6,    65,
+      67,    91,    92,    93,    65,    82,     1,    63,    66,    75,
+      14,    74,    60,    60,    62,    85,     4,     6,    80,    81,
+      75,     1,    75,    92,    92,     1,    75,    75,    43,    44,
+      46,     1,    98,    54,    87,    88,    87,    87,    62,    87,
+      87,    98,     6,    93,    94,     1,     4,     6,    61,    82,
+      95,    96,    97,    41,    48,    66,    75,    59,    66,    75,
+      59,    63,    66,     4,     6,    90,    46,    60,    62,    60,
+      21,    22,    25,    86,    61,    61,    75,    87,    48,    63,
+      49,    66,    63,    63,    63,    75,    63,    49,    68,    63,
+      93,    75,    59,    66,    66,    66,    75,    59,    81,    63,
+      75,    75,    75,    75,    45,    87,    87,    93,    93,    93,
+      93,    62,    93,    96,    93,    59,    59,    59,    66,    75,
+      25,    20,    60,    60,    63,    59,    60,    75,    75,    75,
+      93,    86,    62,    60,    62,    75,    62
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    69,    70,    70,    71,    71,    72,    72,    73,    73,
-      74,    74,    74,    74,    74,    74,    74,    74,    74,    74,
-      74,    74,    74,    74,    74,    74,    74,    74,    74,    74,
-      74,    74,    74,    74,    74,    74,    74,    74,    74,    74,
-      74,    74,    74,    74,    74,    74,    74,    74,    75,    75,
-      76,    76,    76,    77,    78,    78,    79,    79,    80,    80,
-      80,    82,    81,    83,    81,    84,    84,    84,    85,    85,
-      85,    86,    86,    86,    87,    87,    87,    87,    87,    87,
-      87,    87,    87,    87,    87,    87,    87,    87,    87,    87,
-      87,    87,    87,    87,    87,    87,    87,    87,    87,    87,
-      87,    87,    87,    87,    87,    87,    87,    87,    87,    87,
-      87,    87,    87,    87,    87,    87,    87,    87,    88,    88,
-      89,    90,    90,    91,    91,    92,    92,    92,    93,    93,
-      94,    94,    95,    95,    95,    95,    95,    95,    95,    96,
-      96,    96,    96,    96,    96,    96,    96,    96,    96,    96,
-      96,    96,    96,    96,    96,    96,    96,    96,    97,    97,
-      97,    97,    98,    98,    98,    98,    98,    98,    98,    98,
-      98,    98,    98
+       0,    70,    71,    71,    72,    72,    73,    73,    74,    74,
+      75,    75,    75,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    75,    75,    76,    76,
+      77,    77,    77,    78,    79,    79,    80,    80,    81,    81,
+      83,    82,    84,    82,    85,    85,    85,    86,    86,    86,
+      87,    87,    87,    88,    88,    88,    88,    88,    88,    88,
+      88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
+      88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
+      88,    88,    88,    88,    88,    88,    88,    88,    88,    88,
+      88,    88,    88,    88,    88,    88,    88,    89,    89,    90,
+      91,    91,    92,    92,    93,    93,    93,    94,    94,    95,
+      95,    96,    96,    96,    96,    96,    96,    96,    97,    97,
+      97,    97,    97,    97,    97,    97,    97,    97,    97,    97,
+      97,    97,    97,    97,    97,    97,    98,    98,    98,    98,
+      99,    99,    99,    99,    99,    99,    99,    99,    99,    99
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -1629,22 +1603,21 @@ static const yytype_int8 yyr2[] =
 {
        0,     2,     3,     3,     0,     3,     0,     2,     0,     2,
        2,     5,     9,    11,     9,     5,     4,     4,     2,     4,
-       5,     2,     3,     3,     3,     3,     3,     3,     3,     3,
+       4,     2,     3,     3,     3,     3,     3,     3,     3,     3,
        3,     3,     2,     3,     3,     3,     3,     3,     3,     3,
        3,     3,     3,     3,     3,     3,     3,     1,     2,     3,
-       5,     4,     2,     1,     5,     8,     1,     3,     2,     2,
-       1,     0,     4,     0,     5,     0,     2,     4,     5,     3,
-       1,     3,     2,     1,     1,     1,     3,     2,     3,     2,
-       4,     3,     2,     1,     3,     2,     2,     3,     5,     4,
-       6,     5,     4,     3,     5,     4,     7,     6,     6,     6,
-       5,     5,     1,     1,     1,     3,     3,     2,     3,     5,
-       2,     2,     1,     4,     3,     3,     4,     3,     1,     3,
-       1,     3,     1,     3,     1,     2,     3,     3,     1,     3,
-       1,     3,     2,     4,     3,     3,     3,     5,     3,     1,
+       4,     4,     2,     1,     5,     8,     1,     3,     1,     1,
+       0,     4,     0,     5,     0,     2,     4,     5,     3,     1,
+       3,     2,     1,     1,     1,     2,     2,     3,     2,     4,
+       3,     2,     1,     3,     2,     2,     3,     5,     4,     6,
+       5,     4,     3,     5,     4,     7,     6,     6,     6,     5,
+       5,     1,     1,     1,     3,     3,     2,     3,     4,     1,
+       1,     1,     4,     3,     3,     4,     3,     1,     3,     1,
+       3,     1,     3,     1,     1,     3,     3,     1,     3,     1,
+       3,     1,     3,     3,     3,     3,     5,     3,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     0,     1,
-       3,     3,     3,     3,     3,     1,     4,     2,     2,     1,
-       1,     5,     3
+       1,     1,     1,     1,     1,     1,     0,     1,     3,     3,
+       3,     3,     3,     1,     3,     1,     1,     1,     5,     3
 };
 
 
@@ -2214,187 +2187,193 @@ yydestruct (const char *yymsg,
     case YYSYMBOL_IDENT: /* IDENT  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2218 "src/parser.c"
+#line 2191 "src/parser.c"
         break;
 
     case YYSYMBOL_FIELD: /* FIELD  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2224 "src/parser.c"
+#line 2197 "src/parser.c"
+        break;
+
+    case YYSYMBOL_BINDING: /* BINDING  */
+#line 36 "src/parser.y"
+            { jv_free(((*yyvaluep).literal)); }
+#line 2203 "src/parser.c"
         break;
 
     case YYSYMBOL_LITERAL: /* LITERAL  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2230 "src/parser.c"
+#line 2209 "src/parser.c"
         break;
 
     case YYSYMBOL_FORMAT: /* FORMAT  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2236 "src/parser.c"
+#line 2215 "src/parser.c"
         break;
 
     case YYSYMBOL_QQSTRING_TEXT: /* QQSTRING_TEXT  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2242 "src/parser.c"
+#line 2221 "src/parser.c"
         break;
 
     case YYSYMBOL_Module: /* Module  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2248 "src/parser.c"
+#line 2227 "src/parser.c"
         break;
 
     case YYSYMBOL_Imports: /* Imports  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2254 "src/parser.c"
+#line 2233 "src/parser.c"
         break;
 
     case YYSYMBOL_FuncDefs: /* FuncDefs  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2260 "src/parser.c"
+#line 2239 "src/parser.c"
         break;
 
     case YYSYMBOL_Exp: /* Exp  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2266 "src/parser.c"
+#line 2245 "src/parser.c"
         break;
 
     case YYSYMBOL_Import: /* Import  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2272 "src/parser.c"
+#line 2251 "src/parser.c"
         break;
 
     case YYSYMBOL_ImportWhat: /* ImportWhat  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2278 "src/parser.c"
+#line 2257 "src/parser.c"
         break;
 
     case YYSYMBOL_ImportFrom: /* ImportFrom  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2284 "src/parser.c"
+#line 2263 "src/parser.c"
         break;
 
     case YYSYMBOL_FuncDef: /* FuncDef  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2290 "src/parser.c"
+#line 2269 "src/parser.c"
         break;
 
     case YYSYMBOL_Params: /* Params  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2296 "src/parser.c"
+#line 2275 "src/parser.c"
         break;
 
     case YYSYMBOL_Param: /* Param  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2302 "src/parser.c"
+#line 2281 "src/parser.c"
         break;
 
     case YYSYMBOL_String: /* String  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2308 "src/parser.c"
+#line 2287 "src/parser.c"
         break;
 
     case YYSYMBOL_QQString: /* QQString  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2314 "src/parser.c"
+#line 2293 "src/parser.c"
         break;
 
     case YYSYMBOL_ElseBody: /* ElseBody  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2320 "src/parser.c"
+#line 2299 "src/parser.c"
         break;
 
     case YYSYMBOL_ExpD: /* ExpD  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2326 "src/parser.c"
+#line 2305 "src/parser.c"
         break;
 
     case YYSYMBOL_Term: /* Term  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2332 "src/parser.c"
+#line 2311 "src/parser.c"
         break;
 
     case YYSYMBOL_Args: /* Args  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2338 "src/parser.c"
+#line 2317 "src/parser.c"
         break;
 
     case YYSYMBOL_Arg: /* Arg  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2344 "src/parser.c"
+#line 2323 "src/parser.c"
         break;
 
     case YYSYMBOL_RepPatterns: /* RepPatterns  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2350 "src/parser.c"
+#line 2329 "src/parser.c"
         break;
 
     case YYSYMBOL_Patterns: /* Patterns  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2356 "src/parser.c"
+#line 2335 "src/parser.c"
         break;
 
     case YYSYMBOL_Pattern: /* Pattern  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2362 "src/parser.c"
+#line 2341 "src/parser.c"
         break;
 
     case YYSYMBOL_ArrayPats: /* ArrayPats  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2368 "src/parser.c"
+#line 2347 "src/parser.c"
         break;
 
     case YYSYMBOL_ObjPats: /* ObjPats  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2374 "src/parser.c"
+#line 2353 "src/parser.c"
         break;
 
     case YYSYMBOL_ObjPat: /* ObjPat  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2380 "src/parser.c"
+#line 2359 "src/parser.c"
         break;
 
     case YYSYMBOL_Keyword: /* Keyword  */
 #line 36 "src/parser.y"
             { jv_free(((*yyvaluep).literal)); }
-#line 2386 "src/parser.c"
+#line 2365 "src/parser.c"
         break;
 
     case YYSYMBOL_MkDict: /* MkDict  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2392 "src/parser.c"
+#line 2371 "src/parser.c"
         break;
 
     case YYSYMBOL_MkDictPair: /* MkDictPair  */
 #line 37 "src/parser.y"
             { block_free(((*yyvaluep).blk)); }
-#line 2398 "src/parser.c"
+#line 2377 "src/parser.c"
         break;
 
       default:
@@ -2698,31 +2677,31 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* TopLevel: Module Imports Exp  */
-#line 306 "src/parser.y"
+#line 307 "src/parser.y"
                    {
   *answer = BLOCK((yyvsp[-2].blk), (yyvsp[-1].blk), gen_op_simple(TOP), (yyvsp[0].blk));
 }
-#line 2706 "src/parser.c"
+#line 2685 "src/parser.c"
     break;
 
   case 3: /* TopLevel: Module Imports FuncDefs  */
-#line 309 "src/parser.y"
+#line 310 "src/parser.y"
                         {
   *answer = BLOCK((yyvsp[-2].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2714 "src/parser.c"
+#line 2693 "src/parser.c"
     break;
 
   case 4: /* Module: %empty  */
-#line 314 "src/parser.y"
+#line 315 "src/parser.y"
        {
   (yyval.blk) = gen_noop();
 }
-#line 2722 "src/parser.c"
+#line 2701 "src/parser.c"
     break;
 
   case 5: /* Module: "module" Exp ';'  */
-#line 317 "src/parser.y"
+#line 318 "src/parser.y"
                  {
   if (!block_is_const((yyvsp[-1].blk))) {
     FAIL((yyloc), "Module metadata must be constant");
@@ -2736,366 +2715,366 @@ yyreduce:
     (yyval.blk) = gen_module((yyvsp[-1].blk));
   }
 }
-#line 2740 "src/parser.c"
+#line 2719 "src/parser.c"
     break;
 
   case 6: /* Imports: %empty  */
-#line 332 "src/parser.y"
+#line 333 "src/parser.y"
        {
   (yyval.blk) = gen_noop();
 }
-#line 2748 "src/parser.c"
+#line 2727 "src/parser.c"
     break;
 
   case 7: /* Imports: Import Imports  */
-#line 335 "src/parser.y"
+#line 336 "src/parser.y"
                {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2756 "src/parser.c"
+#line 2735 "src/parser.c"
     break;
 
   case 8: /* FuncDefs: %empty  */
-#line 340 "src/parser.y"
+#line 341 "src/parser.y"
        {
   (yyval.blk) = gen_noop();
 }
-#line 2764 "src/parser.c"
+#line 2743 "src/parser.c"
     break;
 
   case 9: /* FuncDefs: FuncDef FuncDefs  */
-#line 343 "src/parser.y"
+#line 344 "src/parser.y"
                  {
   (yyval.blk) = block_join((yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2772 "src/parser.c"
+#line 2751 "src/parser.c"
     break;
 
   case 10: /* Exp: FuncDef Exp  */
-#line 348 "src/parser.y"
+#line 349 "src/parser.y"
                           {
   (yyval.blk) = block_bind_referenced((yyvsp[-1].blk), (yyvsp[0].blk), OP_IS_CALL_PSEUDO);
 }
-#line 2780 "src/parser.c"
+#line 2759 "src/parser.c"
     break;
 
   case 11: /* Exp: Term "as" Patterns '|' Exp  */
-#line 352 "src/parser.y"
+#line 353 "src/parser.y"
                            {
   (yyval.blk) = gen_destructure((yyvsp[-4].blk), (yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2788 "src/parser.c"
+#line 2767 "src/parser.c"
     break;
 
   case 12: /* Exp: "reduce" Term "as" Patterns '(' Exp ';' Exp ')'  */
-#line 355 "src/parser.y"
+#line 356 "src/parser.y"
                                                 {
   (yyval.blk) = gen_reduce((yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 2796 "src/parser.c"
+#line 2775 "src/parser.c"
     break;
 
   case 13: /* Exp: "foreach" Term "as" Patterns '(' Exp ';' Exp ';' Exp ')'  */
-#line 359 "src/parser.y"
+#line 360 "src/parser.y"
                                                          {
   (yyval.blk) = gen_foreach((yyvsp[-9].blk), (yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 2804 "src/parser.c"
+#line 2783 "src/parser.c"
     break;
 
   case 14: /* Exp: "foreach" Term "as" Patterns '(' Exp ';' Exp ')'  */
-#line 363 "src/parser.y"
+#line 364 "src/parser.y"
                                                  {
   (yyval.blk) = gen_foreach((yyvsp[-7].blk), (yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk), gen_noop());
 }
-#line 2812 "src/parser.c"
+#line 2791 "src/parser.c"
     break;
 
   case 15: /* Exp: "if" Exp "then" Exp ElseBody  */
-#line 367 "src/parser.y"
+#line 368 "src/parser.y"
                              {
   (yyval.blk) = gen_cond((yyvsp[-3].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 2820 "src/parser.c"
+#line 2799 "src/parser.c"
     break;
 
   case 16: /* Exp: "if" Exp "then" error  */
-#line 370 "src/parser.y"
+#line 371 "src/parser.y"
                       {
   FAIL((yyloc), "Possibly unterminated 'if' statement");
   (yyval.blk) = (yyvsp[-2].blk);
 }
-#line 2829 "src/parser.c"
+#line 2808 "src/parser.c"
     break;
 
   case 17: /* Exp: "try" Exp "catch" Exp  */
-#line 375 "src/parser.y"
+#line 376 "src/parser.y"
                       {
   //$$ = BLOCK(gen_op_target(FORK_OPT, $2), $2, $4);
   (yyval.blk) = gen_try((yyvsp[-2].blk), gen_try_handler((yyvsp[0].blk)));
 }
-#line 2838 "src/parser.c"
+#line 2817 "src/parser.c"
     break;
 
   case 18: /* Exp: "try" Exp  */
-#line 379 "src/parser.y"
+#line 380 "src/parser.y"
           {
   //$$ = BLOCK(gen_op_target(FORK_OPT, $2), $2, gen_op_simple(BACKTRACK));
   (yyval.blk) = gen_try((yyvsp[0].blk), gen_op_simple(BACKTRACK));
 }
-#line 2847 "src/parser.c"
+#line 2826 "src/parser.c"
     break;
 
   case 19: /* Exp: "try" Exp "catch" error  */
-#line 383 "src/parser.y"
+#line 384 "src/parser.y"
                         {
   FAIL((yyloc), "Possibly unterminated 'try' statement");
   (yyval.blk) = (yyvsp[-2].blk);
 }
-#line 2856 "src/parser.c"
+#line 2835 "src/parser.c"
     break;
 
-  case 20: /* Exp: "label" '$' IDENT '|' Exp  */
-#line 388 "src/parser.y"
-                          {
+  case 20: /* Exp: "label" BINDING '|' Exp  */
+#line 389 "src/parser.y"
+                        {
   jv v = jv_string_fmt("*label-%s", jv_string_value((yyvsp[-2].literal)));
   (yyval.blk) = gen_location((yyloc), locations, gen_label(jv_string_value(v), (yyvsp[0].blk)));
   jv_free((yyvsp[-2].literal));
   jv_free(v);
 }
-#line 2867 "src/parser.c"
+#line 2846 "src/parser.c"
     break;
 
   case 21: /* Exp: Exp '?'  */
-#line 395 "src/parser.y"
+#line 396 "src/parser.y"
         {
   (yyval.blk) = gen_try((yyvsp[-1].blk), gen_op_simple(BACKTRACK));
 }
-#line 2875 "src/parser.c"
+#line 2854 "src/parser.c"
     break;
 
   case 22: /* Exp: Exp '=' Exp  */
-#line 399 "src/parser.y"
+#line 400 "src/parser.y"
             {
   (yyval.blk) = gen_call("_assign", BLOCK(gen_lambda((yyvsp[-2].blk)), gen_lambda((yyvsp[0].blk))));
 }
-#line 2883 "src/parser.c"
+#line 2862 "src/parser.c"
     break;
 
   case 23: /* Exp: Exp "or" Exp  */
-#line 403 "src/parser.y"
+#line 404 "src/parser.y"
              {
   (yyval.blk) = gen_or((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2891 "src/parser.c"
+#line 2870 "src/parser.c"
     break;
 
   case 24: /* Exp: Exp "and" Exp  */
-#line 407 "src/parser.y"
+#line 408 "src/parser.y"
               {
   (yyval.blk) = gen_and((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2899 "src/parser.c"
+#line 2878 "src/parser.c"
     break;
 
   case 25: /* Exp: Exp "//" Exp  */
-#line 411 "src/parser.y"
+#line 412 "src/parser.y"
              {
   (yyval.blk) = gen_definedor((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2907 "src/parser.c"
+#line 2886 "src/parser.c"
     break;
 
   case 26: /* Exp: Exp "//=" Exp  */
-#line 415 "src/parser.y"
+#line 416 "src/parser.y"
               {
   (yyval.blk) = gen_definedor_assign((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2915 "src/parser.c"
+#line 2894 "src/parser.c"
     break;
 
   case 27: /* Exp: Exp "|=" Exp  */
-#line 419 "src/parser.y"
+#line 420 "src/parser.y"
              {
   (yyval.blk) = gen_call("_modify", BLOCK(gen_lambda((yyvsp[-2].blk)), gen_lambda((yyvsp[0].blk))));
 }
-#line 2923 "src/parser.c"
+#line 2902 "src/parser.c"
     break;
 
   case 28: /* Exp: Exp '|' Exp  */
-#line 423 "src/parser.y"
+#line 424 "src/parser.y"
             {
   (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2931 "src/parser.c"
+#line 2910 "src/parser.c"
     break;
 
   case 29: /* Exp: Exp ',' Exp  */
-#line 427 "src/parser.y"
+#line 428 "src/parser.y"
             {
   (yyval.blk) = gen_both((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 2939 "src/parser.c"
+#line 2918 "src/parser.c"
     break;
 
   case 30: /* Exp: Exp '+' Exp  */
-#line 431 "src/parser.y"
+#line 432 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '+');
 }
-#line 2947 "src/parser.c"
+#line 2926 "src/parser.c"
     break;
 
   case 31: /* Exp: Exp "+=" Exp  */
-#line 435 "src/parser.y"
+#line 436 "src/parser.y"
              {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '+');
 }
-#line 2955 "src/parser.c"
+#line 2934 "src/parser.c"
     break;
 
   case 32: /* Exp: '-' Exp  */
-#line 439 "src/parser.y"
+#line 440 "src/parser.y"
         {
   (yyval.blk) = BLOCK((yyvsp[0].blk), gen_call("_negate", gen_noop()));
 }
-#line 2963 "src/parser.c"
+#line 2942 "src/parser.c"
     break;
 
   case 33: /* Exp: Exp '-' Exp  */
-#line 443 "src/parser.y"
+#line 444 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '-');
 }
-#line 2971 "src/parser.c"
+#line 2950 "src/parser.c"
     break;
 
   case 34: /* Exp: Exp "-=" Exp  */
-#line 447 "src/parser.y"
+#line 448 "src/parser.y"
              {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '-');
 }
-#line 2979 "src/parser.c"
+#line 2958 "src/parser.c"
     break;
 
   case 35: /* Exp: Exp '*' Exp  */
-#line 451 "src/parser.y"
+#line 452 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '*');
 }
-#line 2987 "src/parser.c"
+#line 2966 "src/parser.c"
     break;
 
   case 36: /* Exp: Exp "*=" Exp  */
-#line 455 "src/parser.y"
+#line 456 "src/parser.y"
              {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '*');
 }
-#line 2995 "src/parser.c"
+#line 2974 "src/parser.c"
     break;
 
   case 37: /* Exp: Exp '/' Exp  */
-#line 459 "src/parser.y"
+#line 460 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '/');
   if (block_is_const_inf((yyval.blk)))
     FAIL((yyloc), "Division by zero?");
 }
-#line 3005 "src/parser.c"
+#line 2984 "src/parser.c"
     break;
 
   case 38: /* Exp: Exp '%' Exp  */
-#line 465 "src/parser.y"
+#line 466 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '%');
   if (block_is_const_inf((yyval.blk)))
     FAIL((yyloc), "Remainder by zero?");
 }
-#line 3015 "src/parser.c"
+#line 2994 "src/parser.c"
     break;
 
   case 39: /* Exp: Exp "/=" Exp  */
-#line 471 "src/parser.y"
+#line 472 "src/parser.y"
              {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '/');
 }
-#line 3023 "src/parser.c"
+#line 3002 "src/parser.c"
     break;
 
   case 40: /* Exp: Exp "%=" Exp  */
-#line 475 "src/parser.y"
+#line 476 "src/parser.y"
                {
   (yyval.blk) = gen_update((yyvsp[-2].blk), (yyvsp[0].blk), '%');
 }
-#line 3031 "src/parser.c"
+#line 3010 "src/parser.c"
     break;
 
   case 41: /* Exp: Exp "==" Exp  */
-#line 479 "src/parser.y"
+#line 480 "src/parser.y"
              {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), EQ);
 }
-#line 3039 "src/parser.c"
+#line 3018 "src/parser.c"
     break;
 
   case 42: /* Exp: Exp "!=" Exp  */
-#line 483 "src/parser.y"
+#line 484 "src/parser.y"
              {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), NEQ);
 }
-#line 3047 "src/parser.c"
+#line 3026 "src/parser.c"
     break;
 
   case 43: /* Exp: Exp '<' Exp  */
-#line 487 "src/parser.y"
+#line 488 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '<');
 }
-#line 3055 "src/parser.c"
+#line 3034 "src/parser.c"
     break;
 
   case 44: /* Exp: Exp '>' Exp  */
-#line 491 "src/parser.y"
+#line 492 "src/parser.y"
             {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), '>');
 }
-#line 3063 "src/parser.c"
+#line 3042 "src/parser.c"
     break;
 
   case 45: /* Exp: Exp "<=" Exp  */
-#line 495 "src/parser.y"
+#line 496 "src/parser.y"
              {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), LESSEQ);
 }
-#line 3071 "src/parser.c"
+#line 3050 "src/parser.c"
     break;
 
   case 46: /* Exp: Exp ">=" Exp  */
-#line 499 "src/parser.y"
+#line 500 "src/parser.y"
              {
   (yyval.blk) = gen_binop((yyvsp[-2].blk), (yyvsp[0].blk), GREATEREQ);
 }
-#line 3079 "src/parser.c"
+#line 3058 "src/parser.c"
     break;
 
   case 47: /* Exp: Term  */
-#line 503 "src/parser.y"
+#line 504 "src/parser.y"
      {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3087 "src/parser.c"
+#line 3066 "src/parser.c"
     break;
 
   case 48: /* Import: ImportWhat ';'  */
-#line 508 "src/parser.y"
+#line 509 "src/parser.y"
                {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 3095 "src/parser.c"
+#line 3074 "src/parser.c"
     break;
 
   case 49: /* Import: ImportWhat Exp ';'  */
-#line 511 "src/parser.y"
+#line 512 "src/parser.y"
                    {
   if (!block_is_const((yyvsp[-1].blk))) {
     FAIL((yyloc), "Module metadata must be constant");
@@ -3111,25 +3090,25 @@ yyreduce:
     (yyval.blk) = gen_import_meta((yyvsp[-2].blk), (yyvsp[-1].blk));
   }
 }
-#line 3115 "src/parser.c"
+#line 3094 "src/parser.c"
     break;
 
-  case 50: /* ImportWhat: "import" ImportFrom "as" '$' IDENT  */
-#line 528 "src/parser.y"
-                                   {
-  jv v = block_const((yyvsp[-3].blk));
+  case 50: /* ImportWhat: "import" ImportFrom "as" BINDING  */
+#line 529 "src/parser.y"
+                                 {
+  jv v = block_const((yyvsp[-2].blk));
   // XXX Make gen_import take only blocks and the int is_data so we
   // don't have to free so much stuff here
   (yyval.blk) = gen_import(jv_string_value(v), jv_string_value((yyvsp[0].literal)), 1);
-  block_free((yyvsp[-3].blk));
+  block_free((yyvsp[-2].blk));
   jv_free((yyvsp[0].literal));
   jv_free(v);
 }
-#line 3129 "src/parser.c"
+#line 3108 "src/parser.c"
     break;
 
   case 51: /* ImportWhat: "import" ImportFrom "as" IDENT  */
-#line 537 "src/parser.y"
+#line 538 "src/parser.y"
                                {
   jv v = block_const((yyvsp[-2].blk));
   (yyval.blk) = gen_import(jv_string_value(v), jv_string_value((yyvsp[0].literal)), 0);
@@ -3137,22 +3116,22 @@ yyreduce:
   jv_free((yyvsp[0].literal));
   jv_free(v);
 }
-#line 3141 "src/parser.c"
+#line 3120 "src/parser.c"
     break;
 
   case 52: /* ImportWhat: "include" ImportFrom  */
-#line 544 "src/parser.y"
+#line 545 "src/parser.y"
                      {
   jv v = block_const((yyvsp[0].blk));
   (yyval.blk) = gen_import(jv_string_value(v), NULL, 0);
   block_free((yyvsp[0].blk));
   jv_free(v);
 }
-#line 3152 "src/parser.c"
+#line 3131 "src/parser.c"
     break;
 
   case 53: /* ImportFrom: String  */
-#line 552 "src/parser.y"
+#line 553 "src/parser.y"
        {
   if (!block_is_const((yyvsp[0].blk))) {
     FAIL((yyloc), "Import path must be constant");
@@ -3162,191 +3141,182 @@ yyreduce:
     (yyval.blk) = (yyvsp[0].blk);
   }
 }
-#line 3166 "src/parser.c"
+#line 3145 "src/parser.c"
     break;
 
   case 54: /* FuncDef: "def" IDENT ':' Exp ';'  */
-#line 563 "src/parser.y"
+#line 564 "src/parser.y"
                         {
   (yyval.blk) = gen_function(jv_string_value((yyvsp[-3].literal)), gen_noop(), (yyvsp[-1].blk));
   jv_free((yyvsp[-3].literal));
 }
-#line 3175 "src/parser.c"
+#line 3154 "src/parser.c"
     break;
 
   case 55: /* FuncDef: "def" IDENT '(' Params ')' ':' Exp ';'  */
-#line 568 "src/parser.y"
+#line 569 "src/parser.y"
                                        {
   (yyval.blk) = gen_function(jv_string_value((yyvsp[-6].literal)), (yyvsp[-4].blk), (yyvsp[-1].blk));
   jv_free((yyvsp[-6].literal));
 }
-#line 3184 "src/parser.c"
+#line 3163 "src/parser.c"
     break;
 
   case 56: /* Params: Param  */
-#line 574 "src/parser.y"
+#line 575 "src/parser.y"
       {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3192 "src/parser.c"
+#line 3171 "src/parser.c"
     break;
 
   case 57: /* Params: Params ';' Param  */
-#line 577 "src/parser.y"
+#line 578 "src/parser.y"
                  {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3200 "src/parser.c"
+#line 3179 "src/parser.c"
     break;
 
-  case 58: /* Param: '$' IDENT  */
-#line 582 "src/parser.y"
-          {
+  case 58: /* Param: BINDING  */
+#line 583 "src/parser.y"
+        {
   (yyval.blk) = gen_param_regular(jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 3209 "src/parser.c"
+#line 3188 "src/parser.c"
     break;
 
-  case 59: /* Param: '$' Keyword  */
-#line 586 "src/parser.y"
-            {
-  (yyval.blk) = gen_param_regular(jv_string_value((yyvsp[0].literal)));
-  jv_free((yyvsp[0].literal));
-}
-#line 3218 "src/parser.c"
-    break;
-
-  case 60: /* Param: IDENT  */
-#line 590 "src/parser.y"
+  case 59: /* Param: IDENT  */
+#line 587 "src/parser.y"
       {
   (yyval.blk) = gen_param(jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 3227 "src/parser.c"
+#line 3197 "src/parser.c"
     break;
 
-  case 61: /* @1: %empty  */
-#line 597 "src/parser.y"
+  case 60: /* @1: %empty  */
+#line 594 "src/parser.y"
                { (yyval.literal) = jv_string("text"); }
-#line 3233 "src/parser.c"
+#line 3203 "src/parser.c"
     break;
 
-  case 62: /* String: QQSTRING_START @1 QQString QQSTRING_END  */
-#line 597 "src/parser.y"
+  case 61: /* String: QQSTRING_START @1 QQString QQSTRING_END  */
+#line 594 "src/parser.y"
                                                                           {
   (yyval.blk) = (yyvsp[-1].blk);
   jv_free((yyvsp[-2].literal));
 }
-#line 3242 "src/parser.c"
+#line 3212 "src/parser.c"
     break;
 
-  case 63: /* @2: %empty  */
-#line 601 "src/parser.y"
+  case 62: /* @2: %empty  */
+#line 598 "src/parser.y"
                       { (yyval.literal) = (yyvsp[-1].literal); }
-#line 3248 "src/parser.c"
+#line 3218 "src/parser.c"
     break;
 
-  case 64: /* String: FORMAT QQSTRING_START @2 QQString QQSTRING_END  */
-#line 601 "src/parser.y"
+  case 63: /* String: FORMAT QQSTRING_START @2 QQString QQSTRING_END  */
+#line 598 "src/parser.y"
                                                                   {
   (yyval.blk) = (yyvsp[-1].blk);
   jv_free((yyvsp[-2].literal));
 }
-#line 3257 "src/parser.c"
+#line 3227 "src/parser.c"
     break;
 
-  case 65: /* QQString: %empty  */
-#line 608 "src/parser.y"
+  case 64: /* QQString: %empty  */
+#line 605 "src/parser.y"
        {
   (yyval.blk) = gen_const(jv_string(""));
 }
-#line 3265 "src/parser.c"
+#line 3235 "src/parser.c"
     break;
 
-  case 66: /* QQString: QQString QQSTRING_TEXT  */
-#line 611 "src/parser.y"
+  case 65: /* QQString: QQString QQSTRING_TEXT  */
+#line 608 "src/parser.y"
                        {
   (yyval.blk) = gen_binop((yyvsp[-1].blk), gen_const((yyvsp[0].literal)), '+');
 }
-#line 3273 "src/parser.c"
+#line 3243 "src/parser.c"
     break;
 
-  case 67: /* QQString: QQString QQSTRING_INTERP_START Exp QQSTRING_INTERP_END  */
-#line 614 "src/parser.y"
+  case 66: /* QQString: QQString QQSTRING_INTERP_START Exp QQSTRING_INTERP_END  */
+#line 611 "src/parser.y"
                                                        {
   (yyval.blk) = gen_binop((yyvsp[-3].blk), gen_format((yyvsp[-1].blk), jv_copy((yyvsp[-4].literal))), '+');
 }
-#line 3281 "src/parser.c"
+#line 3251 "src/parser.c"
     break;
 
-  case 68: /* ElseBody: "elif" Exp "then" Exp ElseBody  */
-#line 620 "src/parser.y"
+  case 67: /* ElseBody: "elif" Exp "then" Exp ElseBody  */
+#line 617 "src/parser.y"
                                {
   (yyval.blk) = gen_cond((yyvsp[-3].blk), (yyvsp[-1].blk), (yyvsp[0].blk));
 }
-#line 3289 "src/parser.c"
+#line 3259 "src/parser.c"
     break;
 
-  case 69: /* ElseBody: "else" Exp "end"  */
-#line 623 "src/parser.y"
+  case 68: /* ElseBody: "else" Exp "end"  */
+#line 620 "src/parser.y"
                  {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 3297 "src/parser.c"
+#line 3267 "src/parser.c"
     break;
 
-  case 70: /* ElseBody: "end"  */
-#line 626 "src/parser.y"
+  case 69: /* ElseBody: "end"  */
+#line 623 "src/parser.y"
       {
   (yyval.blk) = gen_noop();
 }
-#line 3305 "src/parser.c"
+#line 3275 "src/parser.c"
     break;
 
-  case 71: /* ExpD: ExpD '|' ExpD  */
-#line 631 "src/parser.y"
+  case 70: /* ExpD: ExpD '|' ExpD  */
+#line 628 "src/parser.y"
               {
   (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3313 "src/parser.c"
+#line 3283 "src/parser.c"
     break;
 
-  case 72: /* ExpD: '-' ExpD  */
-#line 634 "src/parser.y"
+  case 71: /* ExpD: '-' ExpD  */
+#line 631 "src/parser.y"
          {
   (yyval.blk) = BLOCK((yyvsp[0].blk), gen_call("_negate", gen_noop()));
 }
-#line 3321 "src/parser.c"
+#line 3291 "src/parser.c"
     break;
 
-  case 73: /* ExpD: Term  */
-#line 637 "src/parser.y"
+  case 72: /* ExpD: Term  */
+#line 634 "src/parser.y"
      {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3329 "src/parser.c"
+#line 3299 "src/parser.c"
     break;
 
-  case 74: /* Term: '.'  */
-#line 643 "src/parser.y"
+  case 73: /* Term: '.'  */
+#line 640 "src/parser.y"
     {
   (yyval.blk) = gen_noop();
 }
-#line 3337 "src/parser.c"
+#line 3307 "src/parser.c"
     break;
 
-  case 75: /* Term: ".."  */
-#line 646 "src/parser.y"
+  case 74: /* Term: ".."  */
+#line 643 "src/parser.y"
     {
   (yyval.blk) = gen_call("recurse", gen_noop());
 }
-#line 3345 "src/parser.c"
+#line 3315 "src/parser.c"
     break;
 
-  case 76: /* Term: "break" '$' IDENT  */
-#line 649 "src/parser.y"
-                {
+  case 75: /* Term: "break" BINDING  */
+#line 646 "src/parser.y"
+              {
   jv v = jv_string_fmt("*label-%s", jv_string_value((yyvsp[0].literal)));     // impossible symbol
   (yyval.blk) = gen_location((yyloc), locations,
                     BLOCK(gen_op_unbound(LOADV, jv_string_value(v)),
@@ -3354,263 +3324,263 @@ yyreduce:
   jv_free(v);
   jv_free((yyvsp[0].literal));
 }
-#line 3358 "src/parser.c"
+#line 3328 "src/parser.c"
     break;
 
-  case 77: /* Term: "break" error  */
-#line 657 "src/parser.y"
+  case 76: /* Term: "break" error  */
+#line 654 "src/parser.y"
             {
   FAIL((yyloc), "break requires a label to break to");
   (yyval.blk) = gen_noop();
 }
-#line 3367 "src/parser.c"
+#line 3337 "src/parser.c"
     break;
 
-  case 78: /* Term: Term FIELD '?'  */
-#line 661 "src/parser.y"
+  case 77: /* Term: Term FIELD '?'  */
+#line 658 "src/parser.y"
                {
   (yyval.blk) = gen_index_opt((yyvsp[-2].blk), gen_const((yyvsp[-1].literal)));
 }
-#line 3375 "src/parser.c"
+#line 3345 "src/parser.c"
     break;
 
-  case 79: /* Term: FIELD '?'  */
-#line 664 "src/parser.y"
+  case 78: /* Term: FIELD '?'  */
+#line 661 "src/parser.y"
           {
   (yyval.blk) = gen_index_opt(gen_noop(), gen_const((yyvsp[-1].literal)));
 }
-#line 3383 "src/parser.c"
+#line 3353 "src/parser.c"
     break;
 
-  case 80: /* Term: Term '.' String '?'  */
-#line 667 "src/parser.y"
+  case 79: /* Term: Term '.' String '?'  */
+#line 664 "src/parser.y"
                     {
   (yyval.blk) = gen_index_opt((yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 3391 "src/parser.c"
+#line 3361 "src/parser.c"
     break;
 
-  case 81: /* Term: '.' String '?'  */
-#line 670 "src/parser.y"
+  case 80: /* Term: '.' String '?'  */
+#line 667 "src/parser.y"
                {
   (yyval.blk) = gen_index_opt(gen_noop(), (yyvsp[-1].blk));
 }
-#line 3399 "src/parser.c"
+#line 3369 "src/parser.c"
     break;
 
-  case 82: /* Term: Term FIELD  */
-#line 673 "src/parser.y"
+  case 81: /* Term: Term FIELD  */
+#line 670 "src/parser.y"
                         {
   (yyval.blk) = gen_index((yyvsp[-1].blk), gen_const((yyvsp[0].literal)));
 }
-#line 3407 "src/parser.c"
+#line 3377 "src/parser.c"
     break;
 
-  case 83: /* Term: FIELD  */
-#line 676 "src/parser.y"
+  case 82: /* Term: FIELD  */
+#line 673 "src/parser.y"
                    {
   (yyval.blk) = gen_index(gen_noop(), gen_const((yyvsp[0].literal)));
 }
-#line 3415 "src/parser.c"
+#line 3385 "src/parser.c"
     break;
 
-  case 84: /* Term: Term '.' String  */
-#line 679 "src/parser.y"
+  case 83: /* Term: Term '.' String  */
+#line 676 "src/parser.y"
                              {
   (yyval.blk) = gen_index((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3423 "src/parser.c"
+#line 3393 "src/parser.c"
     break;
 
-  case 85: /* Term: '.' String  */
-#line 682 "src/parser.y"
+  case 84: /* Term: '.' String  */
+#line 679 "src/parser.y"
                         {
   (yyval.blk) = gen_index(gen_noop(), (yyvsp[0].blk));
 }
-#line 3431 "src/parser.c"
+#line 3401 "src/parser.c"
     break;
 
-  case 86: /* Term: '.' error  */
-#line 685 "src/parser.y"
+  case 85: /* Term: '.' error  */
+#line 682 "src/parser.y"
           {
   FAIL((yyloc), "try .[\"field\"] instead of .field for unusually named fields");
   (yyval.blk) = gen_noop();
 }
-#line 3440 "src/parser.c"
+#line 3410 "src/parser.c"
     break;
 
-  case 87: /* Term: '.' IDENT error  */
-#line 689 "src/parser.y"
+  case 86: /* Term: '.' IDENT error  */
+#line 686 "src/parser.y"
                 {
   jv_free((yyvsp[-1].literal));
   FAIL((yyloc), "try .[\"field\"] instead of .field for unusually named fields");
   (yyval.blk) = gen_noop();
 }
-#line 3450 "src/parser.c"
+#line 3420 "src/parser.c"
     break;
 
-  case 88: /* Term: Term '[' Exp ']' '?'  */
-#line 695 "src/parser.y"
+  case 87: /* Term: Term '[' Exp ']' '?'  */
+#line 692 "src/parser.y"
                      {
   (yyval.blk) = gen_index_opt((yyvsp[-4].blk), (yyvsp[-2].blk));
 }
-#line 3458 "src/parser.c"
+#line 3428 "src/parser.c"
     break;
 
-  case 89: /* Term: Term '[' Exp ']'  */
-#line 698 "src/parser.y"
+  case 88: /* Term: Term '[' Exp ']'  */
+#line 695 "src/parser.y"
                               {
   (yyval.blk) = gen_index((yyvsp[-3].blk), (yyvsp[-1].blk));
 }
-#line 3466 "src/parser.c"
+#line 3436 "src/parser.c"
     break;
 
-  case 90: /* Term: Term '.' '[' Exp ']' '?'  */
-#line 701 "src/parser.y"
+  case 89: /* Term: Term '.' '[' Exp ']' '?'  */
+#line 698 "src/parser.y"
                          {
   (yyval.blk) = gen_index_opt((yyvsp[-5].blk), (yyvsp[-2].blk));
 }
-#line 3474 "src/parser.c"
+#line 3444 "src/parser.c"
     break;
 
-  case 91: /* Term: Term '.' '[' Exp ']'  */
-#line 704 "src/parser.y"
+  case 90: /* Term: Term '.' '[' Exp ']'  */
+#line 701 "src/parser.y"
                                   {
   (yyval.blk) = gen_index((yyvsp[-4].blk), (yyvsp[-1].blk));
 }
-#line 3482 "src/parser.c"
+#line 3452 "src/parser.c"
     break;
 
-  case 92: /* Term: Term '[' ']' '?'  */
-#line 707 "src/parser.y"
+  case 91: /* Term: Term '[' ']' '?'  */
+#line 704 "src/parser.y"
                  {
   (yyval.blk) = block_join((yyvsp[-3].blk), gen_op_simple(EACH_OPT));
 }
-#line 3490 "src/parser.c"
+#line 3460 "src/parser.c"
     break;
 
-  case 93: /* Term: Term '[' ']'  */
-#line 710 "src/parser.y"
+  case 92: /* Term: Term '[' ']'  */
+#line 707 "src/parser.y"
                           {
   (yyval.blk) = block_join((yyvsp[-2].blk), gen_op_simple(EACH));
 }
-#line 3498 "src/parser.c"
+#line 3468 "src/parser.c"
     break;
 
-  case 94: /* Term: Term '.' '[' ']' '?'  */
-#line 713 "src/parser.y"
+  case 93: /* Term: Term '.' '[' ']' '?'  */
+#line 710 "src/parser.y"
                      {
   (yyval.blk) = block_join((yyvsp[-4].blk), gen_op_simple(EACH_OPT));
 }
-#line 3506 "src/parser.c"
+#line 3476 "src/parser.c"
     break;
 
-  case 95: /* Term: Term '.' '[' ']'  */
-#line 716 "src/parser.y"
+  case 94: /* Term: Term '.' '[' ']'  */
+#line 713 "src/parser.y"
                               {
   (yyval.blk) = block_join((yyvsp[-3].blk), gen_op_simple(EACH));
 }
-#line 3514 "src/parser.c"
+#line 3484 "src/parser.c"
     break;
 
-  case 96: /* Term: Term '[' Exp ':' Exp ']' '?'  */
-#line 719 "src/parser.y"
+  case 95: /* Term: Term '[' Exp ':' Exp ']' '?'  */
+#line 716 "src/parser.y"
                              {
   (yyval.blk) = gen_slice_index((yyvsp[-6].blk), (yyvsp[-4].blk), (yyvsp[-2].blk), INDEX_OPT);
 }
-#line 3522 "src/parser.c"
+#line 3492 "src/parser.c"
     break;
 
-  case 97: /* Term: Term '[' Exp ':' ']' '?'  */
-#line 722 "src/parser.y"
+  case 96: /* Term: Term '[' Exp ':' ']' '?'  */
+#line 719 "src/parser.y"
                          {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), (yyvsp[-3].blk), gen_const(jv_null()), INDEX_OPT);
 }
-#line 3530 "src/parser.c"
+#line 3500 "src/parser.c"
     break;
 
-  case 98: /* Term: Term '[' ':' Exp ']' '?'  */
-#line 725 "src/parser.y"
+  case 97: /* Term: Term '[' ':' Exp ']' '?'  */
+#line 722 "src/parser.y"
                          {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), gen_const(jv_null()), (yyvsp[-2].blk), INDEX_OPT);
 }
-#line 3538 "src/parser.c"
+#line 3508 "src/parser.c"
     break;
 
-  case 99: /* Term: Term '[' Exp ':' Exp ']'  */
-#line 728 "src/parser.y"
+  case 98: /* Term: Term '[' Exp ':' Exp ']'  */
+#line 725 "src/parser.y"
                                       {
   (yyval.blk) = gen_slice_index((yyvsp[-5].blk), (yyvsp[-3].blk), (yyvsp[-1].blk), INDEX);
 }
-#line 3546 "src/parser.c"
+#line 3516 "src/parser.c"
     break;
 
-  case 100: /* Term: Term '[' Exp ':' ']'  */
-#line 731 "src/parser.y"
+  case 99: /* Term: Term '[' Exp ':' ']'  */
+#line 728 "src/parser.y"
                                   {
   (yyval.blk) = gen_slice_index((yyvsp[-4].blk), (yyvsp[-2].blk), gen_const(jv_null()), INDEX);
 }
-#line 3554 "src/parser.c"
+#line 3524 "src/parser.c"
     break;
 
-  case 101: /* Term: Term '[' ':' Exp ']'  */
-#line 734 "src/parser.y"
+  case 100: /* Term: Term '[' ':' Exp ']'  */
+#line 731 "src/parser.y"
                                   {
   (yyval.blk) = gen_slice_index((yyvsp[-4].blk), gen_const(jv_null()), (yyvsp[-1].blk), INDEX);
 }
-#line 3562 "src/parser.c"
+#line 3532 "src/parser.c"
     break;
 
-  case 102: /* Term: LITERAL  */
-#line 737 "src/parser.y"
+  case 101: /* Term: LITERAL  */
+#line 734 "src/parser.y"
         {
   (yyval.blk) = gen_const((yyvsp[0].literal));
 }
-#line 3570 "src/parser.c"
+#line 3540 "src/parser.c"
     break;
 
-  case 103: /* Term: String  */
-#line 740 "src/parser.y"
+  case 102: /* Term: String  */
+#line 737 "src/parser.y"
        {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3578 "src/parser.c"
+#line 3548 "src/parser.c"
     break;
 
-  case 104: /* Term: FORMAT  */
-#line 743 "src/parser.y"
+  case 103: /* Term: FORMAT  */
+#line 740 "src/parser.y"
        {
   (yyval.blk) = gen_format(gen_noop(), (yyvsp[0].literal));
 }
-#line 3586 "src/parser.c"
+#line 3556 "src/parser.c"
     break;
 
-  case 105: /* Term: '(' Exp ')'  */
-#line 746 "src/parser.y"
+  case 104: /* Term: '(' Exp ')'  */
+#line 743 "src/parser.y"
             {
   (yyval.blk) = (yyvsp[-1].blk);
 }
-#line 3594 "src/parser.c"
+#line 3564 "src/parser.c"
     break;
 
-  case 106: /* Term: '[' Exp ']'  */
-#line 749 "src/parser.y"
+  case 105: /* Term: '[' Exp ']'  */
+#line 746 "src/parser.y"
             {
   (yyval.blk) = gen_collect((yyvsp[-1].blk));
 }
-#line 3602 "src/parser.c"
+#line 3572 "src/parser.c"
     break;
 
-  case 107: /* Term: '[' ']'  */
-#line 752 "src/parser.y"
+  case 106: /* Term: '[' ']'  */
+#line 749 "src/parser.y"
         {
   (yyval.blk) = gen_const(jv_array());
 }
-#line 3610 "src/parser.c"
+#line 3580 "src/parser.c"
     break;
 
-  case 108: /* Term: '{' MkDict '}'  */
-#line 755 "src/parser.y"
+  case 107: /* Term: '{' MkDict '}'  */
+#line 752 "src/parser.y"
                {
   block o = gen_const_object((yyvsp[-1].blk));
   if (o.first != NULL)
@@ -3618,43 +3588,38 @@ yyreduce:
   else
     (yyval.blk) = BLOCK(gen_subexp(gen_const(jv_object())), (yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3622 "src/parser.c"
+#line 3592 "src/parser.c"
     break;
 
-  case 109: /* Term: '$' '$' '$' '$' IDENT  */
-#line 777 "src/parser.y"
-                      {
+  case 108: /* Term: '$' '$' '$' BINDING  */
+#line 774 "src/parser.y"
+                    {
   (yyval.blk) = gen_location((yyloc), locations, gen_op_unbound(LOADVN, jv_string_value((yyvsp[0].literal))));
   jv_free((yyvsp[0].literal));
 }
-#line 3631 "src/parser.c"
+#line 3601 "src/parser.c"
     break;
 
-  case 110: /* Term: '$' IDENT  */
-#line 781 "src/parser.y"
-          {
+  case 109: /* Term: BINDING  */
+#line 778 "src/parser.y"
+        {
   (yyval.blk) = gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal))));
   jv_free((yyvsp[0].literal));
 }
-#line 3640 "src/parser.c"
+#line 3610 "src/parser.c"
     break;
 
-  case 111: /* Term: '$' Keyword  */
-#line 785 "src/parser.y"
-            {
-  if (strcmp(jv_string_value((yyvsp[0].literal)), "__loc__") == 0) {
-    (yyval.blk) = gen_const(JV_OBJECT(jv_string("file"), jv_copy(locations->fname),
-                             jv_string("line"), jv_number(locfile_get_line(locations, (yyloc).start) + 1)));
-  } else {
-    (yyval.blk) = gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal))));
-  }
-  jv_free((yyvsp[0].literal));
+  case 110: /* Term: "$__loc__"  */
+#line 782 "src/parser.y"
+           {
+  (yyval.blk) = gen_const(JV_OBJECT(jv_string("file"), jv_copy(locations->fname),
+                           jv_string("line"), jv_number(locfile_get_line(locations, (yyloc).start) + 1)));
 }
-#line 3654 "src/parser.c"
+#line 3619 "src/parser.c"
     break;
 
-  case 112: /* Term: IDENT  */
-#line 794 "src/parser.y"
+  case 111: /* Term: IDENT  */
+#line 786 "src/parser.y"
       {
   const char *s = jv_string_value((yyvsp[0].literal));
   if (strcmp(s, "false") == 0)
@@ -3667,198 +3632,198 @@ yyreduce:
     (yyval.blk) = gen_location((yyloc), locations, gen_call(s, gen_noop()));
   jv_free((yyvsp[0].literal));
 }
-#line 3671 "src/parser.c"
+#line 3636 "src/parser.c"
     break;
 
-  case 113: /* Term: IDENT '(' Args ')'  */
-#line 806 "src/parser.y"
+  case 112: /* Term: IDENT '(' Args ')'  */
+#line 798 "src/parser.y"
                    {
   (yyval.blk) = gen_call(jv_string_value((yyvsp[-3].literal)), (yyvsp[-1].blk));
   (yyval.blk) = gen_location((yylsp[-3]), locations, (yyval.blk));
   jv_free((yyvsp[-3].literal));
 }
-#line 3681 "src/parser.c"
+#line 3646 "src/parser.c"
     break;
 
-  case 114: /* Term: '(' error ')'  */
-#line 811 "src/parser.y"
+  case 113: /* Term: '(' error ')'  */
+#line 803 "src/parser.y"
               { (yyval.blk) = gen_noop(); }
-#line 3687 "src/parser.c"
+#line 3652 "src/parser.c"
     break;
 
-  case 115: /* Term: '[' error ']'  */
-#line 812 "src/parser.y"
+  case 114: /* Term: '[' error ']'  */
+#line 804 "src/parser.y"
               { (yyval.blk) = gen_noop(); }
-#line 3693 "src/parser.c"
+#line 3658 "src/parser.c"
     break;
 
-  case 116: /* Term: Term '[' error ']'  */
-#line 813 "src/parser.y"
+  case 115: /* Term: Term '[' error ']'  */
+#line 805 "src/parser.y"
                    { (yyval.blk) = (yyvsp[-3].blk); }
-#line 3699 "src/parser.c"
+#line 3664 "src/parser.c"
     break;
 
-  case 117: /* Term: '{' error '}'  */
-#line 814 "src/parser.y"
+  case 116: /* Term: '{' error '}'  */
+#line 806 "src/parser.y"
               { (yyval.blk) = gen_noop(); }
-#line 3705 "src/parser.c"
+#line 3670 "src/parser.c"
     break;
 
-  case 118: /* Args: Arg  */
-#line 817 "src/parser.y"
+  case 117: /* Args: Arg  */
+#line 809 "src/parser.y"
     {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3713 "src/parser.c"
+#line 3678 "src/parser.c"
     break;
 
-  case 119: /* Args: Args ';' Arg  */
-#line 820 "src/parser.y"
+  case 118: /* Args: Args ';' Arg  */
+#line 812 "src/parser.y"
              {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3721 "src/parser.c"
+#line 3686 "src/parser.c"
     break;
 
-  case 120: /* Arg: Exp  */
-#line 825 "src/parser.y"
+  case 119: /* Arg: Exp  */
+#line 817 "src/parser.y"
     {
   (yyval.blk) = gen_lambda((yyvsp[0].blk));
 }
-#line 3729 "src/parser.c"
+#line 3694 "src/parser.c"
     break;
 
-  case 121: /* RepPatterns: RepPatterns "?//" Pattern  */
-#line 830 "src/parser.y"
+  case 120: /* RepPatterns: RepPatterns "?//" Pattern  */
+#line 822 "src/parser.y"
                           {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), gen_destructure_alt((yyvsp[0].blk)));
 }
-#line 3737 "src/parser.c"
+#line 3702 "src/parser.c"
     break;
 
-  case 122: /* RepPatterns: Pattern  */
-#line 833 "src/parser.y"
+  case 121: /* RepPatterns: Pattern  */
+#line 825 "src/parser.y"
         {
   (yyval.blk) = gen_destructure_alt((yyvsp[0].blk));
 }
-#line 3745 "src/parser.c"
+#line 3710 "src/parser.c"
     break;
 
-  case 123: /* Patterns: RepPatterns "?//" Pattern  */
-#line 838 "src/parser.y"
+  case 122: /* Patterns: RepPatterns "?//" Pattern  */
+#line 830 "src/parser.y"
                           {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3753 "src/parser.c"
+#line 3718 "src/parser.c"
     break;
 
-  case 124: /* Patterns: Pattern  */
-#line 841 "src/parser.y"
+  case 123: /* Patterns: Pattern  */
+#line 833 "src/parser.y"
         {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3761 "src/parser.c"
+#line 3726 "src/parser.c"
     break;
 
-  case 125: /* Pattern: '$' IDENT  */
-#line 846 "src/parser.y"
-          {
+  case 124: /* Pattern: BINDING  */
+#line 838 "src/parser.y"
+        {
   (yyval.blk) = gen_op_unbound(STOREV, jv_string_value((yyvsp[0].literal)));
   jv_free((yyvsp[0].literal));
 }
-#line 3770 "src/parser.c"
+#line 3735 "src/parser.c"
     break;
 
-  case 126: /* Pattern: '[' ArrayPats ']'  */
-#line 850 "src/parser.y"
+  case 125: /* Pattern: '[' ArrayPats ']'  */
+#line 842 "src/parser.y"
                   {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3778 "src/parser.c"
+#line 3743 "src/parser.c"
     break;
 
-  case 127: /* Pattern: '{' ObjPats '}'  */
-#line 853 "src/parser.y"
+  case 126: /* Pattern: '{' ObjPats '}'  */
+#line 845 "src/parser.y"
                 {
   (yyval.blk) = BLOCK((yyvsp[-1].blk), gen_op_simple(POP));
 }
-#line 3786 "src/parser.c"
+#line 3751 "src/parser.c"
     break;
 
-  case 128: /* ArrayPats: Pattern  */
-#line 858 "src/parser.y"
+  case 127: /* ArrayPats: Pattern  */
+#line 850 "src/parser.y"
         {
   (yyval.blk) = gen_array_matcher(gen_noop(), (yyvsp[0].blk));
 }
-#line 3794 "src/parser.c"
+#line 3759 "src/parser.c"
     break;
 
-  case 129: /* ArrayPats: ArrayPats ',' Pattern  */
-#line 861 "src/parser.y"
+  case 128: /* ArrayPats: ArrayPats ',' Pattern  */
+#line 853 "src/parser.y"
                       {
   (yyval.blk) = gen_array_matcher((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3802 "src/parser.c"
+#line 3767 "src/parser.c"
     break;
 
-  case 130: /* ObjPats: ObjPat  */
-#line 866 "src/parser.y"
+  case 129: /* ObjPats: ObjPat  */
+#line 858 "src/parser.y"
        {
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3810 "src/parser.c"
+#line 3775 "src/parser.c"
     break;
 
-  case 131: /* ObjPats: ObjPats ',' ObjPat  */
-#line 869 "src/parser.y"
+  case 130: /* ObjPats: ObjPats ',' ObjPat  */
+#line 861 "src/parser.y"
                    {
   (yyval.blk) = BLOCK((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3818 "src/parser.c"
+#line 3783 "src/parser.c"
     break;
 
-  case 132: /* ObjPat: '$' IDENT  */
-#line 874 "src/parser.y"
-          {
+  case 131: /* ObjPat: BINDING  */
+#line 866 "src/parser.y"
+        {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[0].literal)), gen_op_unbound(STOREV, jv_string_value((yyvsp[0].literal))));
 }
-#line 3826 "src/parser.c"
+#line 3791 "src/parser.c"
     break;
 
-  case 133: /* ObjPat: '$' IDENT ':' Pattern  */
-#line 877 "src/parser.y"
-                      {
+  case 132: /* ObjPat: BINDING ':' Pattern  */
+#line 869 "src/parser.y"
+                    {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), BLOCK(gen_op_simple(DUP), gen_op_unbound(STOREV, jv_string_value((yyvsp[-2].literal))), (yyvsp[0].blk)));
 }
-#line 3834 "src/parser.c"
+#line 3799 "src/parser.c"
     break;
 
-  case 134: /* ObjPat: IDENT ':' Pattern  */
-#line 880 "src/parser.y"
+  case 133: /* ObjPat: IDENT ':' Pattern  */
+#line 872 "src/parser.y"
                   {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
 }
-#line 3842 "src/parser.c"
+#line 3807 "src/parser.c"
     break;
 
-  case 135: /* ObjPat: Keyword ':' Pattern  */
-#line 883 "src/parser.y"
+  case 134: /* ObjPat: Keyword ':' Pattern  */
+#line 875 "src/parser.y"
                     {
   (yyval.blk) = gen_object_matcher(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
 }
-#line 3850 "src/parser.c"
+#line 3815 "src/parser.c"
     break;
 
-  case 136: /* ObjPat: String ':' Pattern  */
-#line 886 "src/parser.y"
+  case 135: /* ObjPat: String ':' Pattern  */
+#line 878 "src/parser.y"
                    {
   (yyval.blk) = gen_object_matcher((yyvsp[-2].blk), (yyvsp[0].blk));
 }
-#line 3858 "src/parser.c"
+#line 3823 "src/parser.c"
     break;
 
-  case 137: /* ObjPat: '(' Exp ')' ':' Pattern  */
-#line 889 "src/parser.y"
+  case 136: /* ObjPat: '(' Exp ')' ':' Pattern  */
+#line 881 "src/parser.y"
                         {
   jv msg = check_object_key((yyvsp[-3].blk));
   if (jv_is_valid(msg)) {
@@ -3867,276 +3832,259 @@ yyreduce:
   jv_free(msg);
   (yyval.blk) = gen_object_matcher((yyvsp[-3].blk), (yyvsp[0].blk));
 }
-#line 3871 "src/parser.c"
+#line 3836 "src/parser.c"
     break;
 
-  case 138: /* ObjPat: error ':' Pattern  */
-#line 897 "src/parser.y"
+  case 137: /* ObjPat: error ':' Pattern  */
+#line 889 "src/parser.y"
                   {
   FAIL((yyloc), "May need parentheses around object key expression");
   (yyval.blk) = (yyvsp[0].blk);
 }
-#line 3880 "src/parser.c"
+#line 3845 "src/parser.c"
     break;
 
-  case 139: /* Keyword: "as"  */
-#line 903 "src/parser.y"
+  case 138: /* Keyword: "as"  */
+#line 895 "src/parser.y"
      {
   (yyval.literal) = jv_string("as");
 }
-#line 3888 "src/parser.c"
+#line 3853 "src/parser.c"
     break;
 
-  case 140: /* Keyword: "def"  */
-#line 906 "src/parser.y"
+  case 139: /* Keyword: "def"  */
+#line 898 "src/parser.y"
       {
   (yyval.literal) = jv_string("def");
 }
-#line 3896 "src/parser.c"
+#line 3861 "src/parser.c"
     break;
 
-  case 141: /* Keyword: "module"  */
-#line 909 "src/parser.y"
+  case 140: /* Keyword: "module"  */
+#line 901 "src/parser.y"
          {
   (yyval.literal) = jv_string("module");
 }
-#line 3904 "src/parser.c"
+#line 3869 "src/parser.c"
     break;
 
-  case 142: /* Keyword: "import"  */
-#line 912 "src/parser.y"
+  case 141: /* Keyword: "import"  */
+#line 904 "src/parser.y"
          {
   (yyval.literal) = jv_string("import");
 }
-#line 3912 "src/parser.c"
+#line 3877 "src/parser.c"
     break;
 
-  case 143: /* Keyword: "include"  */
-#line 915 "src/parser.y"
+  case 142: /* Keyword: "include"  */
+#line 907 "src/parser.y"
           {
   (yyval.literal) = jv_string("include");
 }
-#line 3920 "src/parser.c"
+#line 3885 "src/parser.c"
     break;
 
-  case 144: /* Keyword: "if"  */
-#line 918 "src/parser.y"
+  case 143: /* Keyword: "if"  */
+#line 910 "src/parser.y"
      {
   (yyval.literal) = jv_string("if");
 }
-#line 3928 "src/parser.c"
+#line 3893 "src/parser.c"
     break;
 
-  case 145: /* Keyword: "then"  */
-#line 921 "src/parser.y"
+  case 144: /* Keyword: "then"  */
+#line 913 "src/parser.y"
        {
   (yyval.literal) = jv_string("then");
 }
-#line 3936 "src/parser.c"
+#line 3901 "src/parser.c"
     break;
 
-  case 146: /* Keyword: "else"  */
-#line 924 "src/parser.y"
+  case 145: /* Keyword: "else"  */
+#line 916 "src/parser.y"
        {
   (yyval.literal) = jv_string("else");
 }
-#line 3944 "src/parser.c"
+#line 3909 "src/parser.c"
     break;
 
-  case 147: /* Keyword: "elif"  */
-#line 927 "src/parser.y"
+  case 146: /* Keyword: "elif"  */
+#line 919 "src/parser.y"
        {
   (yyval.literal) = jv_string("elif");
 }
-#line 3952 "src/parser.c"
+#line 3917 "src/parser.c"
     break;
 
-  case 148: /* Keyword: "reduce"  */
-#line 930 "src/parser.y"
+  case 147: /* Keyword: "reduce"  */
+#line 922 "src/parser.y"
          {
   (yyval.literal) = jv_string("reduce");
 }
-#line 3960 "src/parser.c"
+#line 3925 "src/parser.c"
     break;
 
-  case 149: /* Keyword: "foreach"  */
-#line 933 "src/parser.y"
+  case 148: /* Keyword: "foreach"  */
+#line 925 "src/parser.y"
           {
   (yyval.literal) = jv_string("foreach");
 }
-#line 3968 "src/parser.c"
+#line 3933 "src/parser.c"
     break;
 
-  case 150: /* Keyword: "end"  */
-#line 936 "src/parser.y"
+  case 149: /* Keyword: "end"  */
+#line 928 "src/parser.y"
       {
   (yyval.literal) = jv_string("end");
 }
-#line 3976 "src/parser.c"
+#line 3941 "src/parser.c"
     break;
 
-  case 151: /* Keyword: "and"  */
-#line 939 "src/parser.y"
+  case 150: /* Keyword: "and"  */
+#line 931 "src/parser.y"
       {
   (yyval.literal) = jv_string("and");
 }
-#line 3984 "src/parser.c"
+#line 3949 "src/parser.c"
     break;
 
-  case 152: /* Keyword: "or"  */
-#line 942 "src/parser.y"
+  case 151: /* Keyword: "or"  */
+#line 934 "src/parser.y"
      {
   (yyval.literal) = jv_string("or");
 }
-#line 3992 "src/parser.c"
+#line 3957 "src/parser.c"
     break;
 
-  case 153: /* Keyword: "try"  */
-#line 945 "src/parser.y"
+  case 152: /* Keyword: "try"  */
+#line 937 "src/parser.y"
       {
   (yyval.literal) = jv_string("try");
 }
-#line 4000 "src/parser.c"
+#line 3965 "src/parser.c"
     break;
 
-  case 154: /* Keyword: "catch"  */
-#line 948 "src/parser.y"
+  case 153: /* Keyword: "catch"  */
+#line 940 "src/parser.y"
         {
   (yyval.literal) = jv_string("catch");
 }
-#line 4008 "src/parser.c"
+#line 3973 "src/parser.c"
     break;
 
-  case 155: /* Keyword: "label"  */
-#line 951 "src/parser.y"
+  case 154: /* Keyword: "label"  */
+#line 943 "src/parser.y"
         {
   (yyval.literal) = jv_string("label");
 }
-#line 4016 "src/parser.c"
+#line 3981 "src/parser.c"
     break;
 
-  case 156: /* Keyword: "break"  */
-#line 954 "src/parser.y"
+  case 155: /* Keyword: "break"  */
+#line 946 "src/parser.y"
         {
   (yyval.literal) = jv_string("break");
 }
-#line 4024 "src/parser.c"
+#line 3989 "src/parser.c"
     break;
 
-  case 157: /* Keyword: "__loc__"  */
-#line 957 "src/parser.y"
-          {
-  (yyval.literal) = jv_string("__loc__");
-}
-#line 4032 "src/parser.c"
-    break;
-
-  case 158: /* MkDict: %empty  */
-#line 962 "src/parser.y"
+  case 156: /* MkDict: %empty  */
+#line 951 "src/parser.y"
        {
   (yyval.blk)=gen_noop();
 }
-#line 4040 "src/parser.c"
+#line 3997 "src/parser.c"
     break;
 
-  case 159: /* MkDict: MkDictPair  */
-#line 965 "src/parser.y"
+  case 157: /* MkDict: MkDictPair  */
+#line 954 "src/parser.y"
             { (yyval.blk) = (yyvsp[0].blk); }
-#line 4046 "src/parser.c"
+#line 4003 "src/parser.c"
     break;
 
-  case 160: /* MkDict: MkDictPair ',' MkDict  */
-#line 966 "src/parser.y"
+  case 158: /* MkDict: MkDictPair ',' MkDict  */
+#line 955 "src/parser.y"
                         { (yyval.blk)=block_join((yyvsp[-2].blk), (yyvsp[0].blk)); }
-#line 4052 "src/parser.c"
+#line 4009 "src/parser.c"
     break;
 
-  case 161: /* MkDict: error ',' MkDict  */
-#line 967 "src/parser.y"
+  case 159: /* MkDict: error ',' MkDict  */
+#line 956 "src/parser.y"
                    { (yyval.blk) = (yyvsp[0].blk); }
-#line 4058 "src/parser.c"
+#line 4015 "src/parser.c"
     break;
 
-  case 162: /* MkDictPair: IDENT ':' ExpD  */
-#line 970 "src/parser.y"
+  case 160: /* MkDictPair: IDENT ':' ExpD  */
+#line 959 "src/parser.y"
                {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
  }
-#line 4066 "src/parser.c"
+#line 4023 "src/parser.c"
     break;
 
-  case 163: /* MkDictPair: Keyword ':' ExpD  */
-#line 973 "src/parser.y"
+  case 161: /* MkDictPair: Keyword ':' ExpD  */
+#line 962 "src/parser.y"
                    {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
   }
-#line 4074 "src/parser.c"
+#line 4031 "src/parser.c"
     break;
 
-  case 164: /* MkDictPair: String ':' ExpD  */
-#line 976 "src/parser.y"
+  case 162: /* MkDictPair: String ':' ExpD  */
+#line 965 "src/parser.y"
                   {
   (yyval.blk) = gen_dictpair((yyvsp[-2].blk), (yyvsp[0].blk));
   }
-#line 4082 "src/parser.c"
+#line 4039 "src/parser.c"
     break;
 
-  case 165: /* MkDictPair: String  */
-#line 979 "src/parser.y"
+  case 163: /* MkDictPair: String  */
+#line 968 "src/parser.y"
          {
   (yyval.blk) = gen_dictpair((yyvsp[0].blk), BLOCK(gen_op_simple(POP), gen_op_simple(DUP2),
                               gen_op_simple(DUP2), gen_op_simple(INDEX)));
   }
-#line 4091 "src/parser.c"
+#line 4048 "src/parser.c"
     break;
 
-  case 166: /* MkDictPair: '$' IDENT ':' ExpD  */
-#line 983 "src/parser.y"
-                     {
+  case 164: /* MkDictPair: BINDING ':' ExpD  */
+#line 972 "src/parser.y"
+                   {
   (yyval.blk) = gen_dictpair(gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[-2].literal)))),
                     (yyvsp[0].blk));
   }
-#line 4100 "src/parser.c"
+#line 4057 "src/parser.c"
     break;
 
-  case 167: /* MkDictPair: '$' IDENT  */
-#line 987 "src/parser.y"
-            {
+  case 165: /* MkDictPair: BINDING  */
+#line 976 "src/parser.y"
+          {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[0].literal)),
                     gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal)))));
   }
-#line 4109 "src/parser.c"
+#line 4066 "src/parser.c"
     break;
 
-  case 168: /* MkDictPair: '$' Keyword  */
-#line 991 "src/parser.y"
-              {
-  (yyval.blk) = gen_dictpair(gen_const((yyvsp[0].literal)),
-                    gen_location((yyloc), locations, gen_op_unbound(LOADV, jv_string_value((yyvsp[0].literal)))));
-  }
-#line 4118 "src/parser.c"
-    break;
-
-  case 169: /* MkDictPair: IDENT  */
-#line 995 "src/parser.y"
+  case 166: /* MkDictPair: IDENT  */
+#line 980 "src/parser.y"
         {
   (yyval.blk) = gen_dictpair(gen_const(jv_copy((yyvsp[0].literal))),
                     gen_index(gen_noop(), gen_const((yyvsp[0].literal))));
   }
-#line 4127 "src/parser.c"
+#line 4075 "src/parser.c"
     break;
 
-  case 170: /* MkDictPair: Keyword  */
-#line 999 "src/parser.y"
+  case 167: /* MkDictPair: Keyword  */
+#line 984 "src/parser.y"
           {
   (yyval.blk) = gen_dictpair(gen_const(jv_copy((yyvsp[0].literal))),
                     gen_index(gen_noop(), gen_const((yyvsp[0].literal))));
   }
-#line 4136 "src/parser.c"
+#line 4084 "src/parser.c"
     break;
 
-  case 171: /* MkDictPair: '(' Exp ')' ':' ExpD  */
-#line 1003 "src/parser.y"
+  case 168: /* MkDictPair: '(' Exp ')' ':' ExpD  */
+#line 988 "src/parser.y"
                        {
   jv msg = check_object_key((yyvsp[-3].blk));
   if (jv_is_valid(msg)) {
@@ -4145,20 +4093,20 @@ yyreduce:
   jv_free(msg);
   (yyval.blk) = gen_dictpair((yyvsp[-3].blk), (yyvsp[0].blk));
   }
-#line 4149 "src/parser.c"
+#line 4097 "src/parser.c"
     break;
 
-  case 172: /* MkDictPair: error ':' ExpD  */
-#line 1011 "src/parser.y"
+  case 169: /* MkDictPair: error ':' ExpD  */
+#line 996 "src/parser.y"
                  {
   FAIL((yyloc), "May need parentheses around object key expression");
   (yyval.blk) = (yyvsp[0].blk);
   }
-#line 4158 "src/parser.c"
+#line 4106 "src/parser.c"
     break;
 
 
-#line 4162 "src/parser.c"
+#line 4110 "src/parser.c"
 
       default: break;
     }
@@ -4387,7 +4335,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 1015 "src/parser.y"
+#line 1000 "src/parser.y"
 
 
 int jq_parse(struct locfile* locations, block* answer) {

--- a/src/parser.h
+++ b/src/parser.h
@@ -76,48 +76,49 @@ struct lexer_param;
     INVALID_CHARACTER = 258,       /* INVALID_CHARACTER  */
     IDENT = 259,                   /* IDENT  */
     FIELD = 260,                   /* FIELD  */
-    LITERAL = 261,                 /* LITERAL  */
-    FORMAT = 262,                  /* FORMAT  */
-    REC = 263,                     /* ".."  */
-    SETMOD = 264,                  /* "%="  */
-    EQ = 265,                      /* "=="  */
-    NEQ = 266,                     /* "!="  */
-    DEFINEDOR = 267,               /* "//"  */
-    AS = 268,                      /* "as"  */
-    DEF = 269,                     /* "def"  */
-    MODULE = 270,                  /* "module"  */
-    IMPORT = 271,                  /* "import"  */
-    INCLUDE = 272,                 /* "include"  */
-    IF = 273,                      /* "if"  */
-    THEN = 274,                    /* "then"  */
-    ELSE = 275,                    /* "else"  */
-    ELSE_IF = 276,                 /* "elif"  */
-    REDUCE = 277,                  /* "reduce"  */
-    FOREACH = 278,                 /* "foreach"  */
-    END = 279,                     /* "end"  */
-    AND = 280,                     /* "and"  */
-    OR = 281,                      /* "or"  */
-    TRY = 282,                     /* "try"  */
-    CATCH = 283,                   /* "catch"  */
-    LABEL = 284,                   /* "label"  */
-    BREAK = 285,                   /* "break"  */
-    LOC = 286,                     /* "__loc__"  */
-    SETPIPE = 287,                 /* "|="  */
-    SETPLUS = 288,                 /* "+="  */
-    SETMINUS = 289,                /* "-="  */
-    SETMULT = 290,                 /* "*="  */
-    SETDIV = 291,                  /* "/="  */
-    SETDEFINEDOR = 292,            /* "//="  */
-    LESSEQ = 293,                  /* "<="  */
-    GREATEREQ = 294,               /* ">="  */
-    ALTERNATION = 295,             /* "?//"  */
-    QQSTRING_START = 296,          /* QQSTRING_START  */
-    QQSTRING_TEXT = 297,           /* QQSTRING_TEXT  */
-    QQSTRING_INTERP_START = 298,   /* QQSTRING_INTERP_START  */
-    QQSTRING_INTERP_END = 299,     /* QQSTRING_INTERP_END  */
-    QQSTRING_END = 300,            /* QQSTRING_END  */
-    FUNCDEF = 301,                 /* FUNCDEF  */
-    NONOPT = 302                   /* NONOPT  */
+    BINDING = 261,                 /* BINDING  */
+    LITERAL = 262,                 /* LITERAL  */
+    FORMAT = 263,                  /* FORMAT  */
+    REC = 264,                     /* ".."  */
+    SETMOD = 265,                  /* "%="  */
+    EQ = 266,                      /* "=="  */
+    NEQ = 267,                     /* "!="  */
+    DEFINEDOR = 268,               /* "//"  */
+    AS = 269,                      /* "as"  */
+    DEF = 270,                     /* "def"  */
+    MODULE = 271,                  /* "module"  */
+    IMPORT = 272,                  /* "import"  */
+    INCLUDE = 273,                 /* "include"  */
+    IF = 274,                      /* "if"  */
+    THEN = 275,                    /* "then"  */
+    ELSE = 276,                    /* "else"  */
+    ELSE_IF = 277,                 /* "elif"  */
+    REDUCE = 278,                  /* "reduce"  */
+    FOREACH = 279,                 /* "foreach"  */
+    END = 280,                     /* "end"  */
+    AND = 281,                     /* "and"  */
+    OR = 282,                      /* "or"  */
+    TRY = 283,                     /* "try"  */
+    CATCH = 284,                   /* "catch"  */
+    LABEL = 285,                   /* "label"  */
+    BREAK = 286,                   /* "break"  */
+    LOC = 287,                     /* "$__loc__"  */
+    SETPIPE = 288,                 /* "|="  */
+    SETPLUS = 289,                 /* "+="  */
+    SETMINUS = 290,                /* "-="  */
+    SETMULT = 291,                 /* "*="  */
+    SETDIV = 292,                  /* "/="  */
+    SETDEFINEDOR = 293,            /* "//="  */
+    LESSEQ = 294,                  /* "<="  */
+    GREATEREQ = 295,               /* ">="  */
+    ALTERNATION = 296,             /* "?//"  */
+    QQSTRING_START = 297,          /* QQSTRING_START  */
+    QQSTRING_TEXT = 298,           /* QQSTRING_TEXT  */
+    QQSTRING_INTERP_START = 299,   /* QQSTRING_INTERP_START  */
+    QQSTRING_INTERP_END = 300,     /* QQSTRING_INTERP_END  */
+    QQSTRING_END = 301,            /* QQSTRING_END  */
+    FUNCDEF = 302,                 /* FUNCDEF  */
+    NONOPT = 303                   /* NONOPT  */
   };
   typedef enum yytokentype yytoken_kind_t;
 #endif
@@ -129,48 +130,49 @@ struct lexer_param;
 #define INVALID_CHARACTER 258
 #define IDENT 259
 #define FIELD 260
-#define LITERAL 261
-#define FORMAT 262
-#define REC 263
-#define SETMOD 264
-#define EQ 265
-#define NEQ 266
-#define DEFINEDOR 267
-#define AS 268
-#define DEF 269
-#define MODULE 270
-#define IMPORT 271
-#define INCLUDE 272
-#define IF 273
-#define THEN 274
-#define ELSE 275
-#define ELSE_IF 276
-#define REDUCE 277
-#define FOREACH 278
-#define END 279
-#define AND 280
-#define OR 281
-#define TRY 282
-#define CATCH 283
-#define LABEL 284
-#define BREAK 285
-#define LOC 286
-#define SETPIPE 287
-#define SETPLUS 288
-#define SETMINUS 289
-#define SETMULT 290
-#define SETDIV 291
-#define SETDEFINEDOR 292
-#define LESSEQ 293
-#define GREATEREQ 294
-#define ALTERNATION 295
-#define QQSTRING_START 296
-#define QQSTRING_TEXT 297
-#define QQSTRING_INTERP_START 298
-#define QQSTRING_INTERP_END 299
-#define QQSTRING_END 300
-#define FUNCDEF 301
-#define NONOPT 302
+#define BINDING 261
+#define LITERAL 262
+#define FORMAT 263
+#define REC 264
+#define SETMOD 265
+#define EQ 266
+#define NEQ 267
+#define DEFINEDOR 268
+#define AS 269
+#define DEF 270
+#define MODULE 271
+#define IMPORT 272
+#define INCLUDE 273
+#define IF 274
+#define THEN 275
+#define ELSE 276
+#define ELSE_IF 277
+#define REDUCE 278
+#define FOREACH 279
+#define END 280
+#define AND 281
+#define OR 282
+#define TRY 283
+#define CATCH 284
+#define LABEL 285
+#define BREAK 286
+#define LOC 287
+#define SETPIPE 288
+#define SETPLUS 289
+#define SETMINUS 290
+#define SETMULT 291
+#define SETDIV 292
+#define SETDEFINEDOR 293
+#define LESSEQ 294
+#define GREATEREQ 295
+#define ALTERNATION 296
+#define QQSTRING_START 297
+#define QQSTRING_TEXT 298
+#define QQSTRING_INTERP_START 299
+#define QQSTRING_INTERP_END 300
+#define QQSTRING_END 301
+#define FUNCDEF 302
+#define NONOPT 303
 
 /* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
@@ -181,7 +183,7 @@ union YYSTYPE
   jv literal;
   block blk;
 
-#line 185 "src/parser.h"
+#line 187 "src/parser.h"
 
 };
 typedef union YYSTYPE YYSTYPE;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1770,3 +1770,25 @@ false
 1
 1
 
+
+# Using a keyword as variable/label name
+
+123 as $label | $label
+null
+123
+
+[ label $if | range(10) | ., (select(. == 5) | break $if) ]
+null
+[0,1,2,3,4,5]
+
+reduce .[] as $then (4 as $else | $else; . as $elif | . + $then * $elif)
+[1,2,3]
+96
+
+1 as $foreach | 2 as $and | 3 as $or | { $foreach, $and, $or, a }
+{"a":4,"b":5}
+{"foreach":1,"and":2,"or":3,"a":4}
+
+[ foreach .[] as $try (1 as $catch | $catch - 1; . + $try; .) ]
+[10,9,8,7]
+[10,19,27,34]


### PR DESCRIPTION
Previously, variable/symbols were parsed as the combination of two tokens: '$' IDENT

This meant that using a keyword as variable name (e.g. $then, $label) did not work.
Attempts were made to allow $keyword to work by adding some '$' Keyword rules in the parser, but this did not allow $keyword in all places:

  jq --arg label foo -n '$label'  # ok

  jq -n '"foo" as $label | .'     # error

Treating $foo as a single token is much simpler, in my opinion.

This patch also changes how LOC is lexed: "$__loc__" instead of as "__loc__" that gets combined with '$' in the parser.

This patch also disallows having spaces after '$' when recalling a variable  `$ foo'  since that was probably just an unintentional side effect of the implementation, and it was not documented.

Fixes #2675 and fixes #526.