### PR TITLE
Provide strptime implementation on all systems

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1464,7 +1464,7 @@ static jv f_strptime(jq_state *jq, jv a, jv b) {
    */
   set_tm_wday(&tm);
   set_tm_yday(&tm);
-#elif defined(WIN32)
+#elif defined(WIN32) || !defined(HAVE_STRPTIME)
   set_tm_wday(&tm);
 #else
   if (tm.tm_wday == 8 && tm.tm_mday != 0 && tm.tm_mon >= 0 && tm.tm_mon <= 11)

--- a/src/util.c
+++ b/src/util.c
@@ -451,7 +451,7 @@ jv jq_util_input_next_input(jq_util_input_state *state) {
   return value;
 }
 
-#if defined(WIN32) && !defined(HAVE_STRPTIME)
+#ifndef HAVE_STRPTIME
 /* http://cvsweb.netbsd.org/bsdweb.cgi/~checkout~/src/lib/libc/time/strptime.c?only_with_tag=HEAD
  * NetBSD implementation strptime().
  * Format description: https://netbsd.gw.com/cgi-bin/man-cgi?strptime+3+NetBSD-current


### PR DESCRIPTION
Some operating systems, notably [Redox OS](https://redox-os.org), do not have an implementation of `strptime` and would benefit from the built-in fallback as well.