### PR TITLE
Fix leak on too-large programs, OSS Fuzz issue #61349

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -1282,7 +1282,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
   }
   bc->codelen = pos;
   bc->debuginfo = jv_object_set(bc->debuginfo, jv_string("locals"), localnames);
-  if (bc->nsubfunctions) {
+  if (bc->nsubfunctions && !errors) {
     bc->subfunctions = jv_mem_calloc(sizeof(struct bytecode*), bc->nsubfunctions);
     for (inst* curr = b.first; curr; curr = curr->next) {
       if (curr->op == CLOSURE_CREATE) {
@@ -1306,6 +1306,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
       }
     }
   } else {
+    bc->nsubfunctions = 0;
     bc->subfunctions = 0;
   }
   uint16_t* code = jv_mem_calloc(sizeof(uint16_t), bc->codelen);


### PR DESCRIPTION
A very large program can cause these leaks:

```
==758838== 7,820 (16 direct, 7,804 indirect) bytes in 2 blocks are definitely lost in loss record 17 of 28
==758838==    at 0x4848A23: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==758838==    by 0x125D30: jv_mem_calloc (jv_alloc.c:153)
==758838==    by 0x162ADE: compile (compile.c:1286)
==758838==    by 0x162D4B: compile (compile.c:1304)
==758838==    by 0x163697: block_compile (compile.c:1381)
==758838==    by 0x11B5CA: jq_compile_args (execute.c:1245)
==758838==    by 0x115E20: main (main.c:691)
==758838==
==758838== 1,674,694 (103,576 direct, 1,571,118 indirect) bytes in 1,177 blocks are definitely lost in loss record 28 of 28
==758838==    at 0x4843839: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==758838==    by 0x125CD0: jv_mem_alloc (jv_alloc.c:141)
==758838==    by 0x162B19: compile (compile.c:1289)
==758838==    by 0x163697: block_compile (compile.c:1381)
==758838==    by 0x11B5CA: jq_compile_args (execute.c:1245)
==758838==    by 0x115E20: main (main.c:691)
```

This commit fixes that.