### PR TITLE
Fix typo in documentation for map_values

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -1007,7 +1007,7 @@ sections:
           `($x|f)` for each value, $x, in the input array or object,
           but `map_values(f)` only uses `first($x|f)`.
 
-          Specifically, for object inputs, `map_value(f)` constructs
+          Specifically, for object inputs, `map_values(f)` constructs
           the output object by examining in turn the value of
           `first(.[$k]|f)` for each key, $k, of the input.  If this
           expression produces no values, then the corresponding key

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -1007,7 +1007,7 @@ sections:
           `($x|f)` for each value, $x, in the input array or object,
           but `map_values(f)` only uses `first($x|f)`.
 
-          Specifically, for object inputs, `map_value(f)` constructs
+          Specifically, for object inputs, `map_values(f)` constructs
           the output object by examining in turn the value of
           `first(.[$k]|f)` for each key, $k, of the input.  If this
           expression produces no values, then the corresponding key

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "January 2024" "" ""
+.TH "JQ" "1" "February 2024" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -1004,7 +1004,7 @@ When the input to \fBmap_values(f)\fR is an object, the output object has the sa
 The key difference between \fBmap(f)\fR and \fBmap_values(f)\fR is that the former simply forms an array from all the values of \fB($x|f)\fR for each value, $x, in the input array or object, but \fBmap_values(f)\fR only uses \fBfirst($x|f)\fR\.
 .
 .P
-Specifically, for object inputs, \fBmap_value(f)\fR constructs the output object by examining in turn the value of \fBfirst(\.[$k]|f)\fR for each key, $k, of the input\. If this expression produces no values, then the corresponding key will be dropped; otherwise, the output object will have that value at the key, $k\.
+Specifically, for object inputs, \fBmap_values(f)\fR constructs the output object by examining in turn the value of \fBfirst(\.[$k]|f)\fR for each key, $k, of the input\. If this expression produces no values, then the corresponding key will be dropped; otherwise, the output object will have that value at the key, $k\.
 .
 .P
 Here are some examples to clarify the behavior of \fBmap\fR and \fBmap_values\fR when applied to arrays\. These examples assume the input is \fB[1]\fR in all cases:


### PR DESCRIPTION
"map_value(f)" -> "map_values(f)".

This was only in the documentation for v1.7. The documentation for earlier versions did not have the same typo.

This typo appears to have been introduced in the original draft of the documentation for v1.7: https://github.com/jqlang/jq/commit/806475da2942584370a35d75fdd7d1103c17246a