### PR TITLE
Fix negative index double wrapping and add a test (fix #2826)

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -1048,10 +1048,11 @@ sections:
       - title: "`pick(pathexps)`"
         body: |
 
-          Emit the projection of the input object or array defined by the specified
-          sequence of path expressions, such that if p is any one of these specifications,
-          then `(. | p)` will evaluate to the same value as `(. | pick(pathexps) | p)`.
-          For arrays, negative indices and .[m:n] specifications should not be used.
+          Emit the projection of the input object or array defined by the
+          specified sequence of path expressions, such that if `p` is any
+          one of these specifications, then `(. | p)` will evaluate to the
+          same value as `(. | pick(pathexps) | p)`. For arrays, negative
+          indices and `.[m:n]` specifications should not be used.
 
         examples:
           - program: 'pick(.a, .b.c, .x)'

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1050,7 +1050,7 @@ jq \'map_values(\. // empty)\'
 .IP "" 0
 .
 .SS "pick(pathexps)"
-Emit the projection of the input object or array defined by the specified sequence of path expressions, such that if p is any one of these specifications, then \fB(\. | p)\fR will evaluate to the same value as \fB(\. | pick(pathexps) | p)\fR\. For arrays, negative indices and \.[m:n] specifications should not be used\.
+Emit the projection of the input object or array defined by the specified sequence of path expressions, such that if \fBp\fR is any one of these specifications, then \fB(\. | p)\fR will evaluate to the same value as \fB(\. | pick(pathexps) | p)\fR\. For arrays, negative indices and \fB\.[m:n]\fR specifications should not be used\.
 .
 .IP "" 4
 .

--- a/src/execute.c
+++ b/src/execute.c
@@ -694,14 +694,6 @@ jv jq_next(jq_state *jq) {
         set_error(jq, jv_invalid_with_msg(msg));
         goto do_backtrack;
       }
-      // $array | .[-1]
-      if (jv_get_kind(k) == JV_KIND_NUMBER && jv_get_kind(t) == JV_KIND_ARRAY) {
-        int idx = jv_number_value(k);
-        if (idx < 0) {
-          jv_free(k);
-          k = jv_number(jv_array_length(jv_copy(t)) + idx);
-        }
-      }
       jv v = jv_get(t, jv_copy(k));
       if (jv_is_valid(v)) {
         path_append(jq, k, jv_copy(v));

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -248,9 +248,9 @@ null
 2
 3
 
-.[-2]
+[.[-4,-3,-2,-1,0,1,2,3]]
 [1,2,3]
-2
+[null,1,2,3,1,2,3,null]
 
 [range(0;10)]
 null
@@ -1052,9 +1052,9 @@ pick(first|first)
 [[10]]
 
 # negative indices in path expressions (since last/1 is .[-1])
-pick(last)
-[[10,20],30]
-[null,30]
+try pick(last) catch .
+[1,2]
+"Out of bounds negative array index"
 
 #
 # Assignment


### PR DESCRIPTION
I would like to fix #2826 by removing the code to make `path(last)` work. New feature should be added carefully not to change the behavior of this kind of core features. Currently, as mentioned in the manual clearly as `For arrays, negative indices and .[m:n] specifications should not be used.`, we disallow negative indices and array slicing. I added path validation to follow how the manual states.