### PR TITLE
Free expected value on invalid actual for test

### DIFF
--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -188,6 +188,7 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int
       }
       jv actual = jq_next(jq);
       if (!jv_is_valid(actual)) {
+        jv_free(expected);
         jv_free(actual);
         printf("*** Insufficient results for test at line number %u: %s\n", lineno, prog);
         pass = 0;


### PR DESCRIPTION
valgrind (3.19.0) locally on macOS docker container seems to detect this leak but not CI.

```sh
$ cat modulemeta.test
modulemeta | .deps |= length
"c"
{"whatever":null,"deps":6}

$ valgrind --error-exitcode=1 --leak-check=full -q ./jq --run-tests < modulemeta.test
Test #1: 'modulemeta | .deps |= length' at line number 1
*** Insufficient results for test at line number 3: modulemeta | .deps |= length
0 of 1 tests passed (0 malformed, 0 skipped)
==14129== 482 (392 direct, 90 indirect) bytes in 1 blocks are definitely lost in loss record 7 of 8
==14129==    at 0x48407B4: malloc (vg_replace_malloc.c:381)
==14129==    by 0x13BC78: jv_mem_alloc (jv_alloc.c:122)
==14129==    by 0x1371C6: jvp_object_new (jv.c:1521)
==14129==    by 0x145840: parse_token (jv_parse.c:167)
==14129==    by 0x145840: scan (jv_parse.c:684)
==14129==    by 0x145840: jv_parser_next (jv_parse.c:793)
==14129==    by 0x1463CB: jv_parse_sized (jv_parse.c:865)
==14129==    by 0x136BD9: run_jq_tests (jq_test.c:183)
==14129==    by 0x1370FA: jq_testsuite (jq_test.c:34)
==14129==    by 0x13135C: main (main.c:582)
==14129==
```