### PR TITLE
jv_parse: let decNumberFromString/strtod parse complex nans as a NaN

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -514,7 +514,7 @@ static pfunc check_literal(struct jv_parser* p) {
   case 'f': pattern = "false"; plen = 5; v = jv_false(); break;
   case 'n':
     // if it starts with 'n', it could be a literal "nan"
-    if (p->tokenpos != 3) {
+    if (p->tokenbuf[1] == 'u') {
       pattern = "null"; plen = 4; v = jv_null();
     }
   }

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1938,6 +1938,11 @@ tojson | fromjson
 {"a":nan}
 {"a":null}
 
+# also "nan with payload" #2985
+fromjson | isnan
+"nan1234"
+true
+
 
 # calling input/0, or debug/0 in a test doesn't crash jq
 


### PR DESCRIPTION
Before this patch (when using decNumber), "Nan123" was parsed as a NaN,
only if the first n was uppercase.
