### PR TITLE
jq_fuzz_parse_extended.c: don't jv_free() twice

### DIFF
--- a/tests/jq_fuzz_parse_extended.c
+++ b/tests/jq_fuzz_parse_extended.c
@@ -25,9 +25,10 @@ int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
   jv res = jv_parse_custom_flags(null_terminated, fuzz_flags);
   if (jv_is_valid(res)) {
     jv_dump(res, dump_flags);
+  } else {
+    jv_free(res);
   }
-  jv_free(res);
-  
+
   // Free the null-terminated string
   free(null_terminated);
 


### PR DESCRIPTION
jv_dump() frees its argument.

I missed this problem before merging #2952, whoops! =)

fixup from eb3b5654bbd285fa70bab8ca71f2284354adf625
