### PR TITLE
Generate links in man page

### DIFF
--- a/docs/build_manpage.py
+++ b/docs/build_manpage.py
@@ -86,6 +86,9 @@ class RoffWalker(object):
                     self.__write_cmd('.P')
                 self._write_element(root, ensure_newline=(parent_tag != 'li'))
 
+            elif root.tag == 'a':
+                self._write_element(root, ensure_newline=(parent_tag != 'li'))
+
             elif root.tag == 'ul':
                 if self._ul_is_special(root):
                     li = root[0]

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -2738,10 +2738,12 @@ jq \'[\.[] | tonumber?]\'
 .IP "" 0
 .
 .SH "REGULAR EXPRESSIONS"
-jq uses the 
+jq uses the Oniguruma regular expression library, as do PHP, TextMate, Sublime Text, etc, so the description here will focus on jq specifics\.
+
 .
 .P
-Oniguruma supports several flavors of regular expression, so it is important to know that jq uses the 
+Oniguruma supports several flavors of regular expression, so it is important to know that jq uses the "Perl NG" (Perl with named groups) flavor\.
+
 .
 .P
 The jq regex filters are defined so that they can be used using one of these patterns:


### PR DESCRIPTION
Some \[foo](bar) links were added to manual.yml without updating build_manpage.py to make it generate roff for "a" tags.

Fixes #2930
