### PR TITLE
jv_mem_calloc(): always call with (nmemb, size)

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -1282,7 +1282,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
   bc->codelen = pos;
   bc->debuginfo = jv_object_set(bc->debuginfo, jv_string("locals"), localnames);
   if (bc->nsubfunctions && !errors) {
-    bc->subfunctions = jv_mem_calloc(sizeof(struct bytecode*), bc->nsubfunctions);
+    bc->subfunctions = jv_mem_calloc(bc->nsubfunctions, sizeof(struct bytecode*));
     for (inst* curr = b.first; curr; curr = curr->next) {
       if (curr->op == CLOSURE_CREATE) {
         struct bytecode* subfn = jv_mem_alloc(sizeof(struct bytecode));
@@ -1308,7 +1308,7 @@ static int compile(struct bytecode* bc, block b, struct locfile* lf, jv args, jv
     bc->nsubfunctions = 0;
     bc->subfunctions = 0;
   }
-  uint16_t* code = jv_mem_calloc(sizeof(uint16_t), bc->codelen);
+  uint16_t* code = jv_mem_calloc(bc->codelen, sizeof(uint16_t));
   bc->code = code;
   pos = 0;
   jv constant_pool = jv_array();
@@ -1374,7 +1374,7 @@ int block_compile(block b, struct bytecode** out, struct locfile* lf, jv args) {
   bc->globals = jv_mem_alloc(sizeof(struct symbol_table));
   int ncfunc = count_cfunctions(b);
   bc->globals->ncfunctions = 0;
-  bc->globals->cfunctions = jv_mem_calloc(sizeof(struct cfunction), ncfunc);
+  bc->globals->cfunctions = jv_mem_calloc(ncfunc, sizeof(struct cfunction));
   bc->globals->cfunc_names = jv_array();
   bc->debuginfo = jv_object_set(jv_object(), jv_string("name"), jv_null());
   jv env = jv_invalid();

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -553,7 +553,7 @@ jv jv_keys_unsorted(jv x) {
 jv jv_keys(jv x) {
   if (jv_get_kind(x) == JV_KIND_OBJECT) {
     int nkeys = jv_object_length(jv_copy(x));
-    jv* keys = jv_mem_calloc(sizeof(jv), nkeys);
+    jv* keys = jv_mem_calloc(nkeys, sizeof(jv));
     int kidx = 0;
     jv_object_foreach(x, key, value) {
       keys[kidx++] = key;
@@ -674,7 +674,7 @@ static struct sort_entry* sort_items(jv objects, jv keys) {
   assert(jv_get_kind(keys) == JV_KIND_ARRAY);
   assert(jv_array_length(jv_copy(objects)) == jv_array_length(jv_copy(keys)));
   int n = jv_array_length(jv_copy(objects));
-  struct sort_entry* entries = jv_mem_calloc(sizeof(struct sort_entry), n);
+  struct sort_entry* entries = jv_mem_calloc(n, sizeof(struct sort_entry));
   for (int i=0; i<n; i++) {
     entries[i].object = jv_array_get(jv_copy(objects), i);
     entries[i].key = jv_array_get(jv_copy(keys), i);

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -79,7 +79,7 @@ static void put_buf(const char *s, int len, FILE *fout, jv *strout, int is_tty) 
     if (len == -1)
       len = strlen(s);
     wl = MultiByteToWideChar(CP_UTF8, 0, s, len, NULL, 0);
-    ws = jv_mem_calloc((wl + 1), sizeof(*ws));
+    ws = jv_mem_calloc(wl + 1, sizeof(*ws));
     if (!ws)
       return;
     wl = MultiByteToWideChar(CP_UTF8, 0, s, len, ws, wl + 1);

--- a/src/locfile.c
+++ b/src/locfile.c
@@ -21,7 +21,7 @@ struct locfile* locfile_init(jq_state *jq, const char *fname, const char* data, 
   for (int i=0; i<length; i++) {
     if (data[i] == '\n') l->nlines++;
   }
-  l->linemap = jv_mem_calloc(sizeof(int), (l->nlines + 1));
+  l->linemap = jv_mem_calloc(l->nlines + 1, sizeof(int));
   l->linemap[0] = 0;
   int line = 1;
   for (int i=0; i<length; i++) {


### PR DESCRIPTION
It does not matter much since they most likely just get multiplied
together, but some compilers would complain about this if these were
calls to calloc.
