### PR TITLE
Fix Spelling Error in Manual "contruct" > "construct"

### DIFF
--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -569,7 +569,7 @@ sections:
           .bar`, produces both the "foo" fields and "bar" fields as
           separate outputs.
 
-          The `,` operator is one way to contruct generators.
+          The `,` operator is one way to construct generators.
 
         examples:
           - program: ".foo, .bar"


### PR DESCRIPTION
Reading documentation and found a spelling error.

~~"contruct"~~ > _"construct"_

🤟🏾😈🤟🏾