### PR TITLE
Mark src/decNumber/** as vendored files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 .gitignore export-ignore
 * text=auto eol=lf
 
+# vendored files
+src/decNumber/** linguist-vendored
+
 # generated files
 src/lexer.[ch] linguist-generated=true
 src/parser.[ch] linguist-generated=true


### PR DESCRIPTION
This excludes those files from the Languages statistics on github.

| Before | After |
|--------|-------|
| ![file2](https://github.com/jqlang/jq/assets/20175435/8d4a4df9-c6e3-44a4-bdbb-ea414ef178e6) | ![file](https://github.com/jqlang/jq/assets/20175435/d0c1ff8d-11a8-4320-b523-b0fd1df2119c) |
