### PR TITLE
def last:

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -2365,7 +2365,7 @@ sections:
           so are only useful for genuine Boolean operations, rather
           than the common Perl/Python/Ruby idiom of
           "value_that_may_be_null or default". If you want to use this
-          form of "or", picking between two values rather than
+          form of "or", choosing between two values rather than
           evaluating a condition, see the `//` operator below.
 
         examples:

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,3 +1,4 @@
+pipenv run python validate_manual_schema.py content/manual/manual.yml
 .
 .TH "JQ" "1" "August 2023" "" ""
 .
@@ -2547,7 +2548,7 @@ If an operand of one of these operators produces multiple results, the operator 
 \fBnot\fR is in fact a builtin function rather than an operator, so it is called as a filter to which things can be piped rather than with special syntax, as in \fB\.foo and \.bar | not\fR\.
 .
 .P
-These three only produce the values \fBtrue\fR and \fBfalse\fR, and so are only useful for genuine Boolean operations, rather than the common Perl/Python/Ruby idiom of "value_that_may_be_null or default"\. If you want to use this form of "or", picking between two values rather than evaluating a condition, see the \fB//\fR operator below\.
+These three only produce the values \fBtrue\fR and \fBfalse\fR, and so are only useful for genuine Boolean operations, rather than the common Perl/Python/Ruby idiom of "value_that_may_be_null or default"\. If you want to use this form of "or", choosing between two values rather than evaluating a condition, see the \fB//\fR operator below\.
 .
 .IP "" 4
 .

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,4 +1,3 @@
-pipenv run python validate_manual_schema.py content/manual/manual.yml
 .
 .TH "JQ" "1" "August 2023" "" ""
 .

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -168,7 +168,7 @@ def nth($n; g):
   if $n < 0 then error("nth doesn't support negative indices")
   else label $out | foreach g as $item ($n + 1; . - 1; if . <= 0 then $item, break $out else empty end) end;
 def first: .[0];
-def last: .[-1];
+def last: .[length-1];
 def nth($n): .[$n];
 def combinations:
     if length == 0 then [] else

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1051,8 +1051,12 @@ pick(first|first)
 [[10,20],30]
 [[10]]
 
-# negative indices in path expressions (since last/1 is .[-1])
-try pick(last) catch .
+pick(last)
+[1,2]
+[null,2]
+
+# negative indices in path expressions are disallowed
+try pick(.[-1]) catch .
 [1,2]
 "Out of bounds negative array index"
 


### PR DESCRIPTION
`def last: .[length-1]`

This is sufficient to ensure that `pick(last)` works in the obvious way, as it did before some recent updates.