### PR TITLE
Remove non-standard pow10 filter in favor of exp10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,7 +201,6 @@ AC_CHECK_MATH_FUNC(lgamma_r)
 AC_CHECK_MATH_FUNC(nearbyint)
 AC_CHECK_MATH_FUNC(nextafter)
 AC_CHECK_MATH_FUNC(nexttoward)
-AC_CHECK_MATH_FUNC(pow10) # Not available with glibc version >= 2.27
 AC_CHECK_MATH_FUNC(pow)
 AC_CHECK_MATH_FUNC(remainder)
 AC_CHECK_MATH_FUNC(rint)

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3197,7 +3197,7 @@ sections:
       One-input C math functions: `acos` `acosh` `asin` `asinh` `atan`
       `atanh` `cbrt` `ceil` `cos` `cosh` `erf` `erfc` `exp` `exp10`
       `exp2` `expm1` `fabs` `floor` `gamma` `j0` `j1` `lgamma` `log`
-      `log10` `log1p` `log2` `logb` `nearbyint` `pow10` `rint` `round`
+      `log10` `log1p` `log2` `logb` `nearbyint` `rint` `round`
       `significand` `sin` `sinh` `sqrt` `tan` `tanh` `tgamma` `trunc`
       `y0` `y1`.
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "February 2024" "" ""
+.TH "JQ" "1" "March 2024" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -3598,7 +3598,7 @@ Besides simple arithmetic operators such as \fB+\fR, jq also has most standard m
 Availability of standard math functions depends on the availability of the corresponding math functions in your operating system and C math library\. Unavailable math functions will be defined but will raise an error\.
 .
 .P
-One\-input C math functions: \fBacos\fR \fBacosh\fR \fBasin\fR \fBasinh\fR \fBatan\fR \fBatanh\fR \fBcbrt\fR \fBceil\fR \fBcos\fR \fBcosh\fR \fBerf\fR \fBerfc\fR \fBexp\fR \fBexp10\fR \fBexp2\fR \fBexpm1\fR \fBfabs\fR \fBfloor\fR \fBgamma\fR \fBj0\fR \fBj1\fR \fBlgamma\fR \fBlog\fR \fBlog10\fR \fBlog1p\fR \fBlog2\fR \fBlogb\fR \fBnearbyint\fR \fBpow10\fR \fBrint\fR \fBround\fR \fBsignificand\fR \fBsin\fR \fBsinh\fR \fBsqrt\fR \fBtan\fR \fBtanh\fR \fBtgamma\fR \fBtrunc\fR \fBy0\fR \fBy1\fR\.
+One\-input C math functions: \fBacos\fR \fBacosh\fR \fBasin\fR \fBasinh\fR \fBatan\fR \fBatanh\fR \fBcbrt\fR \fBceil\fR \fBcos\fR \fBcosh\fR \fBerf\fR \fBerfc\fR \fBexp\fR \fBexp10\fR \fBexp2\fR \fBexpm1\fR \fBfabs\fR \fBfloor\fR \fBgamma\fR \fBj0\fR \fBj1\fR \fBlgamma\fR \fBlog\fR \fBlog10\fR \fBlog1p\fR \fBlog2\fR \fBlogb\fR \fBnearbyint\fR \fBrint\fR \fBround\fR \fBsignificand\fR \fBsin\fR \fBsinh\fR \fBsqrt\fR \fBtan\fR \fBtanh\fR \fBtgamma\fR \fBtrunc\fR \fBy0\fR \fBy1\fR\.
 .
 .P
 Two\-input C math functions: \fBatan2\fR \fBcopysign\fR \fBdrem\fR \fBfdim\fR \fBfmax\fR \fBfmin\fR \fBfmod\fR \fBfrexp\fR \fBhypot\fR \fBjn\fR \fBldexp\fR \fBmodf\fR \fBnextafter\fR \fBnexttoward\fR \fBpow\fR \fBremainder\fR \fBscalb\fR \fBscalbln\fR \fByn\fR\.

--- a/src/libm.h
+++ b/src/libm.h
@@ -249,11 +249,6 @@ LIBM_DDD(nexttoward)
 #else
 LIBM_DDD_NO(nexttoward)
 #endif
-#if defined(HAVE_POW10) && !defined(WIN32)
-LIBM_DD(pow10)
-#else
-LIBM_DD_NO(pow10)
-#endif
 #ifdef HAVE_RINT
 LIBM_DD(rint)
 #else


### PR DESCRIPTION
The `pow10(3)` function is a non-standard glibc extension removed in 2.27. Listing in the manual often confuses users like  #2456, #2566. The `exp10(3)` function was a glibc extension too, but is standardized in TS 18661-4:2015 and expected to be available widely.