### PR TITLE
Restrict systems operations on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,6 @@ if test "x$valgrind_cmd" = "x" ; then
     AC_MSG_WARN([valgrind is required to test jq.])
 fi
 AC_CHECK_FUNCS(memmem)
-AC_CHECK_FUNCS(mkstemp)
 
 AC_CHECK_HEADER("sys/cygwin.h", [have_cygwin=1;])
 AC_CHECK_HEADER("shlwapi.h",[have_shlwapi=1;])

--- a/src/main.c
+++ b/src/main.c
@@ -317,8 +317,6 @@ int main(int argc, char* argv[]) {
   int last_result = -1; /* -1 = no result, 0=null or false, 1=true */
   int badwrite;
   int options = 0;
-  jv ARGS = jv_array(); /* positional arguments */
-  jv program_arguments = jv_object(); /* named arguments */
 
 #ifdef HAVE_SETLOCALE
   (void) setlocale(LC_ALL, "");
@@ -338,6 +336,9 @@ int main(int argc, char* argv[]) {
   _setmode(fileno(stdout), _O_TEXT | _O_U8TEXT);
   _setmode(fileno(stderr), _O_TEXT | _O_U8TEXT);
 #endif
+
+  jv ARGS = jv_array(); /* positional arguments */
+  jv program_arguments = jv_object(); /* named arguments */
 
   if (argc) progname = argv[0];
 

--- a/src/main.c
+++ b/src/main.c
@@ -324,6 +324,13 @@ int main(int argc, char* argv[]) {
   (void) setlocale(LC_ALL, "");
 #endif
 
+#ifdef __OpenBSD__
+  if (pledge("stdio rpath", NULL) == -1) {
+    perror("pledge");
+    exit(JQ_ERROR_SYSTEM);
+  }
+#endif
+
 #ifdef WIN32
   jv_tsd_dtoa_ctx_init();
   fflush(stdout);

--- a/src/util.c
+++ b/src/util.c
@@ -79,27 +79,6 @@ FILE *fopen(const char *fname, const char *mode) {
 }
 #endif
 
-#ifndef HAVE_MKSTEMP
-int mkstemp(char *template) {
-  size_t len = strlen(template);
-  int tries=5;
-  int fd;
-
-  // mktemp() truncates template when it fails
-  char *s = alloca(len + 1);
-  assert(s != NULL);
-  strcpy(s, template);
-
-  do {
-    // Restore template
-    strcpy(template, s);
-    (void) mktemp(template);
-    fd = open(template, O_CREAT | O_EXCL | O_RDWR, 0600);
-  } while (fd == -1 && tries-- > 0);
-  return fd;
-}
-#endif
-
 jv expand_path(jv path) {
   assert(jv_get_kind(path) == JV_KIND_STRING);
   const char *pstr = jv_string_value(path);

--- a/src/util.h
+++ b/src/util.h
@@ -13,10 +13,6 @@
 
 #include "jv.h"
 
-#ifndef HAVE_MKSTEMP
-int mkstemp(char *template);
-#endif
-
 jv expand_path(jv);
 jv get_home(void);
 jv jq_realpath(jv);


### PR DESCRIPTION
Use pledge(2)[0] to limit jq(1) to reading files.
It does not change files and only writes to standard output/error.
It never deals with TTY, network, process management or other subsystems.

This is to reduce jq's attack surface and potential damage.

OpenBSD is carrying a local patch[1] in its official jq port/package
since 2016.  An improved version:

- drop no longer needed "getpw" promise
  f1c4947 "Avoid getpwuid for static linking" removed getpwuid(3) usage
- pledge before jq_init() to simplify the error path
- use perror(3) to print errno(2)

No behaviour change in tests or real world usage observed on
OpenBSD/amd64 7.4.

0: https://man.openbsd.org/pledge.2
1: https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/textproc/jq/patches/patch-main_c
