### PR TITLE
Allow passing the inline jq script after --

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -313,9 +313,8 @@ sections:
 
       * `--`:
 
-        Terminates argument processing.  Remaining arguments are
-        positional, either strings, JSON texts, or input filenames,
-        according to whether `--args` or `--jsonargs` were given.
+        Terminates argument processing.  Remaining arguments are not
+        interpreted as options.
 
       * `--run-tests [filename]`:
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -250,7 +250,7 @@ Output the jq help and exit with zero\.
 \fB\-\-\fR:
 .
 .IP
-Terminates argument processing\. Remaining arguments are positional, either strings, JSON texts, or input filenames, according to whether \fB\-\-args\fR or \fB\-\-jsonargs\fR were given\.
+Terminates argument processing\. Remaining arguments are not interpreted as options\.
 .
 .TP
 \fB\-\-run\-tests [filename]\fR:

--- a/src/main.c
+++ b/src/main.c
@@ -353,8 +353,10 @@ int main(int argc, char* argv[]) {
   size_t short_opts = 0;
   jv lib_search_paths = jv_null();
   for (int i=1; i<argc; i++, short_opts = 0) {
-    if (args_done) {
-      if (further_args_are_strings) {
+    if (args_done || !isoptish(argv[i])) {
+      if (!program) {
+        program = argv[i];
+      } else if (further_args_are_strings) {
         ARGS = jv_array_append(ARGS, jv_string(argv[i]));
       } else if (further_args_are_json) {
         jv v =  jv_parse(argv[i]);
@@ -368,26 +370,7 @@ int main(int argc, char* argv[]) {
         nfiles++;
       }
     } else if (!strcmp(argv[i], "--")) {
-      if (!program) usage(2, 1);
       args_done = 1;
-    } else if (!isoptish(argv[i])) {
-      if (program) {
-        if (further_args_are_strings) {
-          ARGS = jv_array_append(ARGS, jv_string(argv[i]));
-        } else if (further_args_are_json) {
-          jv v =  jv_parse(argv[i]);
-          if (!jv_is_valid(v)) {
-            fprintf(stderr, "%s: invalid JSON text passed to --jsonargs\n", progname);
-            die();
-          }
-          ARGS = jv_array_append(ARGS, v);
-        } else {
-          jq_util_input_add_input(input_state, argv[i]);
-          nfiles++;
-        }
-      } else {
-        program = argv[i];
-      }
     } else {
       if (argv[i][1] == 'L') {
         if (jv_get_kind(lib_search_paths) == JV_KIND_NULL)

--- a/tests/shtest
+++ b/tests/shtest
@@ -579,4 +579,14 @@ if ( ! $msys && ! $mingw ) && locale -a > /dev/null; then
   fi
 fi
 
+# Allow passing the inline jq script before -- #2919
+if ! r=$($JQ --args -rn -- '$ARGS.positional[0]' bar) || [ "$r" != bar ]; then
+    echo "passing the inline script after -- didn't work"
+    exit 1
+fi
+if ! r=$($JQ --args -rn 1 -- '$ARGS.positional[0]' bar) || [ "$r" != 1 ]; then
+    echo "passing the inline script before -- didn't work"
+    exit 1
+fi
+
 exit 0


### PR DESCRIPTION
jq previously only allowed passing the inline script before `--` (as if they were options) even though one would expect the inline script to be a positional argument.

Since jq previously also refused to run with a usage error if the script was passed after `--` (It was not assuming `.` as script as it does when no arguments are passed), and positional arguments are allowed before `--` and even before other options, it should not be a breaking change to change that weird behaviour, and allow the script to appear after `--`.

It also simplifies the option parsing code a bunch.

Fixes #2918
