### PR TITLE
Fix possible uninitialised value dereference if jq_init() fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -310,6 +310,7 @@ int umain(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
 #endif
   jq_state *jq = NULL;
+  jq_util_input_state *input_state = NULL;
   int ret = JQ_OK_NO_OUTPUT;
   int compiled = 0;
   int parser_flags = 0;
@@ -336,7 +337,7 @@ int main(int argc, char* argv[]) {
 
   jq = jq_init();
   if (jq == NULL) {
-    perror("malloc");
+    perror("jq_init");
     ret = JQ_ERROR_SYSTEM;
     goto out;
   }
@@ -344,7 +345,7 @@ int main(int argc, char* argv[]) {
   int dumpopts = JV_PRINT_INDENT_FLAGS(2);
   const char* program = 0;
 
-  jq_util_input_state *input_state = jq_util_input_init(NULL, NULL); // XXX add err_cb
+  input_state = jq_util_input_init(NULL, NULL); // XXX add err_cb
 
   int further_args_are_strings = 0;
   int further_args_are_json = 0;


### PR DESCRIPTION
If `jq_init()` fails, `goto out` would try to free `input_state` which is uninitialised. I initialised `input_state` to `NULL` to fix the problem.

I also fixed `jq_util_input_init()` not handling OOM errors by returning `NULL`, and added code to make jq exit cleanly if it returns `NULL`. The codebase is filled with these kinds of problems, but this one was easy to fix, so might as well fix it now...

Ref: https://github.com/jqlang/jq/pull/2934#discussion_r1367795641

Reported-By: Klemens Nanni <kn@openbsd.org>
