### PR TITLE
Reject U+001F in string literals (fix #2909)

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -493,7 +493,7 @@ static pfunc found_string(struct jv_parser* p) {
         return "Invalid escape";
       }
     } else {
-      if (c > 0 && c < 0x001f)
+      if (c >= 0 && c <= 0x001f)
         return "Invalid string: control characters from U+0000 through U+001F must be escaped";
       *out++ = c;
     }


### PR DESCRIPTION
This fixes the bounding check errors as reported by #2909.