### PR TITLE
Rename --nul-output to --raw-output0, abort on string containing NUL

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -136,14 +136,15 @@ sections:
         formatted as a JSON string with quotes. This can be useful for
         making jq filters talk to non-JSON-based systems.
 
-      * `--join-output` / `-j`:
-
-        Like `-r` but jq won't print a newline after each output.
-
-      * `--nul-output` / `-0`:
+      * `--raw-output0`:
 
         Like `-r` but jq will print NUL instead of newline after each output.
         This can be useful when the values being output can contain newlines.
+        When the output value contains NUL, jq exits with non-zero code.
+
+      * `--join-output` / `-j`:
+
+        Like `-r` but jq won't print a newline after each output.
 
       * `--ascii-output` / `-a`:
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -82,16 +82,16 @@ By default, jq pretty\-prints JSON output\. Using this option will result in mor
 With this option, if the filter\'s result is a string then it will be written directly to standard output rather than being formatted as a JSON string with quotes\. This can be useful for making jq filters talk to non\-JSON\-based systems\.
 .
 .TP
+\fB\-\-raw\-output0\fR:
+.
+.IP
+Like \fB\-r\fR but jq will print NUL instead of newline after each output\. This can be useful when the values being output can contain newlines\. When the output value contains NUL, jq exits with non\-zero code\.
+.
+.TP
 \fB\-\-join\-output\fR / \fB\-j\fR:
 .
 .IP
 Like \fB\-r\fR but jq won\'t print a newline after each output\.
-.
-.TP
-\fB\-\-nul\-output\fR / \fB\-0\fR:
-.
-.IP
-Like \fB\-r\fR but jq will print NUL instead of newline after each output\. This can be useful when the values being output can contain newlines\.
 .
 .TP
 \fB\-\-ascii\-output\fR / \fB\-a\fR:

--- a/tests/shtest
+++ b/tests/shtest
@@ -165,12 +165,20 @@ cmp $d/out $d/expected
 printf "[1,2][3,4]\n" | $JQ -cs add > $d/out 2>&1
 cmp $d/out $d/expected
 
-# Regression test for -0 / --nul-output
+# Regression test for --raw-output0
 printf "a\0b\0" > $d/expected
-printf '["a", "b"]' | $JQ -0 .[] > $d/out 2>&1
+printf '["a", "b"]' | $VALGRIND $Q $JQ --raw-output0 .[] > $d/out
 cmp $d/out $d/expected
-printf '["a", "b"]' | $JQ --nul-output .[] > $d/out 2>&1
-cmp $d/out $d/expected
+printf "a\0" > $d/expected
+if printf '["a", "c\\u0000d", "b"]' | $VALGRIND $Q $JQ --raw-output0 .[] > $d/out; then
+  echo "Should exit error on string containing NUL with --raw-output0" 1>&2
+  exit 1
+elif [ $? -ne 5 ]; then
+  echo "Invalid error code" 1>&2
+  exit 1
+else
+  cmp $d/out $d/expected
+fi
 
 ## Test streaming parser
 


### PR DESCRIPTION
The option naming --nul-output was confusing, especially when we have a
similar option for input stream in the future (--nul-input vs --null-input).
Based on the observation of other command line tools, we rename the option
to --raw-output0. We also drop the short option -0 to avoid confusion on
introducing the NUL-delimited input option.

Unlike the other command line tools outputting file names with NUL delimiter,
jq deals with JSON, and its strings may contain NUL character. To protect
users from the risk of injection attacks, we abort the program and print an
error message before outputting strings including NUL character. Closes #2683.