### PR TITLE
Enable compilation to WebAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ cross-compilation environment.  See also
 ["Cross compilation"](https://github.com/jqlang/jq/wiki/Cross-compilation) on
 the wiki.
 
+To compile jq to WebAssembly, install the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html), then:
+
+    git submodule update --init # if building from git to get oniguruma
+    autoreconf -i               # if building from git
+    emconfigure ./configure --with-oniguruma=builtin --disable-maintainer-mode
+    emmake make EXEEXT=.js CFLAGS="-O2" LDFLAGS="-s EXPORTED_RUNTIME_METHODS=['callMain']"
+
 
 # Community
 

--- a/src/main.c
+++ b/src/main.c
@@ -146,7 +146,6 @@ enum {
   /* debugging only */
   DUMP_DISASM           = 65536,
 };
-static int options = 0;
 
 enum {
     JQ_OK              =  0,
@@ -174,7 +173,7 @@ static const char *skip_shebang(const char *p) {
   return n+1;
 }
 
-static int process(jq_state *jq, jv value, int flags, int dumpopts) {
+static int process(jq_state *jq, jv value, int flags, int dumpopts, int options) {
   int ret = JQ_OK_NO_OUTPUT; // No valid results && -e -> exit(4)
   jq_start(jq, value, flags);
   jv result;
@@ -281,6 +280,7 @@ int main(int argc, char* argv[]) {
   int nfiles = 0;
   int last_result = -1; /* -1 = no result, 0=null or false, 1=true */
   int badwrite;
+  int options = 0;
   jv ARGS = jv_array(); /* positional arguments */
   jv program_arguments = jv_object(); /* named arguments */
 
@@ -290,12 +290,6 @@ int main(int argc, char* argv[]) {
   fflush(stderr);
   _setmode(fileno(stdout), _O_TEXT | _O_U8TEXT);
   _setmode(fileno(stderr), _O_TEXT | _O_U8TEXT);
-#endif
-
-#ifdef __EMSCRIPTEN__
-  /* When compiling to WebAssembly with Emscripten, reset options to ensure we can
-     call main() multiple times without reinitializing the WebAssembly module. */
-  options = 0;
 #endif
 
   if (argc) progname = argv[0];
@@ -689,13 +683,13 @@ int main(int argc, char* argv[]) {
     jq_util_input_add_input(input_state, "-");
 
   if (options & PROVIDE_NULL) {
-    ret = process(jq, jv_null(), jq_flags, dumpopts);
+    ret = process(jq, jv_null(), jq_flags, dumpopts, options);
   } else {
     jv value;
     while (jq_util_input_errors(input_state) == 0 &&
            (jv_is_valid((value = jq_util_input_next_input(input_state))) || jv_invalid_has_msg(jv_copy(value)))) {
       if (jv_is_valid(value)) {
-        ret = process(jq, value, jq_flags, dumpopts);
+        ret = process(jq, value, jq_flags, dumpopts, options);
         if (ret <= 0 && ret != JQ_OK_NO_OUTPUT)
           last_result = (ret != JQ_OK_NULL_KIND);
         if (jq_halted(jq))

--- a/src/main.c
+++ b/src/main.c
@@ -292,6 +292,12 @@ int main(int argc, char* argv[]) {
   _setmode(fileno(stderr), _O_TEXT | _O_U8TEXT);
 #endif
 
+#ifdef __EMSCRIPTEN__
+  /* When compiling to WebAssembly with Emscripten, reset options to ensure we can
+     call main() multiple times without reinitializing the WebAssembly module. */
+  options = 0;
+#endif
+
   if (argc) progname = argv[0];
 
   jq = jq_init();


### PR DESCRIPTION
This PR adds the ability to compile jq to WebAssembly using Emscripten:

I updated `main.c` to reset `options` to `0` if you're using Emscripten. The issue is that `options` is a global variable set to 0 only once, which makes sense in binary world where we only call `main()` once. But when running `jq.wasm` in the browser, being able to call `main()` multiple times in a row is useful so that you don't reinitialize the WebAssembly module every time. One example is that this has been really useful for my [jq playground](https://github.com/robertaboukhalil/jqkungfu) 🙂

Without this patch, `options` is not reset to 0, so the next time you call `main()`, it uses the previous value of options, which results in an error.
