### PR TITLE
minor buglets

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -210,7 +210,7 @@ static jv f_ ## name(jq_state *jq, jv input, jv a, jv b, jv c) { \
 }
 #define LIBM_DDDD_NO(name) \
 static jv f_ ## name(jq_state *jq, jv input, jv a, jv b, jv c) { \
-  jv_free(c) \
+  jv_free(c); \
   jv_free(b); \
   jv error = jv_string("Error: " #name "/3 not found at build time"); \
   return ret_error2(input, a, error); \

--- a/src/jv_dtoa.c
+++ b/src/jv_dtoa.c
@@ -299,7 +299,7 @@ extern "C" {
 #endif
 
 #if defined(IEEE_8087) + defined(IEEE_MC68k) + defined(VAX) + defined(IBM) != 1
-Exactly one of IEEE_8087, IEEE_MC68k, VAX, or IBM should be defined.
+#  error Exactly one of IEEE_8087, IEEE_MC68k, VAX, or IBM should be defined.
 #endif
 
 typedef union { double d; ULong L[2]; } U;


### PR DESCRIPTION
Just two minor glitches I found accidentally:
- Use `#error` to generate an error, instead of a syntax error.
- Add missing semicolon.

In case you wonder how I found those, I'm trying to convert jq to use [bazel](https://bazel.build) as build system. This is mostly for training, I'm not directly planning to submit that as PR.

Cheers!

Uli
