### PR TITLE
Fix memory leak on halt_error/1

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -223,7 +223,7 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts) {
     } else if (jv_get_kind(error_message) == JV_KIND_NULL) {
       // Halt with no output
     } else if (jv_is_valid(error_message)) {
-      error_message = jv_dump_string(jv_copy(error_message), 0);
+      error_message = jv_dump_string(error_message, 0);
       fprintf(stderr, "%s\n", jv_string_value(error_message));
     } // else no message on stderr; use --debug-trace to see a message
     fflush(stderr);


### PR DESCRIPTION
I discovered where memory leak is occurring on using `halt_error/1`. I confirmed `make check` with valgrind enabled passes.
Ref: https://github.com/jqlang/jq/pull/2714#issuecomment-1635332661.