### PR TITLE
Check `nomem_handler->handler` before calling it

### DIFF
--- a/src/jv_alloc.c
+++ b/src/jv_alloc.c
@@ -111,7 +111,7 @@ static void memory_exhausted() {
   tsd_init_nomem_handler();
 
   nomem_handler = pthread_getspecific(nomem_handler_key);
-  if (nomem_handler)
+  if (nomem_handler && nomem_handler->handler)
     nomem_handler->handler(nomem_handler->data); // Maybe handler() will longjmp() to safety
   // Or not
   fprintf(stderr, "jq: error: cannot allocate memory\n");


### PR DESCRIPTION
Traditionally we `abort()` on `ENOMEM`.  And in `master` we've been segfaulting on `ENOMEM` by trying to call a function at address `0x0`.  With this PR we'll go back to calling `abort()`.  But maybe we should just exit with an error and not `SIGABRT`, and therefore too without dumping core.  Thoughts?

This was reported by @chameleon10712.