### PR TITLE
Hardcode 0/0 => NaN instead of letting C divide 0 by 0

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -383,8 +383,13 @@ static jv f_multiply(jq_state *jq, jv input, jv a, jv b) {
 static jv f_divide(jq_state *jq, jv input, jv a, jv b) {
   jv_free(input);
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
-    if (jv_number_value(b) == 0.0 && jv_number_value(a) != 0.0)
-      return type_error2(a, b, "cannot be divided because the divisor is zero");
+    if (jv_number_value(b) == 0.0) {
+      if (jv_number_value(a) != 0.0)
+        return type_error2(a, b, "cannot be divided because the divisor is zero");
+      jv_free(a);
+      jv_free(b);
+      return jv_number(NAN);
+    }
     jv r = jv_number(jv_number_value(a) / jv_number_value(b));
     jv_free(a);
     jv_free(b);


### PR DESCRIPTION
In C, division by 0 is unspecified in all cases, so we can't expect a C compiler to always generate code that makes a / b yield NaN if both a and b are 0.

Fixup from 886a9b18b10e4e31b8c746d1f243043d2b7ea234

---
Ref: https://github.com/jqlang/jq/pull/2253#discussion_r1276708144