### PR TITLE
Revert unexpected changes in decNumber code (ref #2031)

### DIFF
--- a/src/decNumber/decNumberLocal.h
+++ b/src/decNumber/decNumberLocal.h
@@ -174,7 +174,7 @@
 
 
   /* ---------------------------------------------------------------- */
-  /* Definitions for arbitrary-precision modules (only valid after     */
+  /* Definitions for arbitary-precision modules (only valid after     */
   /* decNumber.h has been included)                                   */
   /* ---------------------------------------------------------------- */
 


### PR DESCRIPTION
This reverts unexpected changes in decNumber code. This kind of fixes should be reported to upstream first. I downloaded the ICU version in https://speleotrove.com/decimal/ and extracted to the directory again to confirm that this line is the only unexpected change. Ref #2031.