### PR TITLE
jq_fuzz_execute.cpp: fix false assert

### DIFF
--- a/tests/jq_fuzz_execute.cpp
+++ b/tests/jq_fuzz_execute.cpp
@@ -16,9 +16,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
   jq_state *jq = NULL;
   jq = jq_init();
   if (jq != NULL) {
-    char *origin = strdup("/tmp/");
-    jq_set_attr(jq, jv_string("JQ_ORIGIN"), jv_string(origin));
-    free(origin);
+    jq_set_attr(jq, jv_string("JQ_ORIGIN"), jv_string("/tmp/"));
 
     if (jq_compile(jq, prog_payload.c_str())) {
       // Process to jv_parse and then jv_next

--- a/tests/jq_fuzz_execute.cpp
+++ b/tests/jq_fuzz_execute.cpp
@@ -16,6 +16,10 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, size_t size) {
   jq_state *jq = NULL;
   jq = jq_init();
   if (jq != NULL) {
+    char *origin = strdup("/tmp/");
+    jq_set_attr(jq, jv_string("JQ_ORIGIN"), jv_string(origin));
+    free(origin);
+
     if (jq_compile(jq, prog_payload.c_str())) {
       // Process to jv_parse and then jv_next
       jv input = jv_parse(parse_payload1.c_str());


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64632 by following the suggestion here: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64632#c2 -- the issue is fixed when this attribute is set.

I did not add any of the other suggestions in the comment: we haven't run into these issues in the fuzzer so far.