### PR TITLE
shtest+configure: remove uses of non-portable/non-standard commands

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_CHECK_FUNCS(memmem)
 
 AC_CHECK_HEADER("sys/cygwin.h", [have_cygwin=1;])
 AC_CHECK_HEADER("shlwapi.h",[have_shlwapi=1;])
-AM_CONDITIONAL([WIN32], [test \( "x$have_shlwapi" = x1 \) -a ! \( "x$have_cygwin" = x1 \)])
+AM_CONDITIONAL([WIN32], [test "x$have_shlwapi" = x1 && test ! "x$have_cygwin" = x1])
 
 dnl Running tests with Valgrind is slow. It is faster to iterate on
 dnl code without Valgrind until tests pass, then enable Valgrind and
@@ -275,7 +275,7 @@ AS_IF([test "x$with_oniguruma" != xno], [
           AC_MSG_NOTICE([Oniguruma was not found. Will use the packaged oniguruma.])
        ])
    ])
-   AS_IF([test "x$build_oniguruma" = xyes -a -f "${srcdir}/modules/oniguruma/configure.ac" ], [
+   AS_IF([test "x$build_oniguruma" = xyes && test -f "${srcdir}/modules/oniguruma/configure.ac" ], [
        onig_CFLAGS="-I${srcdir}/modules/oniguruma/src"
        onig_LDFLAGS="-L${srcdir}/modules/oniguruma/src -Wl,-rpath,${libdir}"
        AC_CONFIG_SUBDIRS([modules/oniguruma])

--- a/tests/shtest
+++ b/tests/shtest
@@ -244,7 +244,7 @@ if which seq > /dev/null 2>&1; then
         if [ -n "$VALGRIND" ]; then
             grep '^==[0-9][0-9]*== ERROR SUMMARY: 0 errors' $d/err > /dev/null
         else
-            tail -1 $d/err | egrep -i 'assert|abort|core' && false
+            tail -n1 -- "$d/err" | grep -Ei 'assert|abort|core' && false
         fi
 
         dd "if=tests/torture/input0.json" bs=$i count=1 2>/dev/null |
@@ -252,7 +252,7 @@ if which seq > /dev/null 2>&1; then
         if [ -n "$VALGRIND" ]; then
             grep '^==[0-9][0-9]*== ERROR SUMMARY: 0 errors' $d/err > /dev/null
         else
-            tail -1 $d/err | egrep -i 'assert|abort|core' && false
+            tail -n1 -- "$d/err" | grep -Ei 'assert|abort|core' && false
         fi
 
         diff $d/out0 $d/out1


### PR DESCRIPTION
Replace deprecated `test(1)` parentheses and `-a` logical operator with two tests command.

Replace deprecated `tail -1` with `tail -n1`.

Replace non-standard `egrep(1)` command with `grep -E`; this also prevents obsolescence warnings on GNU systems.
