### PR TITLE
Do not remove manpage prebuild file on build failure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -164,7 +164,7 @@ endif
 man_MANS = jq.1
 jq.1.prebuilt: $(srcdir)/docs/content/manual/manual.yml
 if ENABLE_DOCS
-	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; $(PIPENV) run python build_manpage.py ) > $@ || { rm -f $@; false; }
+	$(AM_V_GEN) ( cd ${abs_srcdir}/docs; $(PIPENV) run python build_manpage.py ) > $@
 else
 	@echo Changes to the manual.yml require docs to be enabled to update the manpage.
 	@echo As a result, the manpage is out of date.


### PR DESCRIPTION
I'm annoyed by the target removal here, since the target file is managed by git. Just like `tests/man.test`, I don't think we should remove this file on build failure.