### PR TITLE
Fix autoreconf warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,22 +1,21 @@
 m4_define([jq_version], m4_esyscmd_s([scripts/version])))
 
-AC_INIT([jq], [jq_version], [https://github.com/jqlang/jq/issues],
-             [jq], [https://jqlang.github.io/jq])
+AC_INIT([jq],[jq_version],[https://github.com/jqlang/jq/issues],[jq],[https://jqlang.github.io/jq])
 
 dnl Created autoconf implementation thompson@dtosolutions, 26NOV12
-AC_PREREQ([2.64])
+AC_PREREQ([2.65])
 AC_CONFIG_AUX_DIR([config])
+AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.11.2 subdir-objects parallel-tests foreign -Wall])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
 AM_MAINTAINER_MODE([enable])
 AC_PROG_CC
-AC_PROG_CC_STDC
+m4_version_prereq([2.70], [], [AC_PROG_CC_STDC])
 AC_PROG_CPP_WERROR
 AC_PROG_YACC
 AC_OBJEXT
 AC_EXEEXT
-AC_USE_SYSTEM_EXTENSIONS
 LT_INIT([shared static win32-dll])
 AM_PROG_CC_C_O
 
@@ -56,32 +55,32 @@ dnl Running tests with Valgrind is slow. It is faster to iterate on
 dnl code without Valgrind until tests pass, then enable Valgrind and
 dnl fix leaks.
 AC_ARG_ENABLE([valgrind],
-   AC_HELP_STRING([--disable-valgrind], [do not run tests under Valgrind]))
+   AS_HELP_STRING([--disable-valgrind],[do not run tests under Valgrind]))
 
 dnl Running tests with Valgrind is slow; address sanitizer (ASAN) is
 dnl faster.
 AC_ARG_ENABLE([asan],
-   AC_HELP_STRING([--enable-asan], [enable address sanitizer]))
+   AS_HELP_STRING([--enable-asan],[enable address sanitizer]))
 
 dnl Undefined Behavior Sanitizer
 AC_ARG_ENABLE([ubsan],
-   AC_HELP_STRING([--enable-ubsan], [enable undefined behavior sanitizer]))
+   AS_HELP_STRING([--enable-ubsan],[enable undefined behavior sanitizer]))
 
 dnl Code coverage
 AC_ARG_ENABLE([gcov],
-   AC_HELP_STRING([--enable-gcov], [enable gcov code coverage tool]))
+   AS_HELP_STRING([--enable-gcov],[enable gcov code coverage tool]))
 
 dnl Don't attempt to build docs if python deps aren't installed
 AC_ARG_ENABLE([docs],
-   AC_HELP_STRING([--disable-docs], [don't build docs]), [], [enable_docs=yes])
+   AS_HELP_STRING([--disable-docs],[do not build docs]), [], [enable_docs=yes])
 
 dnl Don't attempt to build the error injection object (if there is no LD_PRELOAD support)
 AC_ARG_ENABLE([error-injection],
-   AC_HELP_STRING([--enable-error-injection], [build and test with error injection]))
+   AS_HELP_STRING([--enable-error-injection],[build and test with error injection]))
 
 dnl Enable building all static
 AC_ARG_ENABLE([all-static],
-   AC_HELP_STRING([--enable-all-static], [link jq with static libraries only]))
+   AS_HELP_STRING([--enable-all-static],[link jq with static libraries only]))
 
 dnl find pipenv
 AC_ARG_VAR([PIPENV], [pipenv command])
@@ -110,7 +109,7 @@ AS_IF([test "x$enable_docs" != "xno"],[
 
 dnl Disable decNumber support
 AC_ARG_ENABLE([decnum],
-   AC_HELP_STRING([--disable-decnum], [disable decnum support]))
+   AS_HELP_STRING([--disable-decnum],[disable decnum support]))
 
 AS_IF([test "x$enable_decnum" != "xno"],[
    AC_DEFINE([USE_DECNUM],1)

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -14,20 +14,24 @@
 #   flags that are needed. (The user can also force certain compiler
 #   flags/libs to be tested by setting these environment variables.)
 #
-#   Also sets PTHREAD_CC to any special C compiler that is needed for
-#   multi-threaded programs (defaults to the value of CC otherwise). (This
-#   is necessary on AIX to use the special cc_r compiler alias.)
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
 #
 #   NOTE: You are assumed to not only compile your program with these flags,
 #   but also to link with them as well. For example, you might link with
 #   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
 #
 #   If you are only building threaded programs, you may wish to use these
 #   variables in your default LIBS, CFLAGS, and CC:
 #
 #     LIBS="$PTHREAD_LIBS $LIBS"
 #     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 #     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
 #
 #   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
 #   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
@@ -83,7 +87,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 27
+#serial 31
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
@@ -105,6 +109,7 @@ if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
         AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
@@ -386,7 +391,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              # step
              ax_pthread_save_ac_link="$ac_link"
              ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
              ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
              ax_pthread_save_CFLAGS="$CFLAGS"
              for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
@@ -482,18 +487,28 @@ if test "x$ax_pthread_ok" = "xyes"; then
                     [#handle absolute path differently from PATH based program lookup
                      AS_CASE(["x$CC"],
                          [x/*],
-                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
-                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
                 ;;
             esac
         fi
 fi
 
 test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 AC_SUBST([PTHREAD_LIBS])
 AC_SUBST([PTHREAD_CFLAGS])
 AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then


### PR DESCRIPTION
This PR fixes all the autoreconf warnings (confirmed by both autoconf 2.65 and 2.71).

- Bump up minimum autoconf version to `2.65` (Nov 2009), because that's the minimum version with no warnings I confirmed.<details><summary>Dockerfile</summary>

      FROM debian:12-slim AS builder

      RUN apt-get update \
       && apt-get install -y build-essential libtool curl git

      RUN curl -sSfL https://ftp.gnu.org/gnu/autoconf/autoconf-2.65.tar.gz | tar xz -C /tmp \
       && cd /tmp/autoconf-2.65 && ./configure && make && make install

      RUN curl -sSfL https://ftp.gnu.org/gnu/automake/automake-1.16.tar.gz | tar xz -C /tmp \
       && cd /tmp/automake-1.16 && ./configure && make && make install

      WORKDIR /app
      COPY . /app
      RUN autoreconf -I \
       && ./configure \
            --disable-docs \
            --disable-maintainer-mode \
            --disable-valgrind \
            --with-oniguruma=builtin \
            --enable-static \
            --enable-all-static \
            --prefix=/usr/local \
       && make -j$(nproc) \
       && make check \
       && make install-strip

      FROM scratch

      COPY --from=builder /app/AUTHORS /app/COPYING /usr/local/bin/jq /
      RUN ["/jq", "--version"]
      ENTRYPOINT ["/jq"]
</details>

- Since `AC_PROG_CC_STDC` was obsoleted and unified to `AC_PROG_CC` in autoconf 2.70 (Dec 2020), run the macro only for old autoconf.
- Since `AC_HELP_STRING` was replaced by `AS_HELP_STRING` in old autoconf (at least before 2.60), and emits warning since autoconf 2.70, I replaced them all (by `autoupdate`).
- Since `$as_echo` emits warnings to use `AS_ECHO` since autoconf 2.70, updated `m4/ax_pthread.m4` from downloading the latest version from https://www.gnu.org/software/autoconf-archive/ax_pthread.html.
  - `diff m4/ax_pthread.m4 <(curl -sSf "http://git.savannah.gnu.org/gitweb/?p=autoconf-archive.git;a=blob_plain;f=m4/ax_pthread.m4")` yields nothing.
