### PR TITLE
Add oniguruma workflow to test regex options

### DIFF
--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -1,0 +1,75 @@
+name: oniguruma
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# Since builtin oniguruma is tested in the CI workflow,
+# we test other options for --with-oniguruma here.
+jobs:
+  installed:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y automake autoconf libtool libonig-dev
+      - name: Build
+        run: |
+          autoreconf -i
+          ./configure \
+            --disable-docs \
+            --disable-maintainer-mode \
+            --with-oniguruma=yes
+          make -j"$(nproc)"
+          file ./jq
+      - name: Test
+        run: |
+          ./jq -n '"" | test("")'
+          make check
+          git diff --exit-code
+      - name: Upload Test Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs-oniguruma-installed
+          retention-days: 7
+          path: |
+            test-suite.log
+            tests/*.log
+
+  disabled:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y automake autoconf libtool
+      - name: Build
+        run: |
+          autoreconf -i
+          ./configure \
+            --disable-docs \
+            --disable-maintainer-mode \
+            --with-oniguruma=no
+          make -j"$(nproc)"
+          file ./jq
+      - name: Test
+        run: |
+          ! ./jq -n '"" | test("")'
+          make check
+          git diff --exit-code
+      - name: Upload Test Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs-oniguruma-disabled
+          retention-days: 7
+          path: |
+            test-suite.log
+            tests/*.log


### PR DESCRIPTION
This PR introduces a new oniguruma Actions workflow to cover other options for `--with-oniguruma`. User can link with pre-installed library, or disable the option entirely. Automating these test cases prevents future regression of `make check` fails when built without oniguruma (e.x. #2292).