### PR TITLE
Better checking for `$v` not being a path expression (Fix #2844)

### DIFF
--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -105,7 +105,8 @@ jv get_location(struct bytecode *bc, uint16_t *codeptr) {
   if (offset == -1)
     return jv_copy(bc->fname);
   const char *prog = jv_string_value(bc->program);
-  for (i = 0; i < offset; i++) {
+  int len = jv_string_length_bytes(jv_copy(bc->program));
+  for (i = 0; i < offset && i < len; i++) {
     if (prog[i] == '\n') {
       lineno++;
       column = 0;

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "jv.h"
+#include "locfile.h"
 
 typedef enum {
 #define OP(name, imm, in, out) name,
@@ -80,12 +81,17 @@ struct bytecode {
   struct bytecode* parent;
 
   jv debuginfo;
+  jv fname;
+  jv program;
+  int32_t *location_offsets;
 };
 
 void dump_disassembly(int, struct bytecode* code);
 void dump_operation(struct bytecode* bc, uint16_t* op);
+jv get_location(struct bytecode *, uint16_t *);
 
 int bytecode_operation_length(uint16_t* codeptr);
+struct bytecode *bytecode_alloc(struct locfile *);
 void bytecode_free(struct bytecode* bc);
 
 #endif

--- a/src/compile.c
+++ b/src/compile.c
@@ -1318,8 +1318,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
     const struct opcode_description* op = opcode_describe(curr->op);
     if (op->length == 0)
       continue;
-    if (curr->source.start != -1)
-      bc->location_offsets[pos] = curr->source.start;
+    bc->location_offsets[pos] = curr->source.start;
     code[pos++] = curr->op;
     assert(curr->op != CLOSURE_REF && curr->op != CLOSURE_PARAM);
     if (curr->op == CALL_BUILTIN) {

--- a/src/compile.c
+++ b/src/compile.c
@@ -1286,7 +1286,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
     bc->subfunctions = jv_mem_calloc(sizeof(struct bytecode*), bc->nsubfunctions);
     for (inst* curr = b.first; curr; curr = curr->next) {
       if (curr->op == CLOSURE_CREATE) {
-        struct bytecode* subfn = jv_mem_alloc(sizeof(struct bytecode));
+        struct bytecode* subfn = bytecode_alloc(b.first->locfile ? b.first->locfile : lf);
         bc->subfunctions[curr->imm.intval] = subfn;
         subfn->globals = bc->globals;
         subfn->parent = bc;
@@ -1310,6 +1310,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
   }
   uint16_t* code = jv_mem_calloc(sizeof(uint16_t), bc->codelen);
   bc->code = code;
+  bc->location_offsets = jv_mem_calloc(sizeof(uint32_t), bc->codelen);
   pos = 0;
   jv constant_pool = jv_array();
   int maxvar = -1;
@@ -1317,6 +1318,8 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
     const struct opcode_description* op = opcode_describe(curr->op);
     if (op->length == 0)
       continue;
+    if (curr->source.start != -1)
+      bc->location_offsets[pos] = curr->source.start;
     code[pos++] = curr->op;
     assert(curr->op != CLOSURE_REF && curr->op != CLOSURE_PARAM);
     if (curr->op == CALL_BUILTIN) {
@@ -1368,7 +1371,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
 }
 
 int block_compile(block b, struct bytecode** out, struct locfile* lf, jv args) {
-  struct bytecode* bc = jv_mem_alloc(sizeof(struct bytecode));
+  struct bytecode* bc = bytecode_alloc(lf);
   bc->parent = 0;
   bc->nclosures = 0;
   bc->globals = jv_mem_alloc(sizeof(struct symbol_table));

--- a/src/execute.c
+++ b/src/execute.c
@@ -347,7 +347,11 @@ void jq_report_error(jq_state *jq, jv value) {
 static void set_error(jq_state *jq, uint16_t *pc, jv value) {
   // Record so try/catch can find it.
   jv_free(jq->error);
-  jq->error = jv_invalid_with_msg(JV_STRING(jv_invalid_get_msg(value), jv_string(" at "), get_location(frame_current(jq)->bc, pc)));
+  char errbuf[15];
+  value = jv_invalid_get_msg(value);
+  if (jv_get_kind(value) != JV_KIND_STRING)
+    value = jv_string(jv_dump_string_trunc(value, errbuf, sizeof(errbuf)));
+  jq->error = jv_invalid_with_msg(JV_STRING(value, jv_string(" at "), get_location(frame_current(jq)->bc, pc)));
 }
 
 #define ON_BACKTRACK(op) ((op)+NUM_OPCODES)

--- a/src/execute.c
+++ b/src/execute.c
@@ -310,16 +310,19 @@ static void jq_reset(jq_state *jq) {
   assert(jq->fork_top == 0);
   assert(jq->curr_frame == 0);
   stack_reset(&jq->stk);
-  jv_free(jq->error);
-  jq->error = jv_null();
 
   jq->halted = 0;
+
+  jv_free(jq->error);
   jv_free(jq->exit_code);
   jv_free(jq->error_message);
-  if (jv_get_kind(jq->path) != JV_KIND_INVALID)
-    jv_free(jq->path);
-  jq->path = jv_null();
+  jv_free(jq->path);
   jv_free(jq->value_at_path);
+
+  jq->error = jv_null();
+  jq->exit_code = jv_invalid();
+  jq->error_message = jv_invalid();
+  jq->path = jv_null();
   jq->value_at_path = jv_null();
 
   /*

--- a/src/execute.c
+++ b/src/execute.c
@@ -1259,10 +1259,14 @@ args2obj(jv args)
 }
 
 int jq_compile_args(jq_state *jq, const char* str, jv args) {
+  return jq_compile_args2(jq, "<top-level>", str, args);
+}
+
+int jq_compile_args2(jq_state *jq, const char *fname, const char *str, jv args) {
   jv_nomem_handler(jq->nomem_handler, jq->nomem_handler_data);
   assert(jv_get_kind(args) == JV_KIND_ARRAY || jv_get_kind(args) == JV_KIND_OBJECT);
   struct locfile* locations;
-  locations = locfile_init(jq, "<top-level>", str, strlen(str));
+  locations = locfile_init(jq, fname, str, strlen(str));
   block program;
   jq_reset(jq);
   if (jq->bc) {

--- a/src/execute.c
+++ b/src/execute.c
@@ -491,6 +491,10 @@ jv jq_next(jq_state *jq) {
       jv v = jv_array_get(jv_copy(frame_current(jq)->bc->constants), *pc++);
       assert(jv_is_valid(v));
       jv v2 = stack_pop(jq);
+      if (jq->subexp_nest == 0) {
+        set_error(jq, pc, jv_invalid_with_msg(jv_string("Invalid path expression")));
+        goto do_backtrack;
+      }
       stack_push(jq, v);
       stack_push(jq, v2);
       break;

--- a/src/jq.h
+++ b/src/jq.h
@@ -21,6 +21,7 @@ jv jq_format_error(jv msg);
 void jq_report_error(jq_state *, jv);
 int jq_compile(jq_state *, const char*);
 int jq_compile_args(jq_state *, const char*, jv);
+int jq_compile_args2(jq_state *, const char *, const char *, jv);
 void jq_dump_disassembly(jq_state *, int);
 void jq_start(jq_state *, jv value, int);
 jv jq_next(jq_state *);

--- a/src/jv.h
+++ b/src/jv.h
@@ -131,6 +131,32 @@ jv jv_string_split(jv j, jv sep);
 jv jv_string_explode(jv j);
 jv jv_string_implode(jv j);
 
+#define JV_STRING_1(e) (jv_string_concat(jv_string(""),e))
+#define JV_STRING_2(e1,e2) (jv_string_concat(JV_STRING_1(e1),e2))
+#define JV_STRING_3(e1,e2,e3) (jv_string_concat(JV_STRING_2(e1,e2),e3))
+#define JV_STRING_4(e1,e2,e3,e4) (jv_string_concat(JV_STRING_3(e1,e2,e3),e4))
+#define JV_STRING_5(e1,e2,e3,e4,e5) (jv_string_concat(JV_STRING_4(e1,e2,e3,e4),e5))
+#define JV_STRING_6(e1,e2,e3,e4,e5,e6) (jv_string_concat(JV_STRING_5(e1,e2,e3,e4,e5),e6))
+#define JV_STRING_7(e1,e2,e3,e4,e5,e6,e7) (jv_string_concat(JV_STRING_6(e1,e2,e3,e4,e5,e6),e7))
+#define JV_STRING_8(e1,e2,e3,e4,e5,e6,e7,e8) (jv_string_concat(JV_STRING_7(e1,e2,e3,e4,e5,e6,e7),e8))
+#define JV_STRING_9(e1,e2,e3,e4,e5,e6,e7,e8,e9) (jv_string_concat(JV_STRING_8(e1,e2,e3,e4,e5,e6,e7,e8),e9))
+#define JV_STRING_IDX(_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
+#define JV_STRING(...) \
+  JV_STRING_IDX(__VA_ARGS__, JV_STRING_9, JV_STRING_8, JV_STRING_7, JV_STRING_6, JV_STRING_5, JV_STRING_4, JV_STRING_3, JV_STRING_2, JV_STRING_1, dummy)(__VA_ARGS__)
+
+#define JV_CSTRING_1(e) (jv_string_concat(jv_string(""),jv_string(e)))
+#define JV_CSTRING_2(e1,e2) (jv_string_concat(JV_CSTRING_1(e1),jv_string(e2)))
+#define JV_CSTRING_3(e1,e2,e3) (jv_string_concat(JV_CSTRING_2(e1,e2),jv_string(e3)))
+#define JV_CSTRING_4(e1,e2,e3,e4) (jv_string_concat(JV_CSTRING_3(e1,e2,e3),jv_string(e4)))
+#define JV_CSTRING_5(e1,e2,e3,e4,e5) (jv_string_concat(JV_CSTRING_4(e1,e2,e3,e4),jv_string(e5)))
+#define JV_CSTRING_6(e1,e2,e3,e4,e5,e6) (jv_string_concat(JV_CSTRING_5(e1,e2,e3,e4,e5),jv_string(e6)))
+#define JV_CSTRING_7(e1,e2,e3,e4,e5,e6,e7) (jv_string_concat(JV_CSTRING_6(e1,e2,e3,e4,e5,e6),jv_string(e7)))
+#define JV_CSTRING_8(e1,e2,e3,e4,e5,e6,e7,e8) (jv_string_concat(JV_CSTRING_7(e1,e2,e3,e4,e5,e6,e7),jv_string(e8)))
+#define JV_CSTRING_9(e1,e2,e3,e4,e5,e6,e7,e8,e9) (jv_string_concat(JV_CSTRING_8(e1,e2,e3,e4,e5,e6,e7,e8),jv_string(e9)))
+#define JV_CSTRING_IDX(_1,_2,_3,_4,_5,_6,_7,_8,_9,NAME,...) NAME
+#define JV_CSTRING(...) \
+  JV_CSTRING_IDX(__VA_ARGS__, JV_CSTRING_9, JV_CSTRING_8, JV_CSTRING_7, JV_CSTRING_6, JV_CSTRING_5, JV_CSTRING_4, JV_CSTRING_3, JV_CSTRING_2, JV_CSTRING_1, dummy)(__VA_ARGS__)
+
 jv jv_object(void);
 jv jv_object_get(jv object, jv key);
 int jv_object_has(jv object, jv key);

--- a/src/main.c
+++ b/src/main.c
@@ -677,7 +677,7 @@ int main(int argc, char* argv[]) {
     ARGS = JV_OBJECT(jv_string("positional"), ARGS,
                      jv_string("named"), jv_copy(program_arguments));
     program_arguments = jv_object_set(program_arguments, jv_string("ARGS"), jv_copy(ARGS));
-    compiled = jq_compile_args(jq, skip_shebang(jv_string_value(data)), jv_copy(program_arguments));
+    compiled = jq_compile_args2(jq, program, skip_shebang(jv_string_value(data)), jv_copy(program_arguments));
     free(program_origin);
     jv_free(data);
   } else {

--- a/src/main.c
+++ b/src/main.c
@@ -253,11 +253,11 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts, int options)
     jv msg = jv_invalid_get_msg(jv_copy(result));
     jv input_pos = jq_util_input_get_position(jq);
     if (jv_get_kind(msg) == JV_KIND_STRING) {
-      fprintf(stderr, "jq: error (at %s): %s\n",
+      fprintf(stderr, "jq: error (input at %s): %s\n",
               jv_string_value(input_pos), jv_string_value(msg));
     } else {
       msg = jv_dump_string(msg, 0);
-      fprintf(stderr, "jq: error (at %s) (not a string): %s\n",
+      fprintf(stderr, "jq: error (input at %s) (not a string): %s\n",
               jv_string_value(input_pos), jv_string_value(msg));
     }
     ret = JQ_ERROR_UNKNOWN;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -971,19 +971,19 @@ path(.)
 
 try path(.a | map(select(.b == 0))) catch .
 {"a":[{"b":0}]}
-"Invalid path expression with result [{\"b\":0}]"
+"Invalid path expression ($binding is not a path expression)"
 
 try path(.a | map(select(.b == 0)) | .[0]) catch .
 {"a":[{"b":0}]}
-"Invalid path expression near attempt to access element 0 of [{\"b\":0}]"
+"Invalid path expression ($binding is not a path expression)"
 
 try path(.a | map(select(.b == 0)) | .c) catch .
 {"a":[{"b":0}]}
-"Invalid path expression near attempt to access element \"c\" of [{\"b\":0}]"
+"Invalid path expression ($binding is not a path expression)"
 
 try path(.a | map(select(.b == 0)) | .[]) catch .
 {"a":[{"b":0}]}
-"Invalid path expression near attempt to iterate through [{\"b\":0}]"
+"Invalid path expression ($binding is not a path expression)"
 
 path(.a[path(.b)[0]])
 {"a":{"b":0}}
@@ -1130,11 +1130,11 @@ def inc(x): x |= .+1; inc(.[].a)
 
 try ((map(select(.a == 1))[].b) = 10) catch .
 [{"a":0},{"a":1}]
-"Invalid path expression near attempt to iterate through [{\"a\":1}]"
+"Invalid path expression ($binding is not a path expression)"
 
 try ((map(select(.a == 1))[].a) |= .+1) catch .
 [{"a":0},{"a":1}]
-"Invalid path expression near attempt to iterate through [{\"a\":1}]"
+"Invalid path expression ($binding is not a path expression)"
 
 def x: .[1,2]; x=10
 [0,1,2]
@@ -1142,7 +1142,7 @@ def x: .[1,2]; x=10
 
 try (def x: reverse; x=10) catch .
 [0,1,2]
-"Invalid path expression with result [2,1,0]"
+"Invalid path expression ($binding is not a path expression)"
 
 .[] = 1
 [1,null,Infinity,-Infinity,NaN,-NaN]
@@ -2024,3 +2024,9 @@ walk(1)
 walk(select(IN({}, []) | not))
 {"a":1,"b":[]}
 {"a":1}
+
+# Issue #2844
+try (. as $a | $a = 5) catch .
+null
+"Invalid path expression ($binding is not a path expression)"
+


### PR DESCRIPTION
This PR makes `$binding`s an error when in a path expression running inside `path/1`.

E.g., `jq -cn '. as $a | $a'` outputs `null` as expected, while `jq -cn '. as $a | $a = 5'` now raises an error (it used to output `5`, though the `$a` binding wasn't actually updated, as `jq -cn '. as $a | $a = 5 | $a'` used to output `null`).