### PR TITLE
ci.yml: use `sysctl -n hw.logicalcpu` instead of `nproc` on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
             --enable-static \
             --enable-all-static \
             CFLAGS="-O2 -pthread -fstack-protector-all"
-          make -j"$(nproc)"
+          make -j"$(sysctl -n hw.logicalcpu)"
           strip ./jq
           file ./jq
           cp ./jq jq-${{ env.SUFFIX }}


### PR DESCRIPTION
The "macos (arm64)" runner on github does not have nproc.

    /Users/runner/work/_temp/f44f0d9f-19eb-4a23-860e-26533d7efdfa.sh: line 10: nproc: command not found
