### PR TITLE
Fix destroying of version when building from tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,7 @@ src/builtin.o: src/builtin.inc
 if MAINTAINER_MODE
 CLEANFILES = src/version.h .remake-version-h src/builtin.inc
 else
+DISTCLEANFILES = src/version.h
 CLEANFILES = .remake-version-h src/builtin.inc
 endif
 bin_PROGRAMS = jq

--- a/Makefile.am
+++ b/Makefile.am
@@ -117,8 +117,11 @@ src/builtin.inc: $(srcdir)/src/builtin.jq
 	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $(srcdir)/src/builtin.jq > $@
 src/builtin.o: src/builtin.inc
 
+if MAINTAINER_MODE
 CLEANFILES = src/version.h .remake-version-h src/builtin.inc
-
+else
+CLEANFILES = .remake-version-h src/builtin.inc
+endif
 bin_PROGRAMS = jq
 jq_SOURCES = src/main.c src/version.h
 jq_LDFLAGS = -static-libtool-libs

--- a/scripts/version
+++ b/scripts/version
@@ -2,10 +2,14 @@
 set -eu
 
 cd "$(dirname "$0")"
-if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
-  git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+if test -d .git; then
+  if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
+    git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+  else
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    commit=$(git describe --always --dirty)
+    echo "${branch}-${commit}"
+  fi
 else
-  branch=$(git rev-parse --abbrev-ref HEAD)
-  commit=$(git describe --always --dirty)
-  echo "${branch}-${commit}"
+  cat ../src/version.h |cut -d'"' -f2
 fi

--- a/scripts/version
+++ b/scripts/version
@@ -2,7 +2,7 @@
 set -eu
 
 cd "$(dirname "$0")"
-if test -d .git; then
+if test -d ../.git; then
   if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
     git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
   else


### PR DESCRIPTION
This prevents destroying of `src/version.h` when running `make clean` after `./configure --disable-maintainer-mode`.
It also fixes `scripts/version` to fetch version from `src/version.h` when we are not in a git repository.

Hope this helps,
Colin