### PR TITLE
jv_setpath+setpath/2: don't leak the input after an invalid get

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -408,6 +408,7 @@ jv jv_setpath(jv root, jv path, jv value) {
 
   jv subroot = jv_get(jv_copy(root), jv_copy(pathcurr));
   if (!jv_is_valid(subroot)) {
+    jv_free(root);
     jv_free(pathcurr);
     jv_free(pathrest);
     jv_free(value);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2091,3 +2091,7 @@ try ("foobar" | .[1.5]) catch .
 null
 "Cannot index string with number"
 
+# setpath/2 does not leak the input after an invalid get #2967
+try ["ok", setpath([1]; 1)] catch ["ko", .]
+{"hi":"hello"}
+["ko","Cannot index object with number"]


### PR DESCRIPTION
Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64906
