### PR TITLE
tests: run tests in C locale

### DIFF
--- a/tests/setup
+++ b/tests/setup
@@ -12,6 +12,10 @@ JQTESTDIR=$(cd "$(dirname "$0")" && pwd)
 JQBASEDIR=$JQTESTDIR/..
 JQ=${JQ:-$JQBASEDIR/jq}
 
+# Some tests have locale-dependent output; use C locale.  Fixes #3038
+LC_ALL=C
+export LC_ALL
+
 if [ -z "${NO_VALGRIND-}" ] && which valgrind > /dev/null; then
     VALGRIND="valgrind --error-exitcode=1 --leak-check=full \
                        --suppressions=$JQTESTDIR/onig.supp \


### PR DESCRIPTION
Before:
```
003 (1955373) ~/s/j $ LC_ALL=it_IT.utf-8 make check
make  check-recursive
make[1]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[2]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make  tests/man.test
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[3]: «tests/man.test» è aggiornato.
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make  check-TESTS
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[4]: ingresso nella directory «/home/emanuele6/.source_code/jq»
PASS: tests/mantest
FAIL: tests/jqtest
PASS: tests/shtest
PASS: tests/utf8test
PASS: tests/base64test
FAIL: tests/optionaltest
PASS: tests/onigtest
PASS: tests/manonigtest
============================================================================
Testsuite summary for jq 1.7.1-14-ge5dc5be-dirty
============================================================================
# TOTAL: 8
# PASS:  6
# SKIP:  0
# XFAIL: 0
# FAIL:  2
# XPASS: 0
# ERROR: 0
============================================================================
See ./test-suite.log
Please report to https://github.com/jqlang/jq/issues
============================================================================
make[4]: *** [Makefile:1304: test-suite.log] Error 1
make[4]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[3]: *** [Makefile:1412: check-TESTS] Error 2
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[2]: *** [Makefile:1698: check-am] Error 2
make[2]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[1]: *** [Makefile:1189: check-recursive] Error 1
make[1]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make: *** [Makefile:1700: check] Error 2
```
After:
```
021 (1955373) ~/s/j $ LC_ALL=it_IT.utf-8 make check
mkdir -p src
  GEN      src/version.h
make  check-recursive
make[1]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[2]: ingresso nella directory «/home/emanuele6/.source_code/jq»
  CC       src/main.o
  CCLD     jq
make  tests/man.test
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[3]: «tests/man.test» è aggiornato.
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make  check-TESTS
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[4]: ingresso nella directory «/home/emanuele6/.source_code/jq»
PASS: tests/mantest
PASS: tests/jqtest
PASS: tests/shtest
PASS: tests/utf8test
PASS: tests/base64test
PASS: tests/optionaltest
PASS: tests/onigtest
PASS: tests/manonigtest
============================================================================
Testsuite summary for jq 1.7.1-14-ge5dc5be-dirty
============================================================================
# TOTAL: 8
# PASS:  8
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[4]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[2]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[1]: uscita dalla directory «/home/emanuele6/.source_code/jq»
004 (1955373) ~/s/j $ LANG=it_IT.utf-8 make check
make  check-recursive
make[1]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[2]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make  tests/man.test
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[3]: «tests/man.test» è aggiornato.
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make  check-TESTS
make[3]: ingresso nella directory «/home/emanuele6/.source_code/jq»
make[4]: ingresso nella directory «/home/emanuele6/.source_code/jq»
PASS: tests/mantest
PASS: tests/jqtest
PASS: tests/shtest
PASS: tests/utf8test
PASS: tests/base64test
PASS: tests/optionaltest
PASS: tests/onigtest
PASS: tests/manonigtest
============================================================================
Testsuite summary for jq 1.7.1-14-ge5dc5be-dirty
============================================================================
# TOTAL: 8
# PASS:  8
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[4]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[3]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[2]: uscita dalla directory «/home/emanuele6/.source_code/jq»
make[1]: uscita dalla directory «/home/emanuele6/.source_code/jq»
```

Fixes #3038
