### PR TITLE
Avoid getpwuid for static linking

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -28,9 +28,6 @@ extern "C"
 void *alloca (size_t);
 # endif
 #endif
-#ifndef WIN32
-#include <pwd.h>
-#endif
 
 #ifdef WIN32
 #include <windows.h>
@@ -103,11 +100,7 @@ jv get_home() {
   char *home = getenv("HOME");
   if (!home) {
 #ifndef WIN32
-    struct passwd* pwd = getpwuid(getuid());
-    if (pwd)
-      ret = jv_string(pwd->pw_dir);
-    else
-      ret = jv_invalid_with_msg(jv_string("Could not find home directory."));
+    ret = jv_invalid_with_msg(jv_string("Could not find home directory."));
 #else
     home = getenv("USERPROFILE");
     if (!home) {


### PR DESCRIPTION
We use `getpwuid` for getting the home directory (when `$HOME` is unset), but this prevents the library to be fully static, and the compiler actually emits warnings on the usage; `warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking`. IMO checking `$HOME` is enough to expand `~/` in the library search paths. For reference, [`os.UserHomeDir()` in Go](https://github.com/golang/go/blob/go1.20/src/os/file.go#L489) is something like this (BTW this implementation let us know how we should handle home on Plan9 but nobody has reported on this topic so far).