### PR TITLE
main.c: Remove unused EXIT_STATUS_EXACT option

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -161,7 +161,6 @@ enum {
   RAW_NO_LF             = 1024,
   UNBUFFERED_OUTPUT     = 2048,
   EXIT_STATUS           = 4096,
-  EXIT_STATUS_EXACT     = 8192,
   SEQ                   = 16384,
   RUN_TESTS             = 32768,
   /* debugging only */
@@ -231,7 +230,6 @@ static int process(jq_state *jq, jv value, int flags, int dumpopts, int options)
   }
   if (jq_halted(jq)) {
     // jq program invoked `halt` or `halt_error`
-    options |= EXIT_STATUS_EXACT;
     jv exit_code = jq_get_exit_code(jq);
     if (!jv_is_valid(exit_code))
       ret = JQ_OK;
@@ -783,7 +781,7 @@ out:
   jq_util_input_free(&input_state);
   jq_teardown(&jq);
 
-  if (options & (EXIT_STATUS|EXIT_STATUS_EXACT)) {
+  if (options & EXIT_STATUS) {
     if (ret != JQ_OK_NO_OUTPUT)
       jq_exit_with_status(ret);
     else


### PR DESCRIPTION
In process there is a suspicious `options |= EXIT_STATUS_EXACT` that is run when the jq script is terminated by `halt`, or `halt_error`.

That line of code acutally does nothing because options is a local argument variable, and is not passed as a pointer. It was probably meant
to be a `*options |= EXIT_STATUS_EXACT` with the options argument passed as a `int *`.

In any case, we do not want to run the code in main() that was supposed to run if `EXIT_STATUS_EXACT` is set (but didn't since it is never added to options); as far as I can tell, we only want to run that code when the --exit-status/-e option is passed.

So I removed `EXIT_STATUS_EXACT` completely, and the useless assignment, instead of fixing it since it was not used for anything else.

Useless assignment detected by clang-tidy.
