### PR TITLE
builtin.jq: lpad, nwise/1, nwise/2

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -1976,6 +1976,43 @@ sections:
             input: 'null'
             output: ['"less"']
 
+      - title: "`lpad($len; $fill)`, `lpad($len)`"
+        body: |
+
+          These functions can be used to pad the input string. `$len` should be a non-negative
+          integer, and `$fill` should be a non-empty string.
+
+          If the input string has length less than `$len`, then both these functions
+          will pad it using the characters in the `$fill` string to produce
+          a string of length `$len`. Typically, `$fill` is given as a string of length 1.
+
+          `lpad($len)` is equivalent to `lpad($len; " ")`.
+
+        examples:
+          - program: 'map(lpad(2))'
+            input: '["", "a"]'
+            output: ['["  ", " a"]']
+
+          - program: 'map(lpad(4; "- "))'
+            input: '["", "a"]'
+            output: ['["- - ","- -a"]']
+
+      - title: "`nwise($n)`, `nwise($n; stream)`"
+        body: |
+
+          These filters emit a stream of arrays or strings of length $n, except possibly for the last.
+          In the case of `nwise($n)`, the items in the output are taken `$n` at a time from the input array or string.
+          For `nwise($n; stream)`, the items are taken `$n` at a time from the given stream.
+
+        examples:
+          - program: '[range(0; 5)] | [nwise(2)]'
+            input: 'null'
+            output: ['[[0,1],[2,3],[4]]']
+
+          - program: '[nwise(2; range(0; 5))]'
+            input: 'null'
+            output: ['[[0,1],[2,3],[4]]']
+
       - title: "`transpose`"
         body: |
 

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -102,8 +102,9 @@ def scan($re): scan($re; null);
 # If input is an array, then emit a stream of successive subarrays of length $n (or less),
 # and similarly for strings.
 def nwise($n):
-  def n: if length <= $n then . else .[0:$n] , (.[$n:] | n) end;
-  n;
+  def _n: if length <= $n then . else .[:$n] , (.[$n:] | _n) end;
+  if $n <= 0 then "nwise: argument should be non-negative" else _n end;
+
 # nwise($n; s) emits a stream of arrays of length $n except possibly for the last.
 # s is a stream from which items are selected, $n at a time.
 def nwise($n; s):

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1860,6 +1860,10 @@ nwise(2)
 null
 []
 
+try nwise(0) catch .
+[1]
+"nwise: argument should be non-negative"
+
 map(lpad(4))
 ["","a"]
 ["    ","   a"]

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1848,6 +1848,26 @@ map(abs)
 [0.1,1000000000000000002]
 [1e-1, 1000000000000000002]
 
+nwise(2)
+null
+null
+
+nwise(2)
+[]
+[]
+
+[nwise(2; empty)]
+null
+[]
+
+map(lpad(4))
+["","a"]
+["    ","   a"]
+
+[range(0; 5)] | [nwise(2)]
+null
+[[0,1],[2,3],[4]]
+
 # Using a keyword as variable/label name
 
 123 as $label | $label


### PR DESCRIPTION
lpad: left pad
nwise/1 replaces _nwise/1 and works on arrays and strings. nwise($n; stream) is a stream-oriented version of nwise/1, and places no limits on what may appear in the stream. It has $n as its first argument mainly in deference to limit/2.

_nwise/2 is dropped.