### PR TITLE
Change the default color of null to Bright Black

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,8 +26,8 @@ Full commit log can be found at <https://github.com/jqlang/jq/compare/jq-1.6...j
 - Make object key color configurable using `JQ_COLORS` environment variable. @itchyny @haguenau @ericpruitt #2703
 
   ```sh
-  # this would make "field" yellow (33, the last value)
-  $ JQ_COLORS="1;30:0;37:0;37:0;37:0;32:1;37:1;37:1;33" ./jq -n '{field: 123}'
+  # this would make "field" bold yellow (`1;33`, the last value)
+  $ JQ_COLORS="0;90:0;37:0;37:0;37:0;32:1;37:1;37:1;33" ./jq -n '{field: 123}'
   {
     "field": 123
   }

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3656,7 +3656,7 @@ sections:
         - color for object keys
 
       The default color scheme is the same as setting
-      `JQ_COLORS="1;30:0;37:0;37:0;37:0;32:1;37:1;37:1;34"`.
+      `JQ_COLORS="0;90:0;37:0;37:0;37:0;32:1;37:1;37:1;34"`.
 
       This is not a manual for VT100/ANSI escapes.  However, each of
       these color specifications should consist of two numbers separated

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -4046,7 +4046,7 @@ color for object keys
 .IP "" 0
 .
 .P
-The default color scheme is the same as setting \fBJQ_COLORS="1;30:0;37:0;37:0;37:0;32:1;37:1;37:1;34"\fR\.
+The default color scheme is the same as setting \fBJQ_COLORS="0;90:0;37:0;37:0;37:0;32:1;37:1;37:1;34"\fR\.
 .
 .P
 This is not a manual for VT100/ANSI escapes\. However, each of these color specifications should consist of two numbers separated by a semi\-colon, where the first number is one of these:

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -30,7 +30,7 @@
 static char color_bufs[8][16];
 static const char *color_bufps[8];
 static const char* def_colors[] =
-  {COL("1;30"),    COL("0;37"),      COL("0;37"),     COL("0;37"),
+  {COL("0;90"),    COL("0;37"),      COL("0;37"),     COL("0;37"),
    COL("0;32"),    COL("1;37"),      COL("1;37"),     COL("1;34")};
 #define FIELD_COLOR (colors[7])
 

--- a/tests/shtest
+++ b/tests/shtest
@@ -417,7 +417,7 @@ unset JQ_COLORS
 
 ## Default colors, null input
 $JQ -Ccn . > $d/color
-printf '\033[1;30mnull\033[0m\n' > $d/expect
+printf '\033[0;90mnull\033[0m\n' > $d/expect
 cmp $d/color $d/expect
 
 ## Set non-default color, null input
@@ -438,27 +438,27 @@ $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
   printf '[0m\033[1;37m\033[1;37'
   printf 'm}\033[0m\033[1;37m,\033['
   printf '0;37m123\033[0m\033[1;'
-  printf '37m,\033[1;30mnull\033'
+  printf '37m,\033[0;90mnull\033'
   printf '[0m\033[1;37m\033[1;37'
   printf 'm]\033[0m\n'
 } > $d/expect
 cmp $d/color $d/expect
 
 ## Set non-default colors, complex input
-JQ_COLORS='1;30:0;31:0;32:0;33:0;34:1;35:1;36:1;30' \
+JQ_COLORS='0;30:0;31:0;32:0;33:0;34:1;35:1;36:1;37' \
   $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
 {
   printf '\033[1;35m[\033[1;36m{'
-  printf '\033[0m\033[1;30m"a"\033['
+  printf '\033[0m\033[1;37m"a"\033['
   printf '0m\033[1;36m:\033[0m\033['
   printf '0;32mtrue\033[0m\033[1'
-  printf ';36m,\033[0m\033[1;30m'
+  printf ';36m,\033[0m\033[1;37m'
   printf '"b"\033[0m\033[1;36m:\033'
   printf '[0m\033[0;31mfalse\033'
   printf '[0m\033[1;36m\033[1;36'
   printf 'm}\033[0m\033[1;35m,\033['
   printf '0;33m123\033[0m\033[1;'
-  printf '35m,\033[1;30mnull\033'
+  printf '35m,\033[0;30mnull\033'
   printf '[0m\033[1;35m\033[1;35'
   printf 'm]\033[0m\n'
 } > $d/expect
@@ -503,16 +503,16 @@ if command -v script >/dev/null 2>&1; then
   fi
 
   faketty $JQ -n . > $d/color
-  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   cmp $d/color $d/expect
   NO_COLOR= faketty $JQ -n . > $d/color
-  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   cmp $d/color $d/expect
   NO_COLOR=1 faketty $JQ -n . > $d/color
   printf 'null\r\n' > $d/expect
   cmp $d/color $d/expect
   NO_COLOR=1 faketty $JQ -Cn . > $d/color
-  printf '\033[1;30mnull\033[0m\r\n' > $d/expect
+  printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   cmp $d/color $d/expect
 fi
 


### PR DESCRIPTION
There have been multiple reports about the default color of `null` on dark background (#1252, #1972, #2113). Currently `null` is colored by `\e[1;30m`, which means bold (or increased intensity) black, and is totally invisible on some terminals (e.x. Terminal.app with Homebrew/Pro profile). I think we could improve the `null` color for *the better defaults*, I choose `\e[0;90m`, which means normal bright black. This color should look better on dark background color schemes.
This PR resolves #1252, resolves #1972, and resolves #2113.