### PR TITLE
Redirect questions to Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ about: Create a report to help us improve
 <!--
 READ THIS FIRST!
 
-If you have a usage question, please ask us on either Stack Overflow (https://stackoverflow.com/questions/tagged/jq) or in the #jq channel (https://web.libera.chat/#jq) on Libera.Chat (https://libera.chat/).
+If you have a usage question, please ask us on [Stack Overflow](https://stackoverflow.com/questions/tagged/jq), in the [#jq channel](https://web.libera.chat/#jq) on [Libera.Chat](https://libera.chat/), or in our [Discord server](https://discord.gg/yg6yjNmgAC).
 
 -->
 
@@ -22,8 +22,9 @@ If the input is large, either attach it as a file, or [create a gist](https://gi
 A clear and concise description of what you expected to happen.
 
 **Environment (please complete the following information):**
- - OS and Version: [e.g. macOS, Windows, Linux (please specify distro)]
- - jq version [e.g. 1.5]
+
+- OS and Version: [e.g. macOS, Windows, Linux (please specify distro)]
+- jq version [e.g. 1.5]
 
 **Additional context**
 Add any other context about the problem here.

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -27,26 +27,26 @@ tail: |
   Go read the [tutorial](/jq/tutorial/) for more, or the [manual](/jq/manual/)
   for *way* more.
 
-  Ask questions on [stackoverflow](https://stackoverflow.com/) using the [jq
-  tag](https://stackoverflow.com/questions/tagged/jq), or on the
-  [#jq](https://web.libera.chat/#jq) channel on [Libera.Chat](https://libera.chat/).
+  Have a question related to jq? You can seek answers on [Stack Overflow](https://stackoverflow.com/)
+  by using the [jq tag](https://stackoverflow.com/questions/tagged/jq). For more interactive discussions,
+  feel free to join our [Discord server](https://discord.gg/yg6yjNmgAC).
 
 news:
   - date: 1 November 2018
     body: |
-        jq 1.6 released. See installation options on the [download](/jq/download/)
-        page, and the [release notes](https://github.com/jqlang/jq/releases/tag/jq-1.6)
-        for details.
+      jq 1.6 released. See installation options on the [download](/jq/download/)
+      page, and the [release notes](https://github.com/jqlang/jq/releases/tag/jq-1.6)
+      for details.
 
   - date: 15 August 2015
     body: |
 
-        jq 1.5 released, including new datetime, math, and regexp functions,
-        try/catch syntax, array and object destructuring, a streaming parser,
-        and a module system. See installation options on the
-        [download](/jq/download/) page, and the
-        [release notes](https://github.com/jqlang/jq/releases/tag/jq-1.5)
-        for details.
+      jq 1.5 released, including new datetime, math, and regexp functions,
+      try/catch syntax, array and object destructuring, a streaming parser,
+      and a module system. See installation options on the
+      [download](/jq/download/) page, and the
+      [release notes](https://github.com/jqlang/jq/releases/tag/jq-1.5)
+      for details.
 
   - date: 26 July 2015
     body: |
@@ -69,4 +69,3 @@ news:
     body: |
 
       jq 1.3 released.
-

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -28,8 +28,8 @@ tail: |
   for *way* more.
 
   Have a question related to jq? You can seek answers on [Stack Overflow](https://stackoverflow.com/)
-  by using the [jq tag](https://stackoverflow.com/questions/tagged/jq). For more interactive discussions,
-  feel free to join our [Discord server](https://discord.gg/yg6yjNmgAC).
+  by using the [jq tag](https://stackoverflow.com/questions/tagged/jq), or in the [#jq channel](https://web.libera.chat/#jq)
+  on [Libera.Chat](https://libera.chat/). For more interactive discussions, feel free to join our [Discord server](https://discord.gg/yg6yjNmgAC).
 
 news:
   - date: 1 November 2018


### PR DESCRIPTION
We now have an official Discord server, and most maintainers are hanging out there. It would be a good idea to redirect questions to Discord. Alternatively, we could keep the `Libera.Chat` reference, but this would split the traffic into two places.