### PR TITLE
Add last resort version string in scripts/version

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -2,7 +2,15 @@
 set -eu
 
 cd "$(dirname "$0")/../"
-test -d .git || exit 1
+if ! [ -d .git ]; then
+  # Building from default GitHub tarball, or building from dist after running
+  # autoreconf unnecessarily.  This is something we can fail to update, but
+  # it's been generating a lot of questions.
+  #
+  # Now we'll have to make `Release jq-<version>` commits that change this:
+  echo "jq-1.7-misconfigured"
+  exit 0
+fi
 
 if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
   git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'


### PR DESCRIPTION
Ugh.  We do already include some built sources (e.g., outputs of Bison and Flex, the prebuilt man page), so why not a bit more?  Well, I'm not going that far -- I'm not including `src/version.h` here, just hard-coding a last resort version string into `scripts/version`.

This PR is really about exploring what, if _anything_ we might do about these two issues:

1. GitHub _insists_ on including a tarball of the workspace of the repo checked out at the release tag when making releases.  That tarball does not include `.git`, so `scripts/version` can't figure out the current version being built.
2. Running `autoconf`/`autoreconf` in the dist tarballs we publish in our releases clobbers the `src/version.h` included in the tarball, and once again there is no `.git` so `scripts/version` can be used by `Makefile` to recover from this.

This PR adds a fallback at the price of having one more thing to update at release time.  It might be better instead to commit `src/version.h`, but that's also going to be a pain since we'd have to do that at every commit!