### PR TITLE
Actually use number correctly casted from double to int as index

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -95,7 +95,7 @@ jv jv_get(jv t, jv k) {
       } else {
         if (didx < INT_MIN) didx = INT_MIN;
         if (didx > INT_MAX) didx = INT_MAX;
-        int idx = (int)jv_number_value(k);
+        int idx = (int)didx;
         if (idx < 0)
           idx += jv_array_length(jv_copy(t));
         v = jv_array_get(t, idx);


### PR DESCRIPTION
The code was using `(int)jv_number_value(k)` instead of `(int)didx`.

follow-up from 0e067ef93605493060392f0999be27694146fca4 (#2821)

Useless assignments to `didx` detected by clang-tidy.
