### PR TITLE
shtest: fix out-of-source tests

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -566,15 +566,18 @@ if ! $VALGRIND $Q $JQ -n -f "$JQTESTDIR/yes-main-program.jq" > $d/out 2>&1; then
   exit 1
 fi
 
-if ( ! $msys && ! $mingw ) && locale -a > /dev/null; then
-  locale=$(locale -a | egrep -v '^(C|LANG|POSIX|en)' | egrep -i 'utf8|utf-8' | head -1)
-  if [ -z "$locale" ]; then
+if ! $msys && ! $mingw && locales=$(locale -a); then
+  { l=$(grep -Ev '^(C|LANG|POSIX|en)' | grep -Ei '\.utf-?8$' | head -n1) ;} \
+<<EOF
+$locales
+EOF
+  if [ -z "$l" ]; then
     echo "WARNING: Not testing localization"
   else
-    date=$(LC_ALL="$locale" date +"%a %d %b %Y at %H:%M:%S")
-    if ! LC_ALL="$locale" ./jq -nRe --arg date "$date" '$date|strptime("%a %d %b %Y at %H:%M:%S")? // false'; then
+    date=$(LC_ALL=$l date +'%a %d %b %Y at %H:%M:%S')
+    if ! LC_ALL=$l $JQ -nR --arg date "$date" '$date|strptime("%a %d %b %Y at %H:%M:%S")'; then
       echo "jq does not honor LC_ALL environment variable"
-      exit 1;
+      exit 1
     fi
   fi
 fi


### PR DESCRIPTION
The locale test was using ./jq intead of $JQ.

I also removed the use of obsolete `egrep` instead of `grep -E` that
triggers warnings on GNU systems, and the use deprecated `head -1`
instead of `head -n1`.

Also removed the unnecessary hiding of strptime/1 errors with `? // false`.

--

```
+ false
+ false
+ locale -a
++ locale -a
++ egrep -v '^(C|LANG|POSIX|en)'
++ egrep -i 'utf8|utf-8'
++ head -1
egrep: warning: egrep is obsolescent; using grep -E
egrep: warning: egrep is obsolescent; using grep -E
+ locale=it_IT.utf8
+ '[' -z it_IT.utf8 ']'
++ LC_ALL=it_IT.utf8
++ date '+%a %d %b %Y at %H:%M:%S'
+ date='lun 11 dic 2023 at 18:31:44'
+ LC_ALL=it_IT.utf8
+ ./jq -nRe --arg date 'lun 11 dic 2023 at 18:31:44' '$date|strptime("%a %d %b %Y at %H:%M:%S")? // false'
../../tests/shtest: line 575: ./jq: No such file or directory
+ echo 'jq does not honor LC_ALL environment variable'
jq does not honor LC_ALL environment variable
+ exit 1
clean
+ clean
+ true
+ '[' -n /tmp/jqkQZzXn ']'
+ rm -rf /tmp/jqkQZzXn
FAIL tests/shtest (exit status: 1)
```
