### PR TITLE
Mark src/{parser,lexer}.{c,h} as generated files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 * text=auto eol=lf
+
+# generated files
+src/lexer.[ch] linguist-generated=true
+src/parser.[ch] linguist-generated=true


### PR DESCRIPTION
This should hide edit to those files in PR diffs making PRs easier to review.

Ref: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github