### PR TITLE
Remove undocumented and untested --stream-errors option

### DIFF
--- a/src/jv.h
+++ b/src/jv.h
@@ -220,9 +220,8 @@ jv jv_dump_string(jv, int flags);
 char *jv_dump_string_trunc(jv x, char *outbuf, size_t bufsize);
 
 enum {
-  JV_PARSE_SEQ              = 1,
-  JV_PARSE_STREAMING        = 2,
-  JV_PARSE_STREAM_ERRORS    = 4,
+  JV_PARSE_SEQ       = 1,
+  JV_PARSE_STREAMING = 2,
 };
 
 jv jv_parse(const char* string);

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -72,7 +72,6 @@ static void parser_init(struct jv_parser* p, int flags) {
     p->path = jv_array();
   } else {
     p->path = jv_invalid();
-    p->flags &= ~(JV_PARSE_STREAM_ERRORS);
   }
   p->stack = 0;
   p->stacklen = p->stackpos = 0;
@@ -756,8 +755,6 @@ static jv make_error(struct jv_parser* p, const char *fmt, ...) {
   va_start(ap, fmt);
   jv e = jv_string_vfmt(fmt, ap);
   va_end(ap);
-  if ((p->flags & JV_PARSE_STREAM_ERRORS))
-    return JV_ARRAY(e, jv_copy(p->path));
   return jv_invalid_with_msg(e);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -454,10 +454,6 @@ int main(int argc, char* argv[]) {
         parser_flags |= JV_PARSE_STREAMING;
         continue;
       }
-      if (isoption(argv[i], 0, "stream-errors", &short_opts)) {
-        parser_flags |= JV_PARSE_STREAM_ERRORS;
-        continue;
-      }
       if (isoption(argv[i], 'e', "exit-status", &short_opts)) {
         options |= EXIT_STATUS;
         if (!short_opts) continue;


### PR DESCRIPTION
This PR drops `--stream-errors` option. This option is undocumented, and untested. Also buggy; `printf '[' | jq --stream-errors .` aborts with assertion error.