### PR TITLE
Make object key color configurable (close #1739, #1791, #2638)

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3471,9 +3471,10 @@ sections:
         - color for strings
         - color for arrays
         - color for objects
+        - color for object keys
 
       The default color scheme is the same as setting
-      `"JQ_COLORS=1;30:0;37:0;37:0;37:0;32:1;37:1;37"`.
+      `JQ_COLORS="1;30:0;37:0;37:0;37:0;32:1;37:1;37:1;34"`.
 
       This is not a manual for VT100/ANSI escapes.  However, each of
       these color specifications should consist of two numbers separated

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3711,10 +3711,13 @@ color for arrays
 .IP "\(bu" 4
 color for objects
 .
+.IP "\(bu" 4
+color for object keys
+.
 .IP "" 0
 .
 .P
-The default color scheme is the same as setting \fB"JQ_COLORS=1;30:0;37:0;37:0;37:0;32:1;37:1;37"\fR\.
+The default color scheme is the same as setting \fBJQ_COLORS="1;30:0;37:0;37:0;37:0;32:1;37:1;37:1;34"\fR\.
 .
 .P
 This is not a manual for VT100/ANSI escapes\. However, each of these color specifications should consist of two numbers separated by a semi\-colon, where the first number is one of these:

--- a/tests/shtest
+++ b/tests/shtest
@@ -325,29 +325,55 @@ if [ "$($VALGRIND $Q $JQ -n '{"a":"xyz"} | halt_error(1)' 2>&1)" != '{"a":"xyz"}
 fi
 
 # Check $JQ_COLORS
+unset JQ_COLORS
+
+## Default colors, null input
 $JQ -Ccn . > $d/color
 printf '\033[1;30mnull\033[0m\n' > $d/expect
 cmp $d/color $d/expect
+
+## Set non-default color, null input
 JQ_COLORS='4;31' $JQ -Ccn . > $d/color
 printf '\033[4;31mnull\033[0m\n' > $d/expect
 cmp $d/color $d/expect
-JQ_COLORS='1;30:0;31:0;32:0;33:0;34:1;35:1;36' \
+
+## Default colors, complex input
+$JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
+{
+  printf '\033[1;37m[\033[1;37m{'
+  printf '\033[0m\033[1;34m"a"\033['
+  printf '0m\033[1;37m:\033[0m\033['
+  printf '0;37mtrue\033[0m\033[1'
+  printf ';37m,\033[0m\033[1;34m'
+  printf '"b"\033[0m\033[1;37m:\033'
+  printf '[0m\033[0;37mfalse\033'
+  printf '[0m\033[1;37m\033[1;37'
+  printf 'm}\033[0m\033[1;37m,\033['
+  printf '0;37m123\033[0m\033[1;'
+  printf '37m,\033[1;30mnull\033'
+  printf '[0m\033[1;37m\033[1;37'
+  printf 'm]\033[0m\n'
+} > $d/expect
+cmp $d/color $d/expect
+
+## Set non-default colors, complex input
+JQ_COLORS='1;30:0;31:0;32:0;33:0;34:1;35:1;36:1;30' \
   $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
-(
-printf '\033[1;35m[\033[1;36m{'
-printf '\033[0m\033[34;1m"a"\033['
-printf '0m\033[1;36m:\033[0m\033['
-printf '0;32mtrue\033[0m\033[1'
-printf ';36m,\033[0m\033[34;1m'
-printf '"b"\033[0m\033[1;36m:\033'
-printf '[0m\033[0;31mfalse\033'
-printf '[0m\033[1;36m\033[1;36'
-printf 'm}\033[0m\033[1;35m,\033['
-printf '0;33m123\033[0m\033[1;'
-printf '35m,\033[1;30mnull\033'
-printf '[0m\033[1;35m\033[1;35'
-printf 'm]\033[0m\n'
-) > $d/expect
+{
+  printf '\033[1;35m[\033[1;36m{'
+  printf '\033[0m\033[1;30m"a"\033['
+  printf '0m\033[1;36m:\033[0m\033['
+  printf '0;32mtrue\033[0m\033[1'
+  printf ';36m,\033[0m\033[1;30m'
+  printf '"b"\033[0m\033[1;36m:\033'
+  printf '[0m\033[0;31mfalse\033'
+  printf '[0m\033[1;36m\033[1;36'
+  printf 'm}\033[0m\033[1;35m,\033['
+  printf '0;33m123\033[0m\033[1;'
+  printf '35m,\033[1;30mnull\033'
+  printf '[0m\033[1;35m\033[1;35'
+  printf 'm]\033[0m\n'
+} > $d/expect
 cmp $d/color $d/expect
 
 # Check garbage in JQ_COLORS.  We write each color sequence into a 16


### PR DESCRIPTION
This PR resolves #1739 by allowing user to configure object key at the 8th element of `JQ_COLORS`. The patch is based on the #1791 and #2638, and my comment https://github.com/jqlang/jq/pull/1791#issuecomment-1613218512. Also I optimized colors lookup by using enum to int conversion (already used for type comparison). Closes #1791 and closes #2638.