### PR TITLE
Remove deprecated --argfile option

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -257,14 +257,6 @@ sections:
         available in the program and has a string whose contents are to the texts
         in the file named `bar`.
 
-      * `--argfile variable-name filename`:
-
-        Do not use.  Use `--slurpfile` instead.
-
-        (This option is like `--slurpfile`, but when the file has just
-        one text, then that is used, else an array of texts is used as
-        in `--slurpfile`.)
-
       * `--args`:
 
         Remaining arguments are positional string arguments.  These are

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -196,15 +196,6 @@ This option reads all the JSON texts in the named file and binds an array of the
 This option reads in the named file and binds its contents to the given global variable\. If you run jq with \fB\-\-rawfile foo bar\fR, then \fB$foo\fR is available in the program and has a string whose contents are to the texts in the file named \fBbar\fR\.
 .
 .TP
-\fB\-\-argfile variable\-name filename\fR:
-.
-.IP
-Do not use\. Use \fB\-\-slurpfile\fR instead\.
-.
-.IP
-(This option is like \fB\-\-slurpfile\fR, but when the file has just one text, then that is used, else an array of texts is used as in \fB\-\-slurpfile\fR\.)
-.
-.TP
 \fB\-\-args\fR:
 .
 .IP

--- a/src/main.c
+++ b/src/main.c
@@ -521,14 +521,11 @@ int main(int argc, char* argv[]) {
         i += 2; // skip the next two arguments
         continue;
       }
-      if (isoption(argv[i], 0, "argfile", &short_opts) ||
-          isoption(argv[i], 0, "rawfile", &short_opts) ||
+      if (isoption(argv[i], 0, "rawfile", &short_opts) ||
           isoption(argv[i], 0, "slurpfile", &short_opts)) {
         int raw = isoption(argv[i], 0, "rawfile", &short_opts);
         const char *which;
-        if (isoption(argv[i], 0, "argfile", &short_opts))
-          which = "argfile";
-        else if (raw)
+        if (raw)
           which = "rawfile";
         else
           which = "slurpfile";
@@ -546,9 +543,6 @@ int main(int argc, char* argv[]) {
             ret = JQ_ERROR_SYSTEM;
             goto out;
           }
-          if (strcmp(which, "argfile") == 0 &&
-              jv_get_kind(data) == JV_KIND_ARRAY && jv_array_length(jv_copy(data)) == 1)
-              data = jv_array_get(data, 0);
           program_arguments = jv_object_set(program_arguments, jv_string(argv[i+1]), data);
         }
         i += 2; // skip the next two arguments


### PR DESCRIPTION
The `--argfile` option has been documented as `Do not use.` since jq 1.5. It has been 8 years, so let's remove this.