### PR TITLE
builtins: make ltrimstr and rtrimstr error for non-string inputs

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -294,37 +294,6 @@ static jv f_endswith(jq_state *jq, jv a, jv b) {
   return ret;
 }
 
-static jv f_ltrimstr(jq_state *jq, jv input, jv left) {
-  jv startswith = f_startswith(jq, jv_copy(input), jv_copy(left));
-  if (jv_get_kind(startswith) != JV_KIND_TRUE) {
-    jv_free(startswith);
-    jv_free(left);
-    return input;
-  }
-  /*
-   * FIXME It'd be better to share the suffix with the original input --
-   * that we could do, we just can't share prefixes.
-   */
-  int prefixlen = jv_string_length_bytes(left);
-  jv res = jv_string_sized(jv_string_value(input) + prefixlen,
-                           jv_string_length_bytes(jv_copy(input)) - prefixlen);
-  jv_free(input);
-  return res;
-}
-
-static jv f_rtrimstr(jq_state *jq, jv input, jv right) {
-  jv endswith = f_endswith(jq, jv_copy(input), jv_copy(right));
-  if (jv_get_kind(endswith) == JV_KIND_TRUE) {
-    jv res = jv_string_sized(jv_string_value(input),
-                             jv_string_length_bytes(jv_copy(input)) - jv_string_length_bytes(right));
-    jv_free(input);
-    return res;
-  }
-  jv_free(endswith);
-  jv_free(right);
-  return input;
-}
-
 jv binop_minus(jv a, jv b) {
   if (jv_get_kind(a) == JV_KIND_NUMBER && jv_get_kind(b) == JV_KIND_NUMBER) {
     jv r = jv_number(jv_number_value(a) - jv_number_value(b));
@@ -1736,8 +1705,6 @@ BINOPS
   {f_keys_unsorted, "keys_unsorted", 1},
   {f_startswith, "startswith", 2},
   {f_endswith, "endswith", 2},
-  {f_ltrimstr, "ltrimstr", 2},
-  {f_rtrimstr, "rtrimstr", 2},
   {f_string_split, "split", 2},
   {f_string_explode, "explode", 1},
   {f_string_implode, "implode", 1},

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -74,6 +74,8 @@ def fromdateiso8601: strptime("%Y-%m-%dT%H:%M:%SZ")|mktime;
 def todateiso8601: strftime("%Y-%m-%dT%H:%M:%SZ");
 def fromdate: fromdateiso8601;
 def todate: todateiso8601;
+def ltrimstr($left): if startswith($left) then .[$left | length:] end;
+def rtrimstr($right): if endswith($right) then .[:$right | -length] end;
 def match(re; mode): _match_impl(re; mode; false)|.[];
 def match($val): ($val|type) as $vt | if $vt == "string" then match($val; null)
    elif $vt == "array" and ($val | length) > 1 then match($val[0]; $val[1])

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2110,3 +2110,19 @@ try ltrimstr("x") catch "x", try rtrimstr("x") catch "x" | "ok"
 {"hey":[]}
 "ok"
 "ok"
+
+# ltrimstr/1 and rtrimstr/1 return an error for non-strings. #2969
+
+.[] as [$x, $y] | try ["ok", ($x | ltrimstr($y))] catch ["ko", .]
+[["hi",1],[1,"hi"],["hi","hi"],[1,1]]
+["ko","startswith() requires string inputs"]
+["ko","startswith() requires string inputs"]
+["ok",""]
+["ko","startswith() requires string inputs"]
+
+.[] as [$x, $y] | try ["ok", ($x | rtrimstr($y))] catch ["ko", .]
+[["hi",1],[1,"hi"],["hi","hi"],[1,1]]
+["ko","endswith() requires string inputs"]
+["ko","endswith() requires string inputs"]
+["ok",""]
+["ko","endswith() requires string inputs"]


### PR DESCRIPTION
I also refactored the code in rtrimstr to make it more similar to the
code used by ltrimstr.

Previously, ltrimstr/rtrimstr would just let the input pass through for
non-string inputs or arguments.

That was happening because, they were leaking the errors returned by
startswith/endswith treating them as if they were jv_false().

This patch also fixes that memory leak discovered by oss-fuzz

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64946
