### PR TITLE
Initialise jq.input_cb{,_data} to NULL in jq_init()

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -1012,6 +1012,9 @@ jq_state *jq_init(void) {
   jq->exit_code = jv_invalid();
   jq->error_message = jv_invalid();
 
+  jq->input_cb = NULL;
+  jq->input_cb_data = NULL;
+
   jq->err_cb = default_err_cb;
   jq->err_cb_data = stderr;
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1814,3 +1814,10 @@ true
 tojson | fromjson
 {"a":nan}
 {"a":null}
+
+
+# calling input/1 in a test doesn't crash jq
+
+try input catch .
+null
+"break"


### PR DESCRIPTION
To avoid causing segmentation faults when `input/1` is called in a `jq_state` on which `jq_set_input_cb()` has not been called; e.g. the one used by `jq --run-tests`.

That segfault could also be fixed in run_jq_tests() by calling:
```c
jq_set_input_cb(jq, NULL, NULL);
```
But I think it makes sense to just make `jq_init()` initialise those values to NULL.

Ref: https://github.com/jqlang/jq/pull/2717#discussion_r1264338841