### PR TITLE
Fix tests (valgrind warning) on aarch64/glibc 2.31

### DIFF
--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -74,7 +74,7 @@ static void test_err_cb(void *data, jv e) {
 }
 
 static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int take) {
-  char prog[4096];
+  char prog[4096] = {0};
   char buf[4096];
   struct err_data err_msg;
   int tests = 0, passed = 0, invalid = 0;


### PR DESCRIPTION
tests/mantest were failing on Raspberry Pi OS 11:

==10205== Conditional jump or move depends on uninitialised value(s)
==10205==    at 0x48806F8: checkfail (jq_test.c:58)
==10205==    by 0x48806F8: run_jq_tests (jq_test.c:99)
==10205==    by 0x4880FCB: jq_testsuite (jq_test.c:39)
==10205==    by 0x10B37F: main (main.c:576)
==10205==
==10205== Conditional jump or move depends on uninitialised value(s)
==10205==    at 0x4880714: checkfail (jq_test.c:58)
==10205==    by 0x4880714: run_jq_tests (jq_test.c:99)
==10205==    by 0x4880FCB: jq_testsuite (jq_test.c:39)
==10205==    by 0x10B37F: main (main.c:576)