### PR TITLE
Fix overflow on integer casting on modulo operator

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -396,7 +396,7 @@ static jv f_divide(jq_state *jq, jv input, jv a, jv b) {
   }
 }
 
-#define dtoi(n) ((n) < INTMAX_MIN ? INTMAX_MIN : -(n) < INTMAX_MIN ? INTMAX_MAX : (intmax_t)(n))
+#define dtoi(n) ((n) < INTMAX_MIN ? INTMAX_MIN : -(n) <= INTMAX_MIN ? INTMAX_MAX : (intmax_t)(n))
 static jv f_mod(jq_state *jq, jv input, jv a, jv b) {
   jv_free(input);
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -502,7 +502,7 @@ static block constant_fold(block a, block b, int op) {
       res = jv_number(na / nb);
       break;
     case '%':
-#define is_unsafe_to_int_cast(n) (isnan(n) || (n) < INTMAX_MIN || -(n) < INTMAX_MIN)
+#define is_unsafe_to_int_cast(n) (isnan(n) || (n) < INTMAX_MIN || -(n) <= INTMAX_MIN)
       if (is_unsafe_to_int_cast(na) || is_unsafe_to_int_cast(nb) || (intmax_t)nb == 0) return gen_noop();
 #undef is_unsafe_to_int_cast
       res = jv_number((intmax_t)na % (intmax_t)nb);

--- a/src/parser.y
+++ b/src/parser.y
@@ -235,7 +235,7 @@ static block constant_fold(block a, block b, int op) {
       res = jv_number(na / nb);
       break;
     case '%':
-#define is_unsafe_to_int_cast(n) (isnan(n) || (n) < INTMAX_MIN || -(n) < INTMAX_MIN)
+#define is_unsafe_to_int_cast(n) (isnan(n) || (n) < INTMAX_MIN || -(n) <= INTMAX_MIN)
       if (is_unsafe_to_int_cast(na) || is_unsafe_to_int_cast(nb) || (intmax_t)nb == 0) return gen_noop();
 #undef is_unsafe_to_int_cast
       res = jv_number((intmax_t)na % (intmax_t)nb);


### PR DESCRIPTION
I noticed that `pow(2, 63)` is unsafe to cast to int. I was carefully flipped the sign, but failed to notice the boundary bug. Ref: #2797