### PR TITLE
builtin.jq: Add `assert/2`

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -1974,6 +1974,29 @@ sections:
             output:
               - '[{"a":{"b":2}}]'
 
+      - title: "`assert(test; $message)`"
+        body: |
+          
+          The `assert(test; $message)` function applies the test to the
+          input entity. If the test passes (returns true) then the output
+          is the original input. If the test fails then JQ throws an error
+          containing the message passed in.
+          
+          This can be used to short-circuit pipelines in scripts such as when
+          you want to stop if there is a missing key, or the input is an empty
+          array.
+
+        examples:
+          - program: 'assert(length > 0; "must not be empty")'
+            input: '[1,2,3,4]'
+            output:
+              - '[1,2,3,4]'
+
+          - program: 'try assert(values | add >= 10 ; "values must total at least 10") catch .'
+            input: '{"a": 1, "b": 2 }'
+            output:
+              - '"assertion error: values must total at least 10"'
+
       - title: "`$JQ_BUILD_CONFIGURATION`"
         body: |
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -2152,6 +2152,28 @@ jq \'walk( if type == "object" then with_entries( \.key |= sub( "^_+"; "") ) els
 .
 .IP "" 0
 .
+.SS "assert(test; $message)"
+The \fBassert(test; $message)\fR function applies the test to the input entity\. If the test passes (returns true) then the output is the original input\. If the test fails then JQ throws an error containing the message passed in\.
+.
+.P
+This can be used to short\-circuit pipelines in scripts such as when you want to stop if there is a missing key, or the input is an empty array\.
+.
+.IP "" 4
+.
+.nf
+
+jq \'assert(length > 0; "must not be empty")\'
+   [1,2,3,4]
+=> [1,2,3,4]
+
+jq \'try assert(values | add >= 10 ; "values must total at least 10") catch \.\'
+   {"a": 1, "b": 2 }
+=> "assertion error: values must total at least 10"
+.
+.fi
+.
+.IP "" 0
+.
 .SS "$JQ_BUILD_CONFIGURATION"
 This builtin binding shows the jq executable\'s build configuration\. Its value has no particular format, but it can be expected to be at least the \fB\./configure\fR command\-line arguments, and may be enriched in the future to include the version strings for the build tooling used\.
 .

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -264,6 +264,11 @@ def pick(pathexps):
 # ensure the output of debug(m1,m2) is kept together:
 def debug(msgs): (msgs | debug | empty), .;
 
+# assert property with message
+# success passes the original input through
+# failure raises an error with the original error message
+def assert(test; $message): if test then . else error("assertion error: \($message)") end;
+
 # SQL-ish operators here:
 def INDEX(stream; idx_expr):
   reduce stream as $row ({}; .[$row|idx_expr|tostring] = $row);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2024,3 +2024,11 @@ walk(1)
 walk(select(IN({}, []) | not))
 {"a":1,"b":[]}
 {"a":1}
+
+assert(length > 0; "empty array")
+[1]
+[1]
+
+try assert(length == 0; "non-empty array") catch .
+[1]
+"assertion error: non-empty array"

--- a/tests/man.test
+++ b/tests/man.test
@@ -658,6 +658,14 @@ walk(if type == "array" then sort else . end)
 [[4, 1, 7], [8, 5, 2], [3, 6, 9]]
 [[1,4,7],[2,5,8],[3,6,9]]
 
+assert(length > 0; "must not be empty")
+[1,2,3,4]
+[1,2,3,4]
+
+try assert(values | add >= 10 ; "values must total at least 10") catch .
+{"a": 1, "b": 2 }
+"assertion error: values must total at least 10"
+
 $ENV.PAGER
 null
 "less"


### PR DESCRIPTION
This PR adds a new builtin called `assert(test; $message)`.

The `assert(test; $message)` function applies the test to the input entity.
If the test passes (returns true) then the output is the original input.
If the test fails then JQ throws an error containing the message passed in.
          
This can be used to short-circuit pipelines in scripts such as when you don't want to proceed if there's a missing key, or the input is an empty array.

The motivation for this was when I was writing some scripts around some complex object structures and I wanted to break out of the script entirely if specific fields were missing. Rather than test for this in a wrapper shell script, I wanted to generalise the approach to "apply a test, continue if test passes, error if it doesn't"

Normal path

```jq
// Input
[{a: 4, b: 2}, {a: 7, b: 6}] | assert(map(.b) | add > 5; "your message here")

// Output
[
  {
    "a": 4,
    "b": 2
  },
  {
    "a": 7,
    "b": 6
  }
]
```

Error path

```jq
// Input
[{a: 4, b: 2}, {a: 7, b: 6}] | assert(map(.b) | add > 10; "your message here")

// Output
jq: error (at XXX): assertion failed: your message here
```