### PR TITLE
Keep releasing executables with legacy names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,9 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cp jq-linux/{jq-linux-amd64,jq-linux64}
+          cp jq-macos/{jq-macos-amd64,jq-osx-amd64}
+          cp jq-windows/{jq-windows-amd64.exe,jq-win64.exe}
           sha256sum jq-*/jq-* | sed 's| .*/|  |' > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-*/jq-* sha256sum.txt


### PR DESCRIPTION
We changed the executable names with explicit architecture name in the 1.7 release, but users still keep downloading with the legacy URLs (ref: #2877). To avoid the same troubles in the coming patch release, I would like to keep releasing executables with legacy names.  Based on the download counts, I restored `jq-linux64`, `jq-osx-amd64`, and `jq-win64.exe`.
```
 $ curl -s https://api.github.com/repos/jqlang/jq/releases/tags/jq-1.7 | jq -r '.assets | sort_by(.download_count)[] | "\(.name): \(.download_count)"'
jq-linux-mipsr6el: 147
jq-linux-mipsr6: 148
jq-linux-powerpc: 148
jq-linux-mips64r6: 151
jq-linux-mips64r6el: 151
jq-linux-riscv64: 153
jq-linux-mipsel: 158
jq-linux-mips64el: 160
jq-linux-s390x: 169
jq-linux-mips64: 175
jq-linux-mips: 181
jq-linux-ppc64el: 184
jq-linux-armel: 224
jq-linux32: 479 # ⭐️
jq-linux-armhf: 602
sha256sum.txt: 845
jq-1.7.zip: 1240
jq-win32.exe: 1546 # ⭐️
jq-windows-i386.exe: 4029
jq-linux-arm64: 10296
jq-linux-i386: 11617
jq-macos-amd64: 13424
jq-macos-arm64: 14485
jq-win64.exe: 36470 # ⭐️
jq-1.7.tar.gz: 41273
jq-linux64: 265654 # ⭐️
jq-windows-amd64.exe: 370257
jq-linux-amd64: 433377
jq-osx-amd64: 548536 # ⭐️
```