### PR TITLE
ltrimstr/1+rtrimstr/1: don't leak on invalid input or arguments

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -295,7 +295,9 @@ static jv f_endswith(jq_state *jq, jv a, jv b) {
 }
 
 static jv f_ltrimstr(jq_state *jq, jv input, jv left) {
-  if (jv_get_kind(f_startswith(jq, jv_copy(input), jv_copy(left))) != JV_KIND_TRUE) {
+  jv startswith = f_startswith(jq, jv_copy(input), jv_copy(left));
+  if (jv_get_kind(startswith) != JV_KIND_TRUE) {
+    jv_free(startswith);
     jv_free(left);
     return input;
   }
@@ -311,12 +313,14 @@ static jv f_ltrimstr(jq_state *jq, jv input, jv left) {
 }
 
 static jv f_rtrimstr(jq_state *jq, jv input, jv right) {
-  if (jv_get_kind(f_endswith(jq, jv_copy(input), jv_copy(right))) == JV_KIND_TRUE) {
+  jv endswith = f_endswith(jq, jv_copy(input), jv_copy(right));
+  if (jv_get_kind(endswith) == JV_KIND_TRUE) {
     jv res = jv_string_sized(jv_string_value(input),
                              jv_string_length_bytes(jv_copy(input)) - jv_string_length_bytes(right));
     jv_free(input);
     return res;
   }
+  jv_free(endswith);
   jv_free(right);
   return input;
 }

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2091,7 +2091,22 @@ try ("foobar" | .[1.5]) catch .
 null
 "Cannot index string with number"
 
+
 # setpath/2 does not leak the input after an invalid get #2970
+
 try ["ok", setpath([1]; 1)] catch ["ko", .]
 {"hi":"hello"}
 ["ko","Cannot index object with number"]
+
+
+# ltrimstr/1 rtrimstr/1 don't leak on invalid input #2977
+
+try ltrimstr(1) catch "x", try rtrimstr(1) catch "x" | "ok"
+"hi"
+"ok"
+"ok"
+
+try ltrimstr("x") catch "x", try rtrimstr("x") catch "x" | "ok"
+{"hey":[]}
+"ok"
+"ok"


### PR DESCRIPTION
`ltrimstr`/`rtrimstr` was ignoring and leaking the error returned by `f_startswith()`/`f_endswith()`.

This also means that they just let the input pass through for non-string inputs or arguments.

Only fix the leak for now; in the next release, #2969 will make them rethrow the error returned by startswith/endswith.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64946
