### PR TITLE
Standarize arch types to AMD64 & ARM64 at index page download dropdown

### DIFF
--- a/docs/templates/index.html.j2
+++ b/docs/templates/index.html.j2
@@ -18,11 +18,11 @@
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64" aria-label="Link to download executable: Linux (AMD 64-bit)"><span class="bi bi-download me-2" aria-hidden="true"></span>Linux (AMD 64-bit)</a></li>
-              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64" aria-label="Link to download executable: Linux (ARM 64-bit)"><span class="bi bi-download me-2" aria-hidden="true"></span>Linux (ARM 64-bit)</a></li>
-              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-amd64" aria-label="Link to download executable: macOS (AMD 64-bit)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (AMD 64-bit)</a></li>
-              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-arm64" aria-label="Link to download executable: macOS (ARM 64-bit)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (ARM 64-bit)</a></li>
-              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-windows-amd64.exe" aria-label="Link to download executable: Windows (64-bit)"><span class="bi bi-download me-2" aria-hidden="true"></span>Windows (64-bit)</a></li>
+              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64" aria-label="Link to download executable: Linux (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>Linux (AMD64)</a></li>
+              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64" aria-label="Link to download executable: Linux (ARM64)"><span class="bi bi-download me-2" aria-hidden="true"></span>Linux (ARM64)</a></li>
+              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-amd64" aria-label="Link to download executable: macOS (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (AMD64)</a></li>
+              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-arm64" aria-label="Link to download executable: macOS (ARM64)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (ARM64)</a></li>
+              <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7/jq-windows-amd64.exe" aria-label="Link to download executable: Windows (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>Windows (AMD64)</a></li>
               <li><a class="dropdown-item" href="{{ root }}/download/">Other platforms, older versions, and source</a></li>
             </ul>
             <a class="btn btn-primary text-nowrap" href="https://jqplay.org" target="_blank" rel="noopener">


### PR DESCRIPTION
Standarize arch types to AMD64 & ARM64 at index page download dropdown. These are missed from https://github.com/jqlang/jq/pull/2879.