### PR TITLE
Align prompt in help example

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,7 +59,7 @@ static void usage(int code, int keep_it_short) {
     "The simplest filter is ., which copies jq's input to its output\n"
     "unmodified except for formatting. For more advanced filters see\n"
     "the jq(1) manpage (\"man jq\") and/or https://jqlang.github.io/jq/.\n\n"
-    "Example:\n\n\t $ echo '{\"foo\": 0}' | jq .\n"
+    "Example:\n\n\t$ echo '{\"foo\": 0}' | jq .\n"
     "\t{\n\t  \"foo\": 0\n\t}\n\n",
     JQ_VERSION, progname, progname, progname);
   if (keep_it_short) {


### PR DESCRIPTION
Was accidentally unaligned in #2747

Now looks like this:

Example:

	$ echo '{"foo": 0}' | jq .
	{
	  "foo": 0
	}

Before looks like this:

Example:

	 $ echo '{"foo": 0}' | jq .
	{
		"foo": 0
	}