### PR TITLE
Add --config option printing ./configure options used

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,12 +33,12 @@ ACLOCAL_AMFLAGS = -I config/m4
 # header file creation so we'll use good old make
 if MAINTAINER_MODE
 BUILT_SOURCES = src/lexer.h src/lexer.c src/parser.h src/parser.c 	\
-		src/builtin.inc src/version.h
+		src/builtin.inc src/config_opts.inc src/version.h
 src/lexer.c: src/lexer.l
 	$(AM_V_LEX) flex -o src/lexer.c --header-file=src/lexer.h $<
 src/lexer.h: src/lexer.c
 else
-BUILT_SOURCES = src/builtin.inc src/version.h
+BUILT_SOURCES = src/builtin.inc src/config_opts.inc src/version.h
 .y.c:
 	$(AM_V_YACC) echo "NOT building parser.c!"
 .l.c:
@@ -109,14 +109,20 @@ generate_ver = ver="`{ $(srcdir)/scripts/version || echo '$(VERSION)' ; } | sed 
 src/version.h: .remake-version-h
 	mkdir -p src
 	$(AM_V_GEN) $(generate_ver); echo "$$ver" > $@
-src/main.c: src/version.h
+src/config_opts.inc:
+	mkdir -p src
+	$(AM_V_GEN) if test -x ./config.status; then \
+	  ./config.status --config; \
+	else echo "(unknown)"; \
+	fi | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/"/' -e 's/^/#define JQ_CONFIG /' > $@
+src/main.c: src/version.h src/config_opts.inc
 
 src/builtin.inc: $(srcdir)/src/builtin.jq
 	mkdir -p src
 	$(AM_V_GEN) sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/\\n"/' $(srcdir)/src/builtin.jq > $@
 src/builtin.o: src/builtin.inc
 
-CLEANFILES = src/version.h .remake-version-h src/builtin.inc
+CLEANFILES = src/version.h .remake-version-h src/builtin.inc src/config_opts.inc
 
 bin_PROGRAMS = jq
 jq_SOURCES = src/main.c src/version.h

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -301,6 +301,12 @@ sections:
 
         Output the jq version and exit with zero.
 
+      * `--build-configuration`:
+
+        Output the build configuration of jq and exit with zero.
+        This output has no supported format or structure and may change
+        without notice in future releases.
+
       * `--help` / `-h`:
 
         Output the jq help and exit with zero.
@@ -1967,6 +1973,19 @@ sections:
             input: '[ { "_a": { "__b": 2 } } ]'
             output:
               - '[{"a":{"b":2}}]'
+
+      - title: "`$JQ_BUILD_CONFIGURATION`"
+        body: |
+
+          This builtin binding shows the jq executable's build
+          configuration.  Its value has no particular format, but
+          it can be expected to be at least the `./configure`
+          command-line arguments, and may be enriched in the
+          future to include the version strings for the build
+          tooling used.
+
+          Note that this can be overriden in the command-line
+          with `--arg` and related options.
 
       - title: "`$ENV`, `env`"
         body: |

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -235,6 +235,12 @@ Windows users using WSL, MSYS2, or Cygwin, should use this option when using a n
 Output the jq version and exit with zero\.
 .
 .TP
+\fB\-\-build\-configuration\fR:
+.
+.IP
+Output the build configuration of jq and exit with zero\. This output has no supported format or structure and may change without notice in future releases\.
+.
+.TP
 \fB\-\-help\fR / \fB\-h\fR:
 .
 .IP
@@ -2145,6 +2151,12 @@ jq \'walk( if type == "object" then with_entries( \.key |= sub( "^_+"; "") ) els
 .fi
 .
 .IP "" 0
+.
+.SS "$JQ_BUILD_CONFIGURATION"
+This builtin binding shows the jq executable\'s build configuration\. Its value has no particular format, but it can be expected to be at least the \fB\./configure\fR command\-line arguments, and may be enriched in the future to include the version strings for the build tooling used\.
+.
+.P
+Note that this can be overriden in the command\-line with \fB\-\-arg\fR and related options\.
 .
 .SS "$ENV, env"
 \fB$ENV\fR is an object representing the environment variables as set when the jq program started\.

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@ extern void jv_tsd_dtoa_ctx_init();
 #include "jv_alloc.h"
 #include "util.h"
 #include "src/version.h"
+#include "src/config_opts.inc"
 
 int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
 
@@ -106,6 +107,7 @@ static void usage(int code, int keep_it_short) {
       "  -b, --binary              open input/output streams in binary mode;\n"
 #endif
       "  -V, --version             show the version;\n"
+      "  --build-configuration     show jq's build configuration;\n"
       "  -h, --help                show the help;\n"
       "  --                        terminates argument processing;\n\n"
       "Named arguments are also available as $ARGS.named[], while\n"
@@ -580,6 +582,11 @@ int main(int argc, char* argv[]) {
         ret = JQ_OK;
         goto out;
       }
+      if (isoption(argv[i], 0, "build-configuration", &short_opts)) {
+        printf("%s\n", JQ_CONFIG);
+        ret = JQ_OK;
+        goto out;
+      }
       if (isoption(argv[i], 0, "run-tests", &short_opts)) {
         i++;
         // XXX Pass program_arguments, even a whole jq_state *, through;
@@ -677,6 +684,10 @@ int main(int argc, char* argv[]) {
     ARGS = JV_OBJECT(jv_string("positional"), ARGS,
                      jv_string("named"), jv_copy(program_arguments));
     program_arguments = jv_object_set(program_arguments, jv_string("ARGS"), jv_copy(ARGS));
+    if (!jv_object_has(jv_copy(program_arguments), jv_string("JQ_BUILD_CONFIGURATION")))
+      program_arguments = jv_object_set(program_arguments,
+                                        jv_string("JQ_BUILD_CONFIGURATION"),
+                                        jv_string(JQ_CONFIG)); /* named arguments */
     compiled = jq_compile_args(jq, skip_shebang(jv_string_value(data)), jv_copy(program_arguments));
     free(program_origin);
     jv_free(data);
@@ -685,6 +696,10 @@ int main(int argc, char* argv[]) {
     ARGS = JV_OBJECT(jv_string("positional"), ARGS,
                      jv_string("named"), jv_copy(program_arguments));
     program_arguments = jv_object_set(program_arguments, jv_string("ARGS"), jv_copy(ARGS));
+    if (!jv_object_has(jv_copy(program_arguments), jv_string("JQ_BUILD_CONFIGURATION")))
+      program_arguments = jv_object_set(program_arguments,
+                                        jv_string("JQ_BUILD_CONFIGURATION"),
+                                        jv_string(JQ_CONFIG)); /* named arguments */
     compiled = jq_compile_args(jq, program, jv_copy(program_arguments));
   }
   if (!compiled){


### PR DESCRIPTION
```
./jq --config
'--prefix=/tmp/jq' '--with-oniguruma=builtin' '--enable-maintainer-mode' '--srcdir=..' 'CFLAGS=-pthread -fstack-protector-all'
```

We could add lines recording compiler name and version, flex/bison version, autotools versions, etc.

Closes #2816.