### PR TITLE
 Add continuation character in string literals 

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -463,6 +463,7 @@ static pfunc found_string(struct jv_parser* p) {
       case 't': *out++ = '\t'; break;
       case 'n': *out++ = '\n'; break;
       case 'r': *out++ = '\r'; break;
+      case '\n': break;
 
       case 'u':
         /* ahh, the complicated case */

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -99,6 +99,7 @@ struct lexer_param;
   "\\(" {
     return enter(QQSTRING_INTERP_START, YY_START, yyscanner);
   }
+  "\\\n" { }
   "\"" {
     yy_pop_state(yyscanner);
     return QQSTRING_END;

--- a/tests/shtest
+++ b/tests/shtest
@@ -144,6 +144,23 @@ if printf '1\n' | $JQ -cen --seq '[inputs] == []' >/dev/null 2> $d/out; then
 fi
 cmp $d/out $d/expected
 
+# Multi line string literals
+
+data='"foo
+bar"'
+cat > $d/expected <<EOF
+"foo\nbar"
+EOF
+$JQ -n "$data" > $d/out
+cmp $d/out $d/expected
+
+data='"Hello\
+ World"'
+cat > $d/expected <<EOF
+"Hello World"
+EOF
+$JQ -n "$data" > $d/out
+cmp $d/out $d/expected
 
 ## Test --exit-status
 data='{"i": 1}\n{"i": 2}\n{"i": 3}\n'


### PR DESCRIPTION
This allows to have long string literals without having to introduce
newline characters inside it.

Example:

"Hello\ 
 World"

(space before `World`)

is the same as `"Hello World"`.

Also some tests were added.