### PR TITLE
Rename jv_type_private.h to jv_private.h, move jvp_number_is_nan there

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ LIBJQ_INCS = src/builtin.h src/bytecode.h src/compile.h                 \
         src/linker.h src/locfile.h src/opcode_list.h src/parser.y       \
         src/util.h src/decNumber/decContext.h src/decNumber/decNumber.h \
         src/decNumber/decNumberLocal.h src/jv_dtoa_tsd.h src/jv_thread.h \
-        src/jv_type_private.h
+        src/jv_private.h
 
 LIBJQ_SRC = src/builtin.c src/bytecode.c src/compile.c src/execute.c    \
         src/jq_test.c src/jv.c src/jv_alloc.c src/jv_aux.c              \

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -43,6 +43,7 @@ void *alloca (size_t);
 #include "locfile.h"
 #include "jv_unicode.h"
 #include "jv_alloc.h"
+#include "jv_private.h"
 #include "util.h"
 
 

--- a/src/jv.h
+++ b/src/jv.h
@@ -70,7 +70,6 @@ jv jv_number(double);
 jv jv_number_with_literal(const char*);
 double jv_number_value(jv);
 int jv_is_integer(jv);
-int jvp_number_is_nan(jv);
 
 int jv_number_has_literal(jv n);
 const char* jv_number_get_literal(jv);

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "jv_alloc.h"
-#include "jv_type_private.h"
+#include "jv_private.h"
 
 // making this static verbose function here
 // until we introduce a less confusing naming scheme

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -14,7 +14,7 @@
 #include "jv_dtoa_tsd.h"
 #include "jv_unicode.h"
 #include "jv_alloc.h"
-#include "jv_type_private.h"
+#include "jv_private.h"
 
 #ifndef MAX_PRINT_DEPTH
 #define MAX_PRINT_DEPTH (256)

--- a/src/jv_private.h
+++ b/src/jv_private.h
@@ -1,0 +1,7 @@
+#ifndef JV_PRIVATE
+#define JV_PRIVATE
+
+int jvp_number_cmp(jv, jv);
+int jvp_number_is_nan(jv);
+
+#endif //JV_PRIVATE

--- a/src/jv_type_private.h
+++ b/src/jv_type_private.h
@@ -1,6 +1,0 @@
-#ifndef JV_TYPE_PRIVATE
-#define JV_TYPE_PRIVATE
-
-int jvp_number_cmp(jv, jv);
-
-#endif //JV_TYPE_PRIVATE


### PR DESCRIPTION
I noticed that `jvp_number_is_nan` has been moved to `jv.h` in #2646, but I think it should remain in `jv_type_private.h`. I feel the header name a bit verbose, so I'd like to rename to `jv_private.h`, and put `jvp_number_is_nan` into it.