### PR TITLE
Fix memory leak in  find_lib  for some invalid inputs

### DIFF
--- a/src/linker.c
+++ b/src/linker.c
@@ -136,16 +136,22 @@ static jv jv_basename(jv name) {
 static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv jq_origin, jv lib_origin) {
   if (!jv_is_valid(rel_path)) {
     jv_free(search);
+    jv_free(jq_origin);
+    jv_free(lib_origin);
     return rel_path;
   }
   if (jv_get_kind(rel_path) != JV_KIND_STRING) {
     jv_free(rel_path);
     jv_free(search);
+    jv_free(jq_origin);
+    jv_free(lib_origin);
     return jv_invalid_with_msg(jv_string_fmt("Module path must be a string"));
   }
   if (jv_get_kind(search) != JV_KIND_ARRAY) {
     jv_free(rel_path);
     jv_free(search);
+    jv_free(jq_origin);
+    jv_free(lib_origin);
     return jv_invalid_with_msg(jv_string_fmt("Module search path must be an array"));
   }
 


### PR DESCRIPTION
I was looking at the new OSS fuzz. I was not able to reproduce it locally, but I discovered this memory leak in `find_lib()` while trying to reproduce it.

Reproduce with:
```
$ valgrind ./jq -n 'include "/foo/foo"; .'
==2380572== Memcheck, a memory error detector
==2380572== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==2380572== Using Valgrind-3.21.0 and LibVEX; rerun with -h for copyright info
==2380572== Command: ./jq -n include\ "/foo/foo";\ .
==2380572== 
jq: error: module names must not have equal consecutive components: /foo/foo

jq: 1 compile error
==2380572== 
==2380572== HEAP SUMMARY:
==2380572==     in use at exit: 66 bytes in 2 blocks
==2380572==   total heap usage: 86 allocs, 84 frees, 20,143 bytes allocated
==2380572== 
==2380572== LEAK SUMMARY:
==2380572==    definitely lost: 66 bytes in 2 blocks
==2380572==    indirectly lost: 0 bytes in 0 blocks
==2380572==      possibly lost: 0 bytes in 0 blocks
==2380572==    still reachable: 0 bytes in 0 blocks
==2380572==         suppressed: 0 bytes in 0 blocks
==2380572== Rerun with --leak-check=full to see details of leaked memory
==2380572== 
==2380572== For lists of detected and suppressed errors, rerun with: -s
==2380572== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```