### PR TITLE
Let error(null) throw null

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -1231,10 +1231,6 @@ sections:
           given as the argument. Errors can be caught with try/catch;
           see below.
 
-          When the error value is `null`, it produces nothing and works
-          just like `empty`. So `[null | error]` and `[error(null)]` both
-          emit `[]`.
-
         examples:
           - program: 'try error catch .'
             input: '"error message"'

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1263,9 +1263,6 @@ jq \'[1,2,empty,3]\'
 .SS "error, error(message)"
 Produces an error with the input value, or with the message given as the argument\. Errors can be caught with try/catch; see below\.
 .
-.P
-When the error value is \fBnull\fR, it produces nothing and works just like \fBempty\fR\. So \fB[null | error]\fR and \fB[error(null)]\fR both emit \fB[]\fR\.
-.
 .IP "" 4
 .
 .nf

--- a/src/jv.c
+++ b/src/jv.c
@@ -147,8 +147,6 @@ typedef struct {
 } jvp_invalid;
 
 jv jv_invalid_with_msg(jv err) {
-  if (JVP_HAS_KIND(err, JV_KIND_NULL))
-    return JV_INVALID;
   jvp_invalid* i = jv_mem_alloc(sizeof(jvp_invalid));
   i->refcnt = JV_REFCNT_INIT;
   i->errmsg = err;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1270,13 +1270,11 @@ null
 [null,true,{"a":1}]
 []
 
-[1,error,2]
+.[] | try error catch .
+[1,null,2]
+1
 null
-[1,2]
-
-[1,error(null),2]
-0
-[1,2]
+2
 
 try error("\($__loc__)") catch .
 null


### PR DESCRIPTION
This patch removes the weird behaviour of `jv_invalid_with_msg(jv_null())` that returns `jv_invalid()` (i.e. empty), instead of a boxed `jv_null()`.

The previous behaviour of `null|error` was obviously unintentional, and allowing `jv_invalid_with_msg()` to return values on which you can't call `jv_invalid_get_msg()` is only error prone.

---

I don't see a reason to keep and document this behaviour, it is obviously a bug, it is not useful, and it was not documented in jq 1.6.

Either way, `jv_invalid_with_msg(jv_null())` should be fixed to not return `jv_invalid()` in my opinion.
The "`null|error` is equivalent to `empty`" behaviour can be implemented in `f_error` if we really want to keep it.

```patch
diff --git a/src/builtin.c b/src/builtin.c
index 0d0ac23..e84bef9 100644
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1139,6 +1139,8 @@ static jv f_nan(jq_state *jq, jv input) {
 }
 
 static jv f_error(jq_state *jq, jv input) {
+  if (jv_get_kind(input) == JV_KIND_NULL)
+    return jv_invalid();
   return jv_invalid_with_msg(input);
 }
 
```