### PR TITLE
Make jq_get_lib_dirs return an empty array if JQ_LIBRARY_PATH is not set

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -1267,7 +1267,8 @@ jv jq_get_prog_origin(jq_state *jq) {
 }
 
 jv jq_get_lib_dirs(jq_state *jq) {
-  return jq_get_attr(jq, jv_string("JQ_LIBRARY_PATH"));
+  jv lib_dirs = jq_get_attr(jq, jv_string("JQ_LIBRARY_PATH"));
+  return jv_is_valid(lib_dirs) ? lib_dirs : jv_array();
 }
 
 void jq_set_attrs(jq_state *jq, jv attrs) {


### PR DESCRIPTION
For the jq_state used by the jq utility, the JQ_LIBRARY_PATH attribute
will always be set, but, in general, it is possible that it might not be.

If it is not set, jq_get_lib_dirs() will return jv_invalid().

That is not good, because some code in linker.c expects it to always
returns an array.

This patch makes jq_get_lib_dirs() return an empty array if
JQ_LIBRARY_PATH is not set to prevent problems.

This issue made OSS fuzz trigger failed assertions every time it tried
to compile a script that uses "include".

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61796
