### PR TITLE
Expose a module's function names in `modulemeta`

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3633,7 +3633,8 @@ sections:
 
           Takes a module name as input and outputs the module's metadata
           as an object, with the module's imports (including metadata)
-          as an array value for the `deps` key.
+          as an array value for the `deps` key and the module's defined
+          functions as an array value for the `defs` key.
 
           Programs can use this to query a module's metadata, which they
           could then use to, for example, search for, download, and

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -4011,7 +4011,7 @@ This directive is entirely optional\. It\'s not required for proper operation\. 
 The metadata must be a constant jq expression\. It should be an object with keys like \fBhomepage\fR\. At this time jq doesn\'t use this metadata, but it is made available to users via the \fBmodulemeta\fR builtin\.
 .
 .SS "modulemeta"
-Takes a module name as input and outputs the module\'s metadata as an object, with the module\'s imports (including metadata) as an array value for the \fBdeps\fR key\.
+Takes a module name as input and outputs the module\'s metadata as an object, with the module\'s imports (including metadata) as an array value for the \fBdeps\fR key and the module\'s defined functions as an array value for the \fBdefs\fR key\.
 .
 .P
 Programs can use this to query a module\'s metadata, which they could then use to, for example, search for, download, and install missing dependencies\.

--- a/src/linker.c
+++ b/src/linker.c
@@ -390,6 +390,7 @@ jv load_module_meta(jq_state *jq, jv mod_relpath) {
       if (jv_get_kind(meta) == JV_KIND_NULL)
         meta = jv_object();
       meta = jv_object_set(meta, jv_string("deps"), block_take_imports(&program));
+      meta = jv_object_set(meta, jv_string("defs"), block_list_funcs(program, 0));
     }
     locfile_free(src);
     block_free(program);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1624,11 +1624,15 @@ jq: error: Import path must be constant at <top-level>, line 1:
 
 modulemeta
 "c"
-{"whatever":null,"deps":[{"as":"foo","is_data":false,"relpath":"a"},{"search":"./","as":"d","is_data":false,"relpath":"d"},{"search":"./","as":"d2","is_data":false,"relpath":"d"},{"search":"./../lib/jq","as":"e","is_data":false,"relpath":"e"},{"search":"./../lib/jq","as":"f","is_data":false,"relpath":"f"},{"as":"d","is_data":true,"relpath":"data"}]}
+{"whatever":null,"deps":[{"as":"foo","is_data":false,"relpath":"a"},{"search":"./","as":"d","is_data":false,"relpath":"d"},{"search":"./","as":"d2","is_data":false,"relpath":"d"},{"search":"./../lib/jq","as":"e","is_data":false,"relpath":"e"},{"search":"./../lib/jq","as":"f","is_data":false,"relpath":"f"},{"as":"d","is_data":true,"relpath":"data"}],"defs":["a/0","c/0"]}
 
-modulemeta | .deps |= length
+modulemeta | .deps | length
 "c"
-{"whatever":null,"deps":6}
+6
+
+modulemeta | .defs | length
+"c"
+2
 
 %%FAIL IGNORE MSG
 import "syntaxerror" as e; .


### PR DESCRIPTION
This PR adds a new field, `defs`, to the output of `modulemeta`.

This field contains the names and arities of functions defined within that module. For example

```jq
module {
  name: "example",
  version: "0.0.0"
};

def foo(): 1;
def bar($baz): $baz + 1;
```

```sh
$ jq -L. --null-input '"example" | modulemeta | .defs[]'

"foo/0"
"bar/1"
```

The intent of this change is to make it easier for tools / processes built on top of `jq` to introspect about function definitions within the modules.