### PR TITLE
website: use https URLs instead of http URLs in download page

### DIFF
--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -13,14 +13,14 @@ body:
       details, read the file `COPYING` in the source distribution.
 
       jq uses a C library for decimal number support. This is an ICU 1.8.1
-      licensed code obtained from the ICU downloads archive
-      http://download.icu-project.org/files/decNumber/decNumber-icu-368.zip.
+      licensed code obtained from the ICU downloads archive.  
+      <https://download.icu-project.org/files/decNumber/decNumber-icu-368.zip>
 
 
       ### Linux
 
        * jq is in the official [Debian](https://packages.debian.org/jq) and
-         [Ubuntu](http://packages.ubuntu.com/jq) repositories. Install using
+         [Ubuntu](https://packages.ubuntu.com/jq) repositories. Install using
          `sudo apt-get install jq`.
 
        * jq is in the official [Fedora](https://src.fedoraproject.org/rpms/jq) repository.
@@ -61,7 +61,7 @@ body:
 
       ### macOS
 
-       * Use [Homebrew](http://brew.sh/) to install jq with `brew install jq`.
+       * Use [Homebrew](https://brew.sh/) to install jq with `brew install jq`.
 
        * Use [MacPorts](https://www.macports.org) to install jq with `port install jq`.
 
@@ -199,7 +199,7 @@ body:
       On macOS, these are all included in Apple's command line tools, which can
       be installed from [Xcode](https://developer.apple.com/xcode/). However,
       you may find that you need a newer version of Bison than the one provided
-      by Apple. This can be found in [Homebrew](http://brew.sh) or
+      by Apple. This can be found in [Homebrew](https://brew.sh/) or
       [MacPorts](https://macports.org/).
 
       If you want to generate the lexer and parser from source you can use the


### PR DESCRIPTION
Also add markdown formatting for the decNumber URL so it gets rendered as a link in the html page.
