### PR TITLE
Enable gamma, drem on macOS

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -107,28 +107,31 @@ static jv f_plus(jq_state *jq, jv input, jv a, jv b) {
 #ifdef __APPLE__
 // macOS has a bunch of libm deprecation warnings, so let's clean those up
 #ifdef HAVE_TGAMMA
+#define HAVE_GAMMA
 #define gamma tgamma
 #endif
 #ifdef HAVE___EXP10
+#define HAVE_EXP10
 #define exp10 __exp10
 #endif
 #ifdef HAVE_REMAINDER
+#define HAVE_DREM
 #define drem remainder
 #endif
 
 // We replace significand with our own, since there's not a rename-replacement
 #ifdef HAVE_FREXP
-#define HAVE_CUSTOM_SIGNIFICAND
 static double __jq_significand(double x) {
   int z;
   return 2*frexp(x, &z);
 }
+#define HAVE_SIGNIFICAND
 #define significand __jq_significand
 #elif defined(HAVE_SCALBN) && defined(HAVE_ILOGB)
-#define HAVE_CUSTOM_SIGNIFICAND
 static double __jq_significand(double x) {
   return scalbn(x, -ilogb(x));
 }
+#define HAVE_SIGNIFICAND
 #define significand __jq_significand
 #endif
 
@@ -1876,7 +1879,10 @@ static const char jq_builtins[] =
 #undef LIBM_DD
 
 #ifdef __APPLE__
-#undef HAVE_CUSTOM_SIGNIFICAND
+#undef HAVE_GAMMA
+#undef HAVE_EXP10
+#undef HAVE_DREM
+#undef HAVE_SIGNIFICAND
 #endif
 
 static block gen_builtin_list(block builtins) {

--- a/src/libm.h
+++ b/src/libm.h
@@ -174,7 +174,7 @@ LIBM_DD(erfc)
 #else
 LIBM_DD_NO(erfc)
 #endif
-#if (defined(HAVE_EXP10) && !defined(WIN32)) || (defined(__APPLE__) && defined(HAVE___EXP10))
+#if defined(HAVE_EXP10) && !defined(WIN32)
 LIBM_DD(exp10)
 #else
 LIBM_DD_NO(exp10)
@@ -274,7 +274,7 @@ LIBM_DDD(scalbln)
 #else
 LIBM_DDD_NO(scalbln)
 #endif
-#if defined(HAVE_CUSTOM_SIGNIFICAND) || (defined(HAVE_SIGNIFICAND) && !defined(WIN32))
+#if defined(HAVE_SIGNIFICAND) && !defined(WIN32)
 LIBM_DD(significand)
 #else
 LIBM_DD_NO(significand)


### PR DESCRIPTION
This is very related to what I do in #2756, but current implementation disallows gamma and drem on macOS. I fixed the identifier definitions to enable gamma and drem on macOS. I also fixed some macro for exp10 and significand to make them look similar.