### PR TITLE
Clarify the Docker image location (close #1864)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ you will find cookbooks, discussion of advanced topics, internals,
 release engineering, and more.
 
 Source tarball and built executable releases can be found on the
-homepage and on the github release page, https://github.com/jqlang/jq/releases
+homepage and on the github release page, https://github.com/jqlang/jq/releases.
+Docker image is available at https://github.com/jqlang/jq/pkgs/container/jq.
 
 If you're building directly from the latest git, you'll need flex,
 bison (3.0 or newer), libtool, make, automake, and autoconf installed.

--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -97,6 +97,7 @@ body:
          [32-bit](https://github.com/jqlang/jq/releases/download/jq-1.4/jq-solaris11-32).
 
       ### Windows
+
        * Use [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
          to install jq with `winget install jqlang.jq`.
 
@@ -185,6 +186,13 @@ body:
       from source, leave out this flag. You will need to install
       [Flex](https://github.com/westes/flex) and
       [Bison](https://www.gnu.org/software/bison/).
+
+      ### Docker
+
+      Docker image is available from
+      [GitHub Container Registry](https://github.com/jqlang/jq/pkgs/container/jq).
+
+          docker run -i --rm ghcr.io/jqlang/jq -n 'range(3)'
 
       #### Building the documentation
 


### PR DESCRIPTION
We're going to using GitHub Container Registry for our Docker image releases. Compared to Docker Hub, I prefer the easiness of integration against GitHub Actions. I have already pushed the `latest` tag (again) from the `docker` branch (so the current `latest` tag is a development version), but from the next release new tag `1.7` will available and `latest` will point to that. Anyway we should clarify the image location in the documents. This closes #1864.