### PR TITLE
Fix typo in CI env vars for Linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,9 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       AR: ${{ matrix.CC }}-ar
-      CHOST: ${{ matrix.cc }}
-      CC: ${{ matrix.cc }}-gcc
-      CPP: ${{ matrix.cc }}-cpp
-      CXX: ${{ matrix.cc }}-g++
+      CHOST: ${{ matrix.CC }}
+      CC: ${{ matrix.CC }}-gcc
+      CPP: ${{ matrix.CC }}-cpp
       LDFLAGS: -s
       SUFFIX: linux-${{ matrix.arch }}
     steps:


### PR DESCRIPTION
For some reason, the env vars are set correctly without refering the variable in `matrix` case-sensitvely:

```
2023-08-01T05:05:58.4626090Z env:
2023-08-01T05:05:58.4626367Z   AR: arm-linux-gnueabihf-ar
2023-08-01T05:05:58.4626690Z   CHOST: arm-linux-gnueabihf
2023-08-01T05:05:58.4626961Z   CC: arm-linux-gnueabihf-gcc
2023-08-01T05:05:58.4627332Z   CPP: arm-linux-gnueabihf-cpp
2023-08-01T05:05:58.4627662Z   CXX: arm-linux-gnueabihf-g++
```

For clarify, we update them to match the definitions. Besides, `CXX` is not needed and removed.

Thanks @wader for spotting the typos!