### PR TITLE
On linux amd64, run tests with valgrind

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,42 @@
+name: valgrind
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade
+          sudo apt-get install -y automake autoconf libtool valgrind
+      - name: Build
+        run: |
+          autoreconf -i
+          ./configure \
+            --disable-maintainer-mode \
+            --disable-docs \
+            --with-oniguruma=builtin
+          make -j"$(nproc)"
+          file ./jq
+      - name: Test
+        run: |
+          make check
+          git diff --exit-code
+      - name: Upload Test Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs-valgrind-linux
+          retention-days: 7
+          path: |
+            test-suite.log
+            tests/*.log


### PR DESCRIPTION
This flag only matters if you run  make check  and we only run tests (with make check) on linux amd64, macos amd64, and windows amd64.

We want to run tests using valgrind on those target to avoid introducing memory leaks, so let's not use `--disable-valgrind`.