### PR TITLE
Remove all #define _GNU_SOURCE in source files

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1,6 +1,3 @@
-#ifndef _GNU_SOURCE
-# define _GNU_SOURCE
-#endif
 #ifndef __sun__
 # define _XOPEN_SOURCE
 # define _XOPEN_SOURCE_EXTENDED 1

--- a/src/compile.c
+++ b/src/compile.c
@@ -1,6 +1,3 @@
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE // for strdup
-#endif
 #include <assert.h>
 #include <math.h>
 #include <string.h>

--- a/src/inject_errors.c
+++ b/src/inject_errors.c
@@ -1,5 +1,3 @@
-
-#define _GNU_SOURCE /* for RTLD_NEXT */
 #include <assert.h>
 #include <dlfcn.h>
 #include <errno.h>

--- a/src/util.c
+++ b/src/util.c
@@ -1,8 +1,3 @@
-
-#ifdef HAVE_MEMMEM
-#define _GNU_SOURCE
-#endif
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <assert.h>


### PR DESCRIPTION
This is unnecessary since we are using AC_USE_SYSTEM_EXTENSIONS in configure.ac, which makes the compiler always run with -D_GNU_SOURCE=1 when building for GNU/Linux.

Also, the  #define _GNU_SOURCE  in src/util.c, and in src/inject_errors.c (--enable-inject-errors), ware not guarded by a #ifndef _GNU_SOURCE  so they were just triggering redefinition warnings.

---

This fixes the one warning that [#2695](https://github.com/jqlang/jq/pull/2695#issuecomment-1636968885) does not fix. :)

Also a similar warning only triggered in `--enable-inject-errors` builds.