### PR TITLE
Extend fuzzing

### DIFF
--- a/tests/jq_fuzz_compile.c
+++ b/tests/jq_fuzz_compile.c
@@ -14,7 +14,9 @@ int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
   jq_state *jq = NULL;
   jq = jq_init();
   if (jq != NULL) {
-    jq_compile(jq, null_terminated);
+    if (jq_compile(jq, null_terminated)) {
+      jq_dump_disassembly(jq, 2);
+    }
   }
   jq_teardown(&jq);
 

--- a/tests/jq_fuzz_execute.cpp
+++ b/tests/jq_fuzz_execute.cpp
@@ -1,0 +1,40 @@
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+
+extern "C" {
+#include "jq.h"
+#include "jv.h"
+}
+
+// Fuzzer inspired by /src/jq_test.c
+// The goal is to have the fuzzer execute the functions:
+// jq_compile -> jv_parse -> jq_next.
+extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
+  FuzzedDataProvider fdp(data, size);
+  std::string prog_payload = fdp.ConsumeRandomLengthString();
+  std::string parse_payload1 = fdp.ConsumeRandomLengthString();
+  std::string parse_payload2 = fdp.ConsumeRandomLengthString();
+
+  jq_state *jq = NULL;
+  jq = jq_init();
+  if (jq != NULL) {
+    if (jq_compile(jq, prog_payload.c_str())) {
+      // Process to jv_parse and then jv_next
+      jv input = jv_parse(parse_payload1.c_str());
+      if (jv_is_valid(input)) {
+        jq_start(jq, input, 0);
+        jv next = jv_parse(parse_payload2.c_str());
+        if (jv_is_valid(next)) {
+          jv actual = jq_next(jq);
+          jv_free(actual);
+        }
+        jv_free(next);
+      }
+
+      // Do not free "input" as this is handled by jq_teardown.
+    }
+  }
+  jq_teardown(&jq);
+
+  return 0;
+}

--- a/tests/jq_fuzz_execute.cpp
+++ b/tests/jq_fuzz_execute.cpp
@@ -1,10 +1,8 @@
 #include <fuzzer/FuzzedDataProvider.h>
 #include <string>
 
-extern "C" {
 #include "jq.h"
 #include "jv.h"
-}
 
 // Fuzzer inspired by /src/jq_test.c
 // The goal is to have the fuzzer execute the functions:


### PR DESCRIPTION
Adds `jq_dump_disassembly` as a target for `jq_fuzz_compile.c`

Adds a new fuzzer where the primary purpose is to hit `jq_next`, which is currently not analyzed by the existing fuzzers.