### PR TITLE
Add functions to work with filesystem paths: `expand_path` , `get_home`, `get_abspath`

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1149,6 +1149,28 @@ static jv f_env(jq_state *jq, jv input) {
   return env;
 }
 
+static jv f_expand_path(jq_state *jq, jv input) {
+    if (jv_get_kind(input) != JV_KIND_STRING) {
+        jv_free(input);
+        return type_error(input, "expand_path/1: string required");
+    }
+    return expand_path(input);
+}
+
+static jv f_get_home(jq_state *jq, jv input) {
+    jv_free(input);
+    return get_home();
+}
+
+static jv f_get_abspath(jq_state *jq, jv input) {
+    if (jv_get_kind(input) != JV_KIND_STRING) {
+        jv_free(input);
+        return type_error(input, "get_abspath/1: string required");
+    }
+    return jq_realpath(input);
+}
+
+
 static jv f_halt(jq_state *jq, jv input) {
   jv_free(input);
   jq_halt(jq, jv_invalid(), jv_invalid());
@@ -1738,6 +1760,9 @@ BINOPS
   {f_error, "error", 1},
   {f_format, "format", 2},
   {f_env, "env", 1},
+  {f_expand_path, "expand_path", 1},
+  {f_get_home, "get_home", 1},
+  {f_get_abspath, "jq_realpath", 1},
   {f_halt, "halt", 1},
   {f_halt_error, "halt_error", 2},
   {f_get_search_list, "get_search_list", 1},

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1151,8 +1151,7 @@ static jv f_env(jq_state *jq, jv input) {
 
 static jv f_expand_path(jq_state *jq, jv input) {
     if (jv_get_kind(input) != JV_KIND_STRING) {
-        jv_free(input);
-        return type_error(input, "expand_path/1: string required");
+        return type_error(input, "expand_path/0: string required");
     }
     return expand_path(input);
 }
@@ -1164,8 +1163,7 @@ static jv f_get_home(jq_state *jq, jv input) {
 
 static jv f_get_abspath(jq_state *jq, jv input) {
     if (jv_get_kind(input) != JV_KIND_STRING) {
-        jv_free(input);
-        return type_error(input, "get_abspath/1: string required");
+        return type_error(input, "get_abspath/0: string required");
     }
     return jq_realpath(input);
 }

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1762,7 +1762,7 @@ BINOPS
   {f_env, "env", 1},
   {f_expand_path, "expand_path", 1},
   {f_get_home, "get_home", 1},
-  {f_get_abspath, "jq_realpath", 1},
+  {f_get_abspath, "get_abspath", 1},
   {f_halt, "halt", 1},
   {f_halt_error, "halt_error", 2},
   {f_get_search_list, "get_search_list", 1},


### PR DESCRIPTION
This PR brings to the public interface three functions already available in `util.h`.
* `get_home`
* `get_abspath`
* `expand_path`

Along with the already available `env` function, they can make jq play more nicely with the filesystem.

Here's what they look like.

<img width="560" alt="image" src="https://github.com/jqlang/jq/assets/2118708/bc5bcd96-567b-40e4-8a62-53c0016eb1d9">
