### PR TITLE
Fail quickly if not in git repository in scripts/version

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -eu
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/../"
+test -d .git || exit 1
+
 if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
   git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
 else


### PR DESCRIPTION
The PR #2738 reminds me that while building from tarball, we rely on the script failure at `branch=$(git rev-parse --abbrev-ref HEAD)` to fallback to the `VERSION` variable in Makefile (built from configure). As a result, we see `fatal: not a git repository (or any of the parent directories): .git` a few times while building from tarball. I'd like make the version script fail quickly by simply checking the `.git` directory.