### PR TITLE
License: Improve license statement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,7 @@ For details on cross-compilation, check out the [GitHub Actions file](.github/wo
 
 ## License
 
-`jq` is released under the [MIT License](COPYING).
+`jq` is released under the [MIT License](COPYING). `jq`'s documentation is
+licensed under the [Creative Commons CC BY 3.0](COPYING).
+`jq` uses parts of the open source C library "decNumber", which is distributed
+under [ICU License](COPYING)

--- a/jq.spec
+++ b/jq.spec
@@ -6,7 +6,7 @@ Version: %{myver}
 Release: %{myrel}%{?dist}
 Source0: jq-%{myver}.tar.gz
 URL: https://jqlang.github.io/jq
-License: BSD
+License: MIT AND ICU AND CC-BY-3.0
 AutoReqProv: no
 #BuildPrereq: autoconf, libtool, automake, flex, bison, python
 


### PR DESCRIPTION
The README mentions only the MIT license but in fact part of `jq` is under ICU license and the documentation is under CC.

Also jq.spec claimed that it is licensed under BSD license.