### PR TITLE
builtin.jq: simpler and faster transpose

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -181,14 +181,8 @@ def combinations(n):
       | combinations;
 # transpose a possibly jagged matrix, quickly;
 # rows are padded with nulls so the result is always rectangular.
-def transpose:
-  if . == [] then []
-  else . as $in
-  | (map(length) | max) as $max
-  | length as $length
-  | reduce range(0; $max) as $j
-      ([]; . + [reduce range(0;$length) as $i ([]; . + [ $in[$i][$j] ] )] )
-  end;
+# Using map(length) turns out to be faster than using max(stream)
+def transpose: [range(0; map(length)|max) as $i | [.[][$i]]];
 def in(xs): . as $x | xs | has($x);
 def inside(xs): . as $x | xs | contains($x);
 def repeat(exp):

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -182,7 +182,7 @@ def combinations(n):
 # transpose a possibly jagged matrix, quickly;
 # rows are padded with nulls so the result is always rectangular.
 # Using map(length) turns out to be faster than using max(stream)
-def transpose: [range(0; map(length)|max) as $i | [.[][$i]]];
+def transpose: [range(0; map(length)|max // 0) as $i | [.[][$i]]];
 def in(xs): . as $x | xs | has($x);
 def inside(xs): . as $x | xs | contains($x);
 def repeat(exp):

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -181,7 +181,6 @@ def combinations(n):
       | combinations;
 # transpose a possibly jagged matrix, quickly;
 # rows are padded with nulls so the result is always rectangular.
-# Using map(length) turns out to be faster than using max(stream)
 def transpose: [range(0; map(length)|max // 0) as $i | [.[][$i]]];
 def in(xs): . as $x | xs | has($x);
 def inside(xs): . as $x | xs | contains($x);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1479,6 +1479,10 @@ transpose
 [[1], [2,3]]
 [[1,2],[null,3]]
 
+transpose
+[]
+[]
+
 ascii_upcase
 "useful but not for é"
 "USEFUL BUT NOT FOR é"


### PR DESCRIPTION
It turns out that using max/0 is faster than using a stream-oriented version of max