### PR TITLE
implement borrowing

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -166,7 +166,7 @@ void stack_push(jq_state *jq, jv val) {
   assert(jv_is_valid(val));
   jq->stk_top = stack_push_block(&jq->stk, jq->stk_top, sizeof(jv));
   jv* sval = stack_block(&jq->stk, jq->stk_top);
-  *sval = val;
+  *sval = jv_return(val);
 }
 
 jv stack_pop(jq_state *jq) {
@@ -1274,7 +1274,7 @@ jv jq_get_lib_dirs(jq_state *jq) {
 void jq_set_attrs(jq_state *jq, jv attrs) {
   assert(jv_get_kind(attrs) == JV_KIND_OBJECT);
   jv_free(jq->attrs);
-  jq->attrs = attrs;
+  jq->attrs = jv_return(attrs);
 }
 
 void jq_set_attr(jq_state *jq, jv attr, jv val) {
@@ -1324,8 +1324,8 @@ jq_halt(jq_state *jq, jv exit_code, jv error_message)
 {
   assert(!jq->halted);
   jq->halted = 1;
-  jq->exit_code = exit_code;
-  jq->error_message = error_message;
+  jq->exit_code = jv_return(exit_code);
+  jq->error_message = jv_return(error_message);
 }
 
 int

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -563,10 +563,15 @@ static void jv_test() {
 
      jv_free(b);
 
-     jv o = JV_OBJECT(jv_string("some"), jv_string("value"));
-     jv od = jv_object_delete(jv_borrow(o), jv_string("some"));
-     jv ov = jv_getpath(o, JV_ARRAY(jv_string("some")));
-     assert(jv_equal(ov, jv_string("value")));
-     jv_free(od);
+     jv object = JV_OBJECT(jv_string("some"), jv_string("value"));
+     jv object_deleted = jv_object_delete(jv_borrow(o), jv_string("some"));
+     jv object_value = jv_getpath(object, JV_ARRAY(jv_string("some")));
+     assert(jv_equal(object_value, jv_string("value")));
+     jv_free(object_deleted);
+
+     jv array = JV_ARRAY(jv_string("some"), jv_string("value"));
+     jv new_array = jv_array_slice(jv_borrow(array), 0, 1);
+     assert(jv_equal(array, JV_ARRAY(jv_string("some"), jv_string("value"))));
+     jv_free(new_array);
   }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -564,7 +564,7 @@ static void jv_test() {
      jv_free(b);
 
      jv object = JV_OBJECT(jv_string("some"), jv_string("value"));
-     jv object_deleted = jv_object_delete(jv_borrow(o), jv_string("some"));
+     jv object_deleted = jv_object_delete(jv_borrow(object), jv_string("some"));
      jv object_value = jv_getpath(object, JV_ARRAY(jv_string("some")));
      assert(jv_equal(object_value, jv_string("value")));
      jv_free(object_deleted);
@@ -573,5 +573,13 @@ static void jv_test() {
      jv new_array = jv_array_slice(jv_borrow(array), 0, 1);
      assert(jv_equal(array, JV_ARRAY(jv_string("some"), jv_string("value"))));
      jv_free(new_array);
-  }
+
+
+     jv test = jv_string("value");
+     object = JV_OBJECT(jv_string("some"), jv_borrow(test));
+     jv_free(test);
+     jv object_set = jv_object_set(jv_borrow(object), jv_string("some"), jv_string("other"));
+     assert(jv_equal(object, JV_OBJECT(jv_string("some"), jv_string("value"))));
+     jv_free(object_set);
+}
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -562,5 +562,11 @@ static void jv_test() {
      assert(jv_get_refcnt(a) == 1);
 
      jv_free(b);
+
+     jv o = JV_OBJECT(jv_string("some"), jv_string("value"));
+     jv od = jv_object_delete(jv_borrow(o), jv_string("some"));
+     jv ov = jv_getpath(o, JV_ARRAY(jv_string("some")));
+     assert(jv_equal(ov, jv_string("value")));
+     jv_free(od);
   }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -495,6 +495,7 @@ static void jv_test() {
   {
      jv d = jv_string("b");
      jv a = JV_ARRAY(jv_string("a"), jv_borrow(d));
+     jv_free(d);
 
      jv i = jv_invalid_with_msg(jv_borrow(d));
      jv m = jv_invalid_get_msg(i);
@@ -561,6 +562,5 @@ static void jv_test() {
      assert(jv_get_refcnt(a) == 1);
 
      jv_free(b);
-     jv_free(d);
   }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -581,5 +581,10 @@ static void jv_test() {
      jv object_set = jv_object_set(jv_borrow(object), jv_string("some"), jv_string("other"));
      assert(jv_equal(object, JV_OBJECT(jv_string("some"), jv_string("value"))));
      jv_free(object_set);
+
+     jv string = jv_string("value");
+     jv other = jv_string_append_buf(jv_borrow(string), "test", 4);
+     assert(jv_equal(string, jv_string("value")));
+     assert(jv_equal(other, jv_string("valuetest")));
 }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -528,19 +528,30 @@ static void jv_test() {
      assert(!jv_is_borrowed(k));
      jv_free(k);
 
-     //currently broken stuff
      jv f = jv_array_append(b, jv_number(5));
      assert(!jv_is_borrowed(f));
      jv_free(f);
 
      jv g = jv_array_append(jv_array(), b);
      assert(!jv_is_borrowed(g));
-     g = jv_setpath(g, JV_ARRAY(jv_number(0)), jv_string("test"));
-     assert(!jv_is_borrowed(g));
      jv_free(g);
-     g = jv_setpath(b, JV_ARRAY(jv_number(1)), jv_string("some"));
-     assert(!jv_is_borrowed(g));
-     jv_free(g);
+
+     jv a1 = jv_parse("{\"key\":\"value\"}");
+     jv p = jv_set(jv_borrow(a1), jv_string("key"), jv_string("other"));
+     assert(!jv_is_borrowed(p));
+     jv_free(p);
+
+     jv q = jv_get(jv_borrow(a1), jv_string("key"));
+     assert(!jv_is_borrowed(q));
+     jv_free(q);
+
+     jv_free(a1);
+
+
+
+     jv h = jv_setpath(b, JV_ARRAY(jv_number(1)), jv_string("some"));
+     assert(!jv_is_borrowed(h));
+     jv_free(h);
 
 
      b = jv_unborrow(b);
@@ -550,6 +561,5 @@ static void jv_test() {
      assert(jv_get_refcnt(a) == 1);
 
      jv_free(b);
-
   }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -586,5 +586,11 @@ static void jv_test() {
      jv other = jv_string_append_buf(jv_borrow(string), "test", 4);
      assert(jv_equal(string, jv_string("value")));
      assert(jv_equal(other, jv_string("valuetest")));
+
+     array = JV_ARRAY(jv_string("test"));
+     jv array_out = jv_array_set(jv_borrow(array), 0, jv_string("value"));
+     assert(jv_equal(array, JV_ARRAY(jv_string("test"))));
+     assert(!jv_is_borrowed(array_out));
+     jv_free(array_out);
 }
 }

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -508,7 +508,6 @@ static void jv_test() {
      assert(!jv_is_borrowed(c2));
      assert(jv_cmp(jv_borrow(c), jv_borrow(c2)) == 0);
      jv_free(c);
-     jv_free(d);
      jv_free(c2);
 
      jv b = jv_borrow(a);
@@ -518,7 +517,6 @@ static void jv_test() {
 
      assert(jv_equal(jv_copy(a), b));
 
-     //subject of potential debate
      jv e = jv_array_concat(b, JV_ARRAY(jv_number(5)));
      assert(!jv_is_borrowed(e));
      jv_free(e);
@@ -547,7 +545,9 @@ static void jv_test() {
 
      jv_free(a1);
 
-
+     jv res = jv_array_get(b, 1);
+     assert(!jv_is_borrowed(res));
+     jv_free(res);
 
      jv h = jv_setpath(b, JV_ARRAY(jv_number(1)), jv_string("some"));
      assert(!jv_is_borrowed(h));
@@ -561,5 +561,6 @@ static void jv_test() {
      assert(jv_get_refcnt(a) == 1);
 
      jv_free(b);
+     jv_free(d);
   }
 }

--- a/src/jv.c
+++ b/src/jv.c
@@ -164,7 +164,7 @@ jv jv_invalid_get_msg(jv inv) {
 
   jv x;
   if (JVP_HAS_FLAGS(inv, JVP_FLAGS_INVALID_MSG)) {
-    x = jv_copy(((jvp_invalid*)inv.u.ptr)->errmsg);
+    x = jv_unborrow(((jvp_invalid*)inv.u.ptr)->errmsg);
   }
   else {
     x = jv_null();
@@ -862,7 +862,7 @@ static jv* jvp_array_write(jv* a, int i) {
     int j;
     for (j = 0; j < jvp_array_length(*a); j++) {
       new_array->elements[j] =
-        jv_copy(array->elements[j + jvp_array_offset(*a)]);
+        jv_unborrow(array->elements[j + jvp_array_offset(*a)]);
     }
     for (; j < new_length; j++) {
       new_array->elements[j] = JV_NULL;
@@ -974,7 +974,7 @@ jv jv_array_get(jv j, int idx) {
   jv* slot = jvp_array_read(j, idx);
   jv val;
   if (slot) {
-    val = jv_copy(*slot);
+    val = jv_unborrow(*slot);
   } else {
     val = jv_invalid();
   }
@@ -1636,8 +1636,8 @@ static jv jvp_object_unshare(jv object) {
     struct object_slot* new_slot = jvp_object_get_slot(new_object, i);
     *new_slot = *old_slot;
     if (jv_get_kind(old_slot->string) != JV_KIND_NULL) {
-      new_slot->string = jv_copy(old_slot->string);
-      new_slot->value = jv_copy(old_slot->value);
+      new_slot->string = jv_unborrow(old_slot->string);
+      new_slot->value = jv_unborrow(old_slot->value);
     }
   }
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -1433,6 +1433,8 @@ jv jv_string_slice(jv j, int start, int end) {
 }
 
 jv jv_string_concat(jv a, jv b) {
+  a = jv_return(a);
+  b = jv_return(b);
   a = jvp_string_append(a, jv_string_value(b),
                         jvp_string_length(jvp_string_ptr(b)));
   jv_free(b);
@@ -1785,17 +1787,12 @@ jv jv_object_set(jv input, jv key, jv value) {
   assert(JVP_HAS_KIND(input, JV_KIND_OBJECT));
   assert(JVP_HAS_KIND(key, JV_KIND_STRING));
 
-  jv object = jv_unborrow(input);
-  jv_free(input);
+  input = jv_return(input);
   // copy/free of object, key, value coalesced
-  jv* slot = jvp_object_write(&object, key);
+  jv* slot = jvp_object_write(&input, jv_return(key));
   jv_free(*slot);
-  if(jv_is_borrowed(value)){
-    *slot = jv_unborrow(value);
-  }else{
-     *slot = value;
-  }
-  return object;
+  *slot = jv_return(value);
+  return input;
 }
 
 jv jv_object_delete(jv input, jv key) {

--- a/src/jv.c
+++ b/src/jv.c
@@ -995,7 +995,11 @@ jv jv_array_set(jv j, int idx, jv val) {
   // copy/free of val,j coalesced
   jv* slot = jvp_array_write(&j, idx);
   jv_free(*slot);
-  *slot = val;
+  if(jv_is_borrowed(val)){
+    *slot = jv_unborrow(val);
+  }else{
+    *slot = val;
+  }
   if(jv_is_borrowed(j)) return jv_unborrow(j);
   return j;
 }
@@ -1774,7 +1778,11 @@ jv jv_object_set(jv object, jv key, jv value) {
   // copy/free of object, key, value coalesced
   jv* slot = jvp_object_write(&object, key);
   jv_free(*slot);
-  *slot = value;
+  if(jv_is_borrowed(value)){
+    *slot = jv_unborrow(value);
+  }else{
+     *slot = value;
+  }
   if(jv_is_borrowed(object)) return jv_unborrow(object);
   return object;
 }

--- a/src/jv.c
+++ b/src/jv.c
@@ -114,10 +114,10 @@ const char* jv_kind_name(jv_kind k) {
   return "<unknown>";
 }
 
-const jv JV_NULL = {JVP_FLAGS_NULL, 0, 0, 0, {0}};
-const jv JV_INVALID = {JVP_FLAGS_INVALID, 0, 0, 0, {0}};
-const jv JV_FALSE = {JVP_FLAGS_FALSE, 0, 0, 0, {0}};
-const jv JV_TRUE = {JVP_FLAGS_TRUE, 0, 0, 0, {0}};
+const jv JV_NULL = {JVP_FLAGS_NULL, 0, 0, 0, 0, {0}};
+const jv JV_INVALID = {JVP_FLAGS_INVALID, 0, 0, 0, 0, {0}};
+const jv JV_FALSE = {JVP_FLAGS_FALSE, 0, 0, 0, 0, {0}};
+const jv JV_TRUE = {JVP_FLAGS_TRUE, 0, 0, 0, 0, {0}};
 
 jv jv_true() {
   return JV_TRUE;
@@ -151,7 +151,7 @@ jv jv_invalid_with_msg(jv err) {
   i->refcnt = JV_REFCNT_INIT;
   i->errmsg = err;
 
-  jv x = {JVP_FLAGS_INVALID_MSG, 0, 0, 0, {&i->refcnt}};
+  jv x = {JVP_FLAGS_INVALID_MSG, 0, 0, 0, 0, {&i->refcnt}};
   return x;
 }
 
@@ -590,7 +590,7 @@ static jv jvp_literal_number_new(const char * literal) {
     return JV_INVALID;
   }
 
-  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, JV_NUMBER_SIZE_INIT, {&n->refcnt}};
+  jv r = {JVP_FLAGS_NUMBER_LITERAL, 0, 0, 0, JV_NUMBER_SIZE_INIT, {&n->refcnt}};
   return r;
 }
 
@@ -674,7 +674,7 @@ jv jv_number(double x) {
 #else
     JV_KIND_NUMBER,
 #endif
-    0, 0, 0, {.number = x}
+    0, 0, 0, 0, {.number = x}
   };
   return j;
 }
@@ -806,7 +806,7 @@ static jvp_array* jvp_array_alloc(unsigned size) {
 }
 
 static jv jvp_array_new(unsigned size) {
-  jv r = {JVP_FLAGS_ARRAY, 0, 0, 0, {&jvp_array_alloc(size)->refcnt}};
+  jv r = {JVP_FLAGS_ARRAY, 0, 0, 0, 0, {&jvp_array_alloc(size)->refcnt}};
   return r;
 }
 
@@ -869,7 +869,7 @@ static jv* jvp_array_write(jv* a, int i) {
     }
     new_array->length = new_length;
     jvp_array_free(*a);
-    jv new_jv = {JVP_FLAGS_ARRAY, 0, 0, new_length, {&new_array->refcnt}};
+    jv new_jv = {JVP_FLAGS_ARRAY, 0, 0, 0, new_length, {&new_array->refcnt}};
     *a = new_jv;
     return &new_array->elements[i];
   }
@@ -1091,7 +1091,7 @@ static jv jvp_string_copy_replace_bad(const char* data, uint32_t length) {
   length = out - s->data;
   s->data[length] = 0;
   s->length_hashed = length << 1;
-  jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&s->refcnt}};
+  jv r = {JVP_FLAGS_STRING, 0, 0, 0, 0, {&s->refcnt}};
   return r;
 }
 
@@ -1102,7 +1102,7 @@ static jv jvp_string_new(const char* data, uint32_t length) {
   if (data != NULL)
     memcpy(s->data, data, length);
   s->data[length] = 0;
-  jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&s->refcnt}};
+  jv r = {JVP_FLAGS_STRING, 0, 0, 0, 0, {&s->refcnt}};
   return r;
 }
 
@@ -1110,7 +1110,7 @@ static jv jvp_string_empty_new(uint32_t length) {
   jvp_string* s = jvp_string_alloc(length);
   s->length_hashed = 0;
   memset(s->data, 0, length);
-  jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&s->refcnt}};
+  jv r = {JVP_FLAGS_STRING, 0, 0, 0, 0, {&s->refcnt}};
   return r;
 }
 
@@ -1153,7 +1153,7 @@ static jv jvp_string_append(jv string, const char* data, uint32_t len) {
     memcpy(news->data + currlen, data, len);
     news->data[currlen + len] = 0;
     jvp_string_free(string);
-    jv r = {JVP_FLAGS_STRING, 0, 0, 0, {&news->refcnt}};
+    jv r = {JVP_FLAGS_STRING, 0, 0, 0, 0, {&news->refcnt}};
     return r;
   }
 }
@@ -1521,7 +1521,7 @@ static jv jvp_object_new(int size) {
   for (int i=0; i<size*2; i++) {
     hashbuckets[i] = -1;
   }
-  jv r = {JVP_FLAGS_OBJECT, 0, 0, size, {&obj->refcnt}};
+  jv r = {JVP_FLAGS_OBJECT, 0, 0, 0, size, {&obj->refcnt}};
   return r;
 }
 
@@ -1862,14 +1862,14 @@ jv jv_object_iter_value(jv object, int iter) {
 /*
  * Memory management
  */
-jv jv_copy(jv j) {
-  if (JVP_IS_ALLOCATED(j)) {
+jv jv__copy(jv j) {
+  if (JVP_IS_ALLOCATED(j) && !j.borrowed) {
     jvp_refcnt_inc(j.u.ptr);
   }
   return j;
 }
 
-void jv_free(jv j) {
+void jv__free(jv j) {
   switch(JVP_KIND(j)) {
     case JV_KIND_ARRAY:
       jvp_array_free(j);

--- a/src/jv.c
+++ b/src/jv.c
@@ -1717,8 +1717,7 @@ static int jvp_object_equal(jv o1, jv o2) {
     if (jv_get_kind(slot->string) == JV_KIND_NULL) continue;
     jv* slot2 = jvp_object_read(o2, slot->string);
     if (!slot2) return 0;
-    // FIXME: do less refcounting here
-    if (!jv_equal(jv_copy(slot->value), jv_copy(*slot2))) return 0;
+    if (!jv_equal(jv_borrow(slot->value), jv_borrow(*slot2))) return 0;
     len1++;
   }
   return len1 == len2;

--- a/src/jv.c
+++ b/src/jv.c
@@ -1775,9 +1775,12 @@ int jv_object_has(jv object, jv key) {
   return res;
 }
 
-jv jv_object_set(jv object, jv key, jv value) {
-  assert(JVP_HAS_KIND(object, JV_KIND_OBJECT));
+jv jv_object_set(jv input, jv key, jv value) {
+  assert(JVP_HAS_KIND(input, JV_KIND_OBJECT));
   assert(JVP_HAS_KIND(key, JV_KIND_STRING));
+
+  jv object = jv_unborrow(input);
+  jv_free(input);
   // copy/free of object, key, value coalesced
   jv* slot = jvp_object_write(&object, key);
   jv_free(*slot);
@@ -1786,7 +1789,6 @@ jv jv_object_set(jv object, jv key, jv value) {
   }else{
      *slot = value;
   }
-  if(jv_is_borrowed(object)) return jv_unborrow(object);
   return object;
 }
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -867,7 +867,7 @@ static jv* jvp_array_write(jv* a, int i) {
     int j;
     for (j = 0; j < jvp_array_length(*a); j++) {
       new_array->elements[j] =
-        jv_unborrow(array->elements[j + jvp_array_offset(*a)]);
+        jv_copy(array->elements[j + jvp_array_offset(*a)]);
     }
     for (; j < new_length; j++) {
       new_array->elements[j] = JV_NULL;
@@ -989,6 +989,8 @@ jv jv_array_get(jv j, int idx) {
 
 jv jv_array_set(jv j, int idx, jv val) {
   assert(JVP_HAS_KIND(j, JV_KIND_ARRAY));
+
+  j = jv_return(j);
 
   if (idx < 0)
     idx = jvp_array_length(j) + idx;

--- a/src/jv.c
+++ b/src/jv.c
@@ -996,6 +996,7 @@ jv jv_array_set(jv j, int idx, jv val) {
   jv* slot = jvp_array_write(&j, idx);
   jv_free(*slot);
   *slot = val;
+  if(jv_is_borrowed(j)) return jv_unborrow(j);
   return j;
 }
 
@@ -1013,6 +1014,7 @@ jv jv_array_concat(jv a, jv b) {
     a = jv_array_append(a, elem);
   }
   jv_free(b);
+  if(jv_is_borrowed(a)) return jv_unborrow(a);
   return a;
 }
 

--- a/src/jv.c
+++ b/src/jv.c
@@ -1437,7 +1437,9 @@ jv jv_string_concat(jv a, jv b) {
   return a;
 }
 
-jv jv_string_append_buf(jv a, const char* buf, int len) {
+jv jv_string_append_buf(jv input, const char* buf, int len) {
+  jv a = jv_return(input);
+
   if (jvp_utf8_is_valid(buf, buf+len)) {
     a = jvp_string_append(a, buf, len);
   } else {
@@ -1447,7 +1449,9 @@ jv jv_string_append_buf(jv a, const char* buf, int len) {
   return a;
 }
 
-jv jv_string_append_codepoint(jv a, uint32_t c) {
+jv jv_string_append_codepoint(jv input, uint32_t c) {
+  jv a = jv_return(input);
+
   char buf[5];
   int len = jvp_utf8_encode(c, buf);
   a = jvp_string_append(a, buf, len);

--- a/src/jv.c
+++ b/src/jv.c
@@ -1775,6 +1775,7 @@ jv jv_object_set(jv object, jv key, jv value) {
   jv* slot = jvp_object_write(&object, key);
   jv_free(*slot);
   *slot = value;
+  if(jv_is_borrowed(object)) return jv_unborrow(object);
   return object;
 }
 
@@ -1783,6 +1784,7 @@ jv jv_object_delete(jv object, jv key) {
   assert(JVP_HAS_KIND(key, JV_KIND_STRING));
   jvp_object_delete(&object, key);
   jv_free(key);
+  if(jv_is_borrowed(object)) return jv_unborrow(object);
   return object;
 }
 

--- a/src/jv.h
+++ b/src/jv.h
@@ -60,6 +60,7 @@ static inline void jv_free(jv a){if(!a.borrowed) jv__free(a);}
 
 static inline jv jv_borrow(jv a){a.borrowed = 1; return a;}
 static inline jv jv_unborrow(jv a){a.borrowed = 0; return jv_copy(a);}
+static inline jv jv_return(jv a){if(a.borrowed) return jv_unborrow(a); return a;}
 
 int jv_get_refcnt(jv);
 

--- a/src/jv.h
+++ b/src/jv.h
@@ -33,7 +33,8 @@ struct jv_refcnt;
    Really. Do not play with them. */
 typedef struct {
   unsigned char kind_flags;
-  unsigned char pad_;
+  unsigned char pad_:7;
+  unsigned char borrowed:1;
   unsigned short offset;  /* array offsets */
   int size;
   union {
@@ -51,8 +52,13 @@ jv_kind jv_get_kind(jv);
 const char* jv_kind_name(jv_kind);
 static int jv_is_valid(jv x) { return jv_get_kind(x) != JV_KIND_INVALID; }
 
-jv jv_copy(jv);
-void jv_free(jv);
+void jv__free(jv);
+jv jv__copy(jv);
+
+static inline jv jv_copy(jv a){if(a.borrowed) return a; return jv__copy(a);}
+static inline void jv_free(jv a){if(!a.borrowed) jv__free(a);}
+
+static inline jv jv_borrow(jv a){a.borrowed = 1; return a;}
 
 int jv_get_refcnt(jv);
 
@@ -69,6 +75,8 @@ jv jv_null(void);
 jv jv_true(void);
 jv jv_false(void);
 jv jv_bool(int);
+
+static inline jv jv_is_borrowed(jv a){if(a.borrowed) return jv_true(); return jv_false();}
 
 jv jv_number(double);
 jv jv_number_with_literal(const char*);

--- a/src/jv.h
+++ b/src/jv.h
@@ -77,7 +77,7 @@ jv jv_true(void);
 jv jv_false(void);
 jv jv_bool(int);
 
-static inline jv jv_is_borrowed(jv a){if(a.borrowed) return jv_true(); return jv_false();}
+static inline int jv_is_borrowed(jv a){return a.borrowed;}
 
 jv jv_number(double);
 jv jv_number_with_literal(const char*);

--- a/src/jv.h
+++ b/src/jv.h
@@ -59,6 +59,7 @@ static inline jv jv_copy(jv a){if(a.borrowed) return a; return jv__copy(a);}
 static inline void jv_free(jv a){if(!a.borrowed) jv__free(a);}
 
 static inline jv jv_borrow(jv a){a.borrowed = 1; return a;}
+static inline jv jv_unborrow(jv a){a.borrowed = 0; return jv_copy(a);}
 
 int jv_get_refcnt(jv);
 

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -236,7 +236,6 @@ jv jv_set(jv t, jv k, jv v) {
     jv_free(v);
     t = err;
   }
-  if(jv_is_borrowed(t)) return jv_unborrow(t);
   return t;
 }
 

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -389,11 +389,13 @@ jv jv_setpath(jv root, jv path, jv value) {
   if (!jv_is_valid(root)){
     jv_free(value);
     jv_free(path);
+    if(jv_is_borrowed(root)) return jv_unborrow(root);
     return root;
   }
   if (jv_array_length(jv_copy(path)) == 0) {
     jv_free(path);
     jv_free(root);
+    if(jv_is_borrowed(value)) return jv_unborrow(value);
     return value;
   }
   jv pathcurr = jv_array_get(jv_copy(path), 0);

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -151,6 +151,8 @@ jv jv_get(jv t, jv k) {
     jv_free(t);
     jv_free(k);
   }
+
+  if(jv_is_borrowed(v)) return jv_unborrow(v);
   return v;
 }
 
@@ -158,6 +160,7 @@ jv jv_set(jv t, jv k, jv v) {
   if (!jv_is_valid(v)) {
     jv_free(t);
     jv_free(k);
+    if(jv_is_borrowed(v)) return jv_unborrow(v);
     return v;
   }
   int isnull = jv_get_kind(t) == JV_KIND_NULL;
@@ -233,6 +236,7 @@ jv jv_set(jv t, jv k, jv v) {
     jv_free(v);
     t = err;
   }
+  if(jv_is_borrowed(t)) return jv_unborrow(t);
   return t;
 }
 

--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -152,7 +152,6 @@ jv jv_get(jv t, jv k) {
     jv_free(k);
   }
 
-  if(jv_is_borrowed(v)) return jv_unborrow(v);
   return v;
 }
 
@@ -160,8 +159,7 @@ jv jv_set(jv t, jv k, jv v) {
   if (!jv_is_valid(v)) {
     jv_free(t);
     jv_free(k);
-    if(jv_is_borrowed(v)) return jv_unborrow(v);
-    return v;
+    return jv_return(v);
   }
   int isnull = jv_get_kind(t) == JV_KIND_NULL;
   if (jv_get_kind(k) == JV_KIND_STRING &&
@@ -388,14 +386,12 @@ jv jv_setpath(jv root, jv path, jv value) {
   if (!jv_is_valid(root)){
     jv_free(value);
     jv_free(path);
-    if(jv_is_borrowed(root)) return jv_unborrow(root);
-    return root;
+    return jv_return(root);
   }
   if (jv_array_length(jv_copy(path)) == 0) {
     jv_free(path);
     jv_free(root);
-    if(jv_is_borrowed(value)) return jv_unborrow(value);
-    return value;
+    return jv_return(value);
   }
   jv pathcurr = jv_array_get(jv_copy(path), 0);
   jv pathrest = jv_array_slice(path, 1, jv_array_length(jv_copy(path)));
@@ -440,11 +436,11 @@ jv jv_getpath(jv root, jv path) {
   }
   if (!jv_is_valid(root)) {
     jv_free(path);
-    return root;
+    return jv_return(root);
   }
   if (jv_array_length(jv_copy(path)) == 0) {
     jv_free(path);
-    return root;
+    return jv_return(root);
   }
   jv pathcurr = jv_array_get(jv_copy(path), 0);
   jv pathrest = jv_array_slice(path, 1, jv_array_length(jv_copy(path)));
@@ -496,7 +492,7 @@ static jv delpaths_sorted(jv object, jv paths, int start) {
     object = jv_dels(object, delkeys);
   else
     jv_free(delkeys);
-  return object;
+  return jv_return(object);
 }
 
 jv jv_delpaths(jv object, jv paths) {
@@ -520,7 +516,7 @@ jv jv_delpaths(jv object, jv paths) {
   if (jv_array_length(jv_copy(paths)) == 0) {
     // nothing is being deleted
     jv_free(paths);
-    return object;
+    return jv_return(object);
   }
   if (jv_array_length(jv_array_get(jv_copy(paths), 0)) == 0) {
     // everything is being deleted


### PR DESCRIPTION
This commit adds borrowing to the jv c-api

As discussed this adds a borrowed flag in the jv struct.

Adds the following functions
`jv jv_borrow(jv)`
`jv jv_is_borrowed(jv)`

Changes jv_copy() and jv_free() to return early if the jv is borrowed

still need to add documentation for the two functions