### PR TITLE
libjq: extern C for C++

### DIFF
--- a/src/jq.h
+++ b/src/jq.h
@@ -4,6 +4,10 @@
 #include <stdio.h>
 #include "jv.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
   JQ_DEBUG_TRACE = 1,
   JQ_DEBUG_TRACE_DETAIL = 2,
@@ -68,5 +72,9 @@ jv jq_util_input_get_current_filename(jq_state*);
 jv jq_util_input_get_current_line(jq_state*);
 
 int jq_set_colors(const char *);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !JQ_H */

--- a/src/jv.h
+++ b/src/jv.h
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if (defined(__GNUC__) && __GNUC__ >= 7) || \
     (defined(__clang__) && __clang_major__ >= 10)
 # define JQ_FALLTHROUGH __attribute__((fallthrough))
@@ -259,6 +263,9 @@ int jv_cmp(jv, jv);
 jv jv_group(jv, jv);
 jv jv_sort(jv, jv);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
If using libjq from C++ it would be nice to not need to do this at the
import site, so just extern "C" to the public headers for libjq
