### PR TITLE
Make maintainer-mode default to disabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
           ./configure \
             --host=${{ matrix.CC }} \
             --disable-docs \
-            --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
             --enable-static \
@@ -156,7 +155,6 @@ jobs:
           ./configure \
             --host="${{ matrix.target }}$(uname -r)" \
             --disable-docs \
-            --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
             --enable-static \
@@ -233,7 +231,6 @@ jobs:
           ./configure \
             --host=${{ matrix.CC }} \
             --disable-docs \
-            --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin \
             --disable-shared \
@@ -282,7 +279,6 @@ jobs:
           autoreconf -i
           ./configure \
             --disable-docs \
-            --disable-maintainer-mode \
             --disable-valgrind \
             --with-oniguruma=builtin
           make distcheck

--- a/.github/workflows/oniguruma.yml
+++ b/.github/workflows/oniguruma.yml
@@ -22,7 +22,6 @@ jobs:
           autoreconf -i
           ./configure \
             --disable-docs \
-            --disable-maintainer-mode \
             --with-oniguruma=yes
           make -j"$(nproc)"
           file ./jq
@@ -55,7 +54,6 @@ jobs:
           autoreconf -i
           ./configure \
             --disable-docs \
-            --disable-maintainer-mode \
             --with-oniguruma=no
           make -j"$(nproc)"
           file ./jq

--- a/.github/workflows/scanbuild.yml
+++ b/.github/workflows/scanbuild.yml
@@ -48,10 +48,7 @@ jobs:
                 CC: ${{ matrix.compiler }}
                 MAKEVARS: ${{ matrix.makevars }}
               run: |
-                autoreconf -i
-                rm src/lexer.c src/lexer.h
-                rm src/parser.c src/parser.h
-                ./configure --with-oniguruma=builtin YACC="$(which bison) -y" $COVERAGE
+                ./configure --with-oniguruma=builtin $COVERAGE
                 scan-build --keep-going make -j4
             - name: Test
               env:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -22,7 +22,6 @@ jobs:
         run: |
           autoreconf -i
           ./configure \
-            --disable-maintainer-mode \
             --disable-docs \
             --with-oniguruma=builtin
           make -j"$(nproc)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ COPY . /app
 RUN autoreconf -i \
  && ./configure \
       --disable-docs \
-      --disable-maintainer-mode \
       --disable-valgrind \
       --with-oniguruma=builtin \
       --enable-static \

--- a/Makefile.am
+++ b/Makefile.am
@@ -229,7 +229,7 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/jq.test tests/onig.test tests/base64.test                 \
         tests/utf8-truncate.jq tests/jq-f-test.sh
 
-AM_DISTCHECK_CONFIGURE_FLAGS=--disable-maintainer-mode --with-oniguruma=builtin
+AM_DISTCHECK_CONFIGURE_FLAGS=--with-oniguruma=builtin
 
 # README.md is expected in GitHub projects, good stuff in it, so we'll
 # distribute it and install it with the package in the doc directory.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Source tarball and built executable releases can be found on the
 homepage and on the github release page, https://github.com/jqlang/jq/releases.
 Docker image is available at https://github.com/jqlang/jq/pkgs/container/jq.
 
-If you're building directly from the latest git, you'll need flex,
-bison (3.0 or newer), libtool, make, automake, and autoconf installed.
+If you're building directly from the latest git, you'll need libtool, make, automake,
+and autoconf installed.
 To get regexp support you'll also need to install Oniguruma or clone it as a
 git submodule as per the instructions below. To build, run:
 
@@ -29,13 +29,8 @@ git submodule as per the instructions below. To build, run:
     make -j8
     make check
 
-To build without bison or flex, add `--disable-maintainer-mode` to the
-./configure invocation:
-
-    ./configure --with-oniguruma=builtin --disable-maintainer-mode
-
-(Developers must not use `--disable-maintainer-mode`, not when making
-changes to the jq parser and/or lexer.)
+Developers must `--enable-maintainer-mode` when making changes to the
+jq parser and lexer which also requires bison and flex to be installed.
 
 To build a statically linked version of jq, run:
 
@@ -71,7 +66,7 @@ To compile jq to WebAssembly, install the [Emscripten SDK](https://emscripten.or
 
     git submodule update --init # if building from git to get oniguruma
     autoreconf -i               # if building from git
-    emconfigure ./configure --with-oniguruma=builtin --disable-maintainer-mode
+    emconfigure ./configure --with-oniguruma=builtin
     emmake make EXEEXT=.js CFLAGS="-O2" LDFLAGS="-s EXPORTED_RUNTIME_METHODS=['callMain']"
 
 

--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -89,7 +89,7 @@ cd "${builddir}/"
      cd ${cwd}
      [[ ! -f ./configure ]] && autoreconf -ivf
      CC=${CC} LDFLAGS=${LDFLAGS} \
-     ./configure --host=${HOST} --build=$(./config/config.guess) --enable-docs=no --enable-shared=no --enable-static=yes --prefix=/ --with-oniguruma=${cwd}/ios/onig/${arch} $(test -z ${BISON+x} && echo '--disable-maintainer-mode')
+     ./configure --host=${HOST} --build=$(./config/config.guess) --enable-docs=no --enable-shared=no --enable-static=yes --prefix=/ --with-oniguruma=${cwd}/ios/onig/${arch} $(test -z ${BISON+x} || echo '--enable-maintainer-mode')
      make -j${MAKEJOBS} install DESTDIR="${cwd}/ios/jq/${arch}"
      make clean
  done

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_USE_SYSTEM_EXTENSIONS
 AM_INIT_AUTOMAKE([1.11.2 subdir-objects parallel-tests foreign -Wall])
 AM_SILENT_RULES([yes])
 AM_PROG_AR
-AM_MAINTAINER_MODE([enable])
+AM_MAINTAINER_MODE([disable])
 AC_PROG_CC
 m4_version_prereq([2.70], [], [AC_PROG_CC_STDC])
 AC_PROG_CPP_WERROR
@@ -33,7 +33,7 @@ if test "$USE_MAINTAINER_MODE" = yes; then
   else
     AX_PROG_BISON_VERSION([3],
       [],
-      [AC_MSG_ERROR([You need bison version 3.0 or greater, or use --disable-maintainer-mode.])])
+      [AC_MSG_ERROR([You need bison version 3.0 or greater])])
   fi
 
   AC_CHECK_PROGS(LEX, flex lex)

--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -160,7 +160,7 @@ body:
           git clone --recursive https://github.com/jqlang/jq.git
           cd jq
           autoreconf -i
-          ./configure --disable-maintainer-mode
+          ./configure
           make
           sudo make install
 
@@ -181,9 +181,8 @@ body:
       by Apple. This can be found in [Homebrew](http://brew.sh) or
       [MacPorts](https://macports.org/).
 
-      The `--disable-maintainer-mode` flag says to use the pre-generated lexer
-      and parser that come with the code. To compile the lexer and parser also
-      from source, leave out this flag. You will need to install
+      If you want to generate the lexer and parser from source you can use the
+      `--enable-maintainer-mode` configure flag. This requires bison to be installed.
       [Flex](https://github.com/westes/flex) and
       [Bison](https://www.gnu.org/software/bison/).
 


### PR DESCRIPTION
This makes the standard build instructions a bit easier, just ./configure, and also requires less tools installed (bison).

Also i think few people probably want to generate the lexer and paser code.