### PR TITLE
Fix the default colors to use 39, the default foreground color

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3677,7 +3677,7 @@ sections:
         - color for object keys
 
       The default color scheme is the same as setting
-      `JQ_COLORS="0;90:0;37:0;37:0;37:0;32:1;37:1;37:1;34"`.
+      `JQ_COLORS="0;90:0;39:0;39:0;39:0;32:1;39:1;39:1;34"`.
 
       This is not a manual for VT100/ANSI escapes.  However, each of
       these color specifications should consist of two numbers separated

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -3343,7 +3343,7 @@ sections:
         - color for objects
 
       The default color scheme is the same as setting
-      `"JQ_COLORS=1;30:0;37:0;37:0;37:0;32:1;37:1;37"`.
+      `"JQ_COLORS=1;30:0;39:0;39:0;39:0;32:1;39:1;39"`.
 
       This is not a manual for VT100/ANSI escapes.  However, each of
       these color specifications should consist of two numbers separated

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "August 2023" "" ""
+.TH "JQ" "1" "September 2023" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -4058,7 +4058,7 @@ color for object keys
 .IP "" 0
 .
 .P
-The default color scheme is the same as setting \fBJQ_COLORS="0;90:0;37:0;37:0;37:0;32:1;37:1;37:1;34"\fR\.
+The default color scheme is the same as setting \fBJQ_COLORS="0;90:0;39:0;39:0;39:0;32:1;39:1;39:1;34"\fR\.
 .
 .P
 This is not a manual for VT100/ANSI escapes\. However, each of these color specifications should consist of two numbers separated by a semi\-colon, where the first number is one of these:

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -30,8 +30,8 @@
 static char color_bufs[8][16];
 static const char *color_bufps[8];
 static const char* def_colors[] =
-  {COL("0;90"),    COL("0;37"),      COL("0;37"),     COL("0;37"),
-   COL("0;32"),    COL("1;37"),      COL("1;37"),     COL("1;34")};
+  {COL("0;90"),    COL("0;39"),      COL("0;39"),     COL("0;39"),
+   COL("0;32"),    COL("1;39"),      COL("1;39"),     COL("1;34")};
 #define FIELD_COLOR (colors[7])
 
 static const char **colors = def_colors;

--- a/tests/shtest
+++ b/tests/shtest
@@ -438,18 +438,18 @@ cmp $d/color $d/expect
 ## Default colors, complex input
 $JQ -Ccn '[{"a":true,"b":false},123,null]' > $d/color
 {
-  printf '\033[1;37m[\033[1;37m{'
+  printf '\033[1;39m[\033[1;39m{'
   printf '\033[0m\033[1;34m"a"\033['
-  printf '0m\033[1;37m:\033[0m\033['
-  printf '0;37mtrue\033[0m\033[1'
-  printf ';37m,\033[0m\033[1;34m'
-  printf '"b"\033[0m\033[1;37m:\033'
-  printf '[0m\033[0;37mfalse\033'
-  printf '[0m\033[1;37m\033[1;37'
-  printf 'm}\033[0m\033[1;37m,\033['
-  printf '0;37m123\033[0m\033[1;'
-  printf '37m,\033[0;90mnull\033'
-  printf '[0m\033[1;37m\033[1;37'
+  printf '0m\033[1;39m:\033[0m\033['
+  printf '0;39mtrue\033[0m\033[1'
+  printf ';39m,\033[0m\033[1;34m'
+  printf '"b"\033[0m\033[1;39m:\033'
+  printf '[0m\033[0;39mfalse\033'
+  printf '[0m\033[1;39m\033[1;39'
+  printf 'm}\033[0m\033[1;39m,\033['
+  printf '0;39m123\033[0m\033[1;'
+  printf '39m,\033[0;90mnull\033'
+  printf '[0m\033[1;39m\033[1;39'
   printf 'm]\033[0m\n'
 } > $d/expect
 cmp $d/color $d/expect


### PR DESCRIPTION
This reverts commit 07b18a33feb6ccab08be221657e19b82abf0d84e, and fix #2903.

According to Linux manpage `console_codes(4)`, "color 39" is not a undefined value:

```
39         set default foreground color (before Linux 3.16: set underscore off, set default foreground color)
```

I'm afraid that what in https://github.com/jqlang/jq/pull/2032 does not hold, and setting its value to 37 hurts users with light background, as "color 37" is:

```
37         set white foreground
```