### PR TITLE
docs: rename example jq utility to total

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3571,8 +3571,8 @@ sections:
       when writing the "shebang" for a jq script:
 
           #!/bin/sh --
-          # sum - Output the sum of the given arguments (or stdin)
-          # usage: sum [numbers...]
+          # total - Output the sum of the given arguments (or stdin)
+          # usage: total [numbers...]
           # \
           exec jq --args -MRnf "$0" -- "$@"
 
@@ -3585,16 +3585,16 @@ sections:
             . as $dot |
             try tonumber catch false |
             if not or isnan then
-              @json "sum: Invalid number \($dot).\n" | halt_error(1)
+              @json "total: Invalid number \($dot).\n" | halt_error(1)
             end
           ) as $n (0; . + $n)
 
       The `exec` line is considered a comment by jq, so it is ignored.
       But it is not ignored by `sh`, since in `sh` a backslash at the
       end of the line does not continue the comment.
-      With this trick, when the script is invoked as `sum 1 2`,
-      `/bin/sh -- /path/to/sum 1 2` will be run, and `sh` will then
-      run `exec jq --args -MRnf /path/to/sum -- 1 2` replacing itself
+      With this trick, when the script is invoked as `total 1 2`,
+      `/bin/sh -- /path/to/total 1 2` will be run, and `sh` will then
+      run `exec jq --args -MRnf /path/to/total -- 1 2` replacing itself
       with a `jq` interpreter invoked with the specified options (`-M`,
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
       with the arguments (`$@`) that were passed to `sh`.

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "December 2023" "" ""
+.TH "JQ" "1" "January 2024" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -3998,8 +3998,8 @@ Backslash continuing the comment on the next line can be useful when writing the
 .nf
 
 #!/bin/sh \-\-
-# sum \- Output the sum of the given arguments (or stdin)
-# usage: sum [numbers\.\.\.]
+# total \- Output the sum of the given arguments (or stdin)
+# usage: total [numbers\.\.\.]
 # \e
 exec jq \-\-args \-MRnf "$0" \-\- "$@"
 
@@ -4012,7 +4012,7 @@ reduce (
   \. as $dot |
   try tonumber catch false |
   if not or isnan then
-    @json "sum: Invalid number \e($dot)\.\en" | halt_error(1)
+    @json "total: Invalid number \e($dot)\.\en" | halt_error(1)
   end
 ) as $n (0; \. + $n)
 .
@@ -4021,7 +4021,7 @@ reduce (
 .IP "" 0
 .
 .P
-The \fBexec\fR line is considered a comment by jq, so it is ignored\. But it is not ignored by \fBsh\fR, since in \fBsh\fR a backslash at the end of the line does not continue the comment\. With this trick, when the script is invoked as \fBsum 1 2\fR, \fB/bin/sh \-\- /path/to/sum 1 2\fR will be run, and \fBsh\fR will then run \fBexec jq \-\-args \-MRnf /path/to/sum \-\- 1 2\fR replacing itself with a \fBjq\fR interpreter invoked with the specified options (\fB\-M\fR, \fB\-R\fR, \fB\-n\fR, \fB\-\-args\fR), that evaluates the current file (\fB$0\fR), with the arguments (\fB$@\fR) that were passed to \fBsh\fR\.
+The \fBexec\fR line is considered a comment by jq, so it is ignored\. But it is not ignored by \fBsh\fR, since in \fBsh\fR a backslash at the end of the line does not continue the comment\. With this trick, when the script is invoked as \fBtotal 1 2\fR, \fB/bin/sh \-\- /path/to/total 1 2\fR will be run, and \fBsh\fR will then run \fBexec jq \-\-args \-MRnf /path/to/total \-\- 1 2\fR replacing itself with a \fBjq\fR interpreter invoked with the specified options (\fB\-M\fR, \fB\-R\fR, \fB\-n\fR, \fB\-\-args\fR), that evaluates the current file (\fB$0\fR), with the arguments (\fB$@\fR) that were passed to \fBsh\fR\.
 .
 .SH "MODULES"
 jq has a library/module system\. Modules are files whose names end in \fB\.jq\fR\.


### PR DESCRIPTION
Apparently sum(1) is a BSD and GNU coreutil used to compute the
"16-bit BSD checksum" of a file.
