### PR TITLE
Remove useless assignments/variables detected by clang/clang-tidy

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -372,7 +372,6 @@ static block block_bind(block binder, block body, int bindflags) {
 
 block block_bind_library(block binder, block body, int bindflags, const char *libname) {
   bindflags |= OP_HAS_BINDING;
-  int nrefs = 0;
   int matchlen = (libname == NULL) ? 0 : strlen(libname);
   char *matchname = jv_mem_alloc(matchlen+2+1);
   matchname[0] = '\0';
@@ -395,7 +394,7 @@ block block_bind_library(block binder, block body, int bindflags, const char *li
 
     // This mutation is ugly, even if we undo it
     curr->symbol = tname;
-    nrefs += block_bind_subblock(inst_block(curr), body, bindflags2, 0);
+    block_bind_subblock(inst_block(curr), body, bindflags2, 0);
     curr->symbol = cname;
     free(tname);
   }

--- a/src/execute.c
+++ b/src/execute.c
@@ -1242,7 +1242,7 @@ int jq_compile_args(jq_state *jq, const char* str, jv args) {
   if (nerrors == 0) {
     nerrors = builtins_bind(jq, &program);
     if (nerrors == 0) {
-      nerrors = block_compile(program, &jq->bc, locations, args = args2obj(args));
+      nerrors = block_compile(program, &jq->bc, locations, args2obj(args));
     }
   } else
     jv_free(args);

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -127,7 +127,6 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int
       take--;
     } else if (take == 0) {
       printf("Hit the number of tests limit (%d), breaking\n", tests_to_take);
-      take = -1;
       break;
     }
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -1080,14 +1080,13 @@ static jvp_string* jvp_string_alloc(uint32_t size) {
 static jv jvp_string_copy_replace_bad(const char* data, uint32_t length) {
   const char* end = data + length;
   const char* i = data;
-  const char* cstart;
 
   uint32_t maxlength = length * 3 + 1; // worst case: all bad bytes, each becomes a 3-byte U+FFFD
   jvp_string* s = jvp_string_alloc(maxlength);
   char* out = s->data;
   int c = 0;
 
-  while ((i = jvp_utf8_next((cstart = i), end, &c))) {
+  while ((i = jvp_utf8_next(i, end, &c))) {
     if (c == -1) {
       c = 0xFFFD; // U+FFFD REPLACEMENT CHARACTER
     }

--- a/src/util.c
+++ b/src/util.c
@@ -353,7 +353,7 @@ static int jq_util_input_read_more(jq_util_input_state *state) {
          * terminating '\0'. This only works because we previously memset our
          * buffer with something nonzero.
          */
-        for (p = state->buf, i = sizeof(state->buf) - 1; i > 0; i--) {
+        for (i = sizeof(state->buf) - 1; i > 0; i--) {
           if (state->buf[i] == '\0')
             break;
         }


### PR DESCRIPTION
Remove unused `nref` accumulator in `block_bind_library`
    detected as a warning compiling jq with clang.

Remove a bunch of unused variables, and useless assignments
    Detected by clang-tidy.
