### PR TITLE
Respect NO_COLOR environment variable to disable color output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -588,6 +588,11 @@ int main(int argc, char* argv[]) {
         dumpopts |= JV_PRINT_COLOR;
     }
 #endif
+    if (dumpopts & JV_PRINT_COLOR) {
+      char *no_color = getenv("NO_COLOR");
+      if (no_color != NULL && no_color[0] != '\0')
+        dumpopts &= ~JV_PRINT_COLOR;
+    }
   }
 #endif
   if (options & SORTED_OUTPUT) dumpopts |= JV_PRINT_SORTED;

--- a/tests/shtest
+++ b/tests/shtest
@@ -414,4 +414,28 @@ JQ_COLORS="0123456789123:0123456789123:0123456789123:0123456789123:0123456789123
 cmp $d/color $d/expect
 cmp $d/warning $d/expect_warning
 
+# Check $NO_COLOR
+if command -v script >/dev/null 2>&1; then
+  unset NO_COLOR
+  if script -qc echo /dev/null >/dev/null 2>&1; then
+    faketty() { script -qec "$*" /dev/null; }
+  else # macOS
+    faketty() { script -q /dev/null "$@" /dev/null |
+      sed 's/^\x5E\x44\x08\x08//'; }
+  fi
+
+  faketty $JQ -n . > $d/color
+  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  cmp $d/color $d/expect
+  NO_COLOR= faketty $JQ -n . > $d/color
+  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  cmp $d/color $d/expect
+  NO_COLOR=1 faketty $JQ -n . > $d/color
+  printf 'null\r\n' > $d/expect
+  cmp $d/color $d/expect
+  NO_COLOR=1 faketty $JQ -Cn . > $d/color
+  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  cmp $d/color $d/expect
+fi
+
 exit 0


### PR DESCRIPTION
This PR implements `NO_COLOR` support. The `NO_COLOR` environment variable is recognized by various command line tools to disable their color output in terminal. See https://no-color.org for the list of commands and example implementation in C. When `--color-output` (`-C`) is used, the color output is enabled regardless of the environment variable (as described in https://no-color.org). This PR resolves #2297.