### PR TITLE
Enable verbose output of make check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         # Only run tests for amd64 matching the CI machine arch
         if: ${{ matrix.arch == 'amd64' }}
         run: |
-          make check
+          make check VERBOSE=yes
           git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}
@@ -169,7 +169,7 @@ jobs:
         # Only run tests for amd64 matching the CI machine arch
         if: ${{ matrix.arch == 'amd64' }}
         run: |
-          make check
+          make check VERBOSE=yes
           git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}
@@ -247,7 +247,7 @@ jobs:
         if: ${{ matrix.arch == 'amd64' }}
         shell: msys2 {0}
         run: |
-          make check
+          make check VERBOSE=yes
           git diff --exit-code --ignore-submodules
       - name: Upload Test Logs
         if: ${{ failure() }}

--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test
         run: |
           ./jq -n '"" | test("")'
-          make check
+          make check VERBOSE=yes
           git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}
@@ -62,7 +62,7 @@ jobs:
       - name: Test
         run: |
           ! ./jq -n '"" | test("")'
-          make check
+          make check VERBOSE=yes
           git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -29,7 +29,7 @@ jobs:
           file ./jq
       - name: Test
         run: |
-          make check
+          make check VERBOSE=yes
           git diff --exit-code
       - name: Upload Test Logs
         if: ${{ failure() }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN autoreconf -i \
       --enable-all-static \
       --prefix=/usr/local \
  && make -j$(nproc) \
- && make check \
+ && make check VERBOSE=yes \
  && make install-strip
 
 FROM scratch


### PR DESCRIPTION
This allows us to find what failed without downloading test log files. Fixes #2589 and #2742.