### PR TITLE
Always build Docker image on CI, group Dependabot PRs for official actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      official-actions:
+        patterns: ["actions/*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,6 @@ jobs:
     permissions:
       packages: write
     needs: linux
-    if: startsWith(github.ref, 'refs/tags/jq-')
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -330,7 +329,9 @@ jobs:
         id: metadata
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: type=match,pattern=jq-(.*),group=1,value=${{ github.ref_name }}
+          tags: ${{ startsWith(github.ref, 'refs/tags/jq-')
+            && format('type=match,pattern=jq-(.*),group=1,value={0}', github.ref_name)
+            || 'type=sha,format=long' }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -345,7 +346,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: ${{ startsWith(github.ref, 'refs/tags/jq-') }}
           provenance: false
           platforms: linux/386,linux/amd64,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
           tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Download executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: jq-linux
       - name: Move executables
@@ -364,7 +364,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
       - name: Upload release
         env:
           TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
We should build the docker image to keep the CI workflow working, and just stop before pushing the image to the registry. Otherwise, we don't notice upgrading actions/download-artifact breaks the workflow. Also I improved the Dependabot configuration to group official actions.