### PR TITLE
Enable valgrind in oniguruma workflow

### DIFF
--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y automake autoconf libtool libonig-dev
+          sudo apt-get install -y automake autoconf libtool valgrind libonig-dev
       - name: Build
         run: |
           autoreconf -i
@@ -49,7 +49,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y automake autoconf libtool
+          sudo apt-get install -y automake autoconf libtool valgrind
       - name: Build
         run: |
           autoreconf -i


### PR DESCRIPTION
This PR installs valgrind in the oniguruma workflow. This prevents future memory leakage when oniguruma is disbaled (e.x. #2727).