### PR TITLE
Make maximum depth configurable via CLI option

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -266,6 +266,13 @@ sections:
         available in the program and has a string whose contents are to the texts
         in the file named `bar`.
 
+      * `--depth n`:
+
+        This option sets the maximum parsing depth (of objects and arrays) to
+        `n`. Exceeding the parsing depth causes `jq` to exit early with an error.
+        If you set `n` to 0, the parser will go arbitrarily deep. The default
+        value is 256.
+
       * `--args`:
 
         Remaining arguments are positional string arguments.  These are

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -202,6 +202,12 @@ This option reads all the JSON texts in the named file and binds an array of the
 This option reads in the named file and binds its contents to the given global variable\. If you run jq with \fB\-\-rawfile foo bar\fR, then \fB$foo\fR is available in the program and has a string whose contents are to the texts in the file named \fBbar\fR\.
 .
 .TP
+\fB\-\-depth n\fR:
+.
+.IP
+This option sets the maximum parsing depth (of objects and arrays) to \fBn\fR\. Exceeding the parsing depth causes \fBjq\fR to exit early with an error\. If you set \fBn\fR to 0, the parser will go arbitrarily deep\. The default value is 256\.
+.
+.TP
 \fB\-\-args\fR:
 .
 .IP

--- a/src/execute.c
+++ b/src/execute.c
@@ -38,6 +38,7 @@ struct jq_state {
   int subexp_nest;
   int debug_trace_enabled;
   int initial_execution;
+  int parser_maxdepth;
   unsigned next_label;
 
   int halted;
@@ -1072,6 +1073,8 @@ jq_state *jq_init(void) {
   jq->exit_code = jv_invalid();
   jq->error_message = jv_invalid();
 
+  jq->parser_maxdepth = DEFAULT_MAX_PARSING_DEPTH;
+
   jq->input_cb = NULL;
   jq->input_cb_data = NULL;
 
@@ -1346,4 +1349,14 @@ jv jq_get_exit_code(jq_state *jq)
 jv jq_get_error_message(jq_state *jq)
 {
   return jv_copy(jq->error_message);
+}
+
+int jq_get_parser_maxdepth(jq_state *jq)
+{
+  return jq->parser_maxdepth;
+}
+
+void jq_set_parser_maxdepth(jq_state *jq, int parser_maxdepth)
+{
+  jq->parser_maxdepth = parser_maxdepth;
 }

--- a/src/jq.h
+++ b/src/jq.h
@@ -35,6 +35,9 @@ int jq_halted(jq_state *);
 jv jq_get_exit_code(jq_state *);
 jv jq_get_error_message(jq_state *);
 
+int jq_get_parser_maxdepth(jq_state *);
+void jq_set_parser_maxdepth(jq_state *, int);
+
 typedef jv (*jq_input_cb)(jq_state *, void *);
 void jq_set_input_cb(jq_state *, jq_input_cb, void *);
 void jq_get_input_cb(jq_state *, jq_input_cb *, void **);

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -354,7 +354,7 @@ static void *test_pthread_run(void *ptr) {
         return NULL;
     }
 
-    struct jv_parser *parser = jv_parser_new(0);
+    struct jv_parser *parser = jv_parser_new(0, jq_get_parser_maxdepth(jq));
     jv_parser_set_buf(parser, buf, strlen(buf), 0);
     rv = test_pthread_jq_parse(jq, parser);
 

--- a/src/jv.h
+++ b/src/jv.h
@@ -246,10 +246,13 @@ jv jv_parse_custom_flags(const char* string, int flags);
 typedef void (*jv_nomem_handler_f)(void *);
 void jv_nomem_handler(jv_nomem_handler_f, void *);
 
-jv jv_load_file(const char *, int);
+jv jv_load_file(const char *, int, int);
 
+#ifndef DEFAULT_MAX_PARSING_DEPTH
+#define DEFAULT_MAX_PARSING_DEPTH (256)
+#endif
 typedef struct jv_parser jv_parser;
-jv_parser* jv_parser_new(int);
+jv_parser* jv_parser_new(int, int);
 void jv_parser_set_buf(jv_parser*, const char*, int, int);
 int jv_parser_remaining(jv_parser*);
 jv jv_parser_next(jv_parser*);

--- a/src/jv_file.c
+++ b/src/jv_file.c
@@ -9,7 +9,7 @@
 #include "jv.h"
 #include "jv_unicode.h"
 
-jv jv_load_file(const char* filename, int raw) {
+jv jv_load_file(const char* filename, int raw, int maxdepth) {
   struct stat sb;
   int fd = open(filename, O_RDONLY);
   if (fd == -1) {
@@ -36,7 +36,7 @@ jv jv_load_file(const char* filename, int raw) {
     data = jv_string("");
   } else {
     data = jv_array();
-    parser = jv_parser_new(0);
+    parser = jv_parser_new(0, maxdepth);
   }
 
   // To avoid mangling UTF-8 multi-byte sequences that cross the end of our read

--- a/src/linker.c
+++ b/src/linker.c
@@ -334,9 +334,9 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
   block program;
   jv data;
   if (is_data && !raw)
-    data = jv_load_file(jv_string_value(lib_path), 0);
+    data = jv_load_file(jv_string_value(lib_path), 0, jq_get_parser_maxdepth(jq));
   else
-    data = jv_load_file(jv_string_value(lib_path), 1);
+    data = jv_load_file(jv_string_value(lib_path), 1, jq_get_parser_maxdepth(jq));
   int state_idx;
   if (!jv_is_valid(data)) {
     program = gen_noop();
@@ -386,7 +386,7 @@ jv load_module_meta(jq_state *jq, jv mod_relpath) {
   if (!jv_is_valid(lib_path))
     return lib_path;
   jv meta = jv_null();
-  jv data = jv_load_file(jv_string_value(lib_path), 1);
+  jv data = jv_load_file(jv_string_value(lib_path), 1, jq_get_parser_maxdepth(jq));
   if (jv_is_valid(data)) {
     block program;
     struct locfile* src = locfile_init(jq, jv_string_value(lib_path), jv_string_value(data), jv_string_length_bytes(jv_copy(data)));

--- a/src/main.c
+++ b/src/main.c
@@ -101,6 +101,7 @@ static void usage(int code, int keep_it_short) {
       "      --slurpfile name file set $name to an array of JSON values read\n"
       "                            from the file;\n"
       "      --rawfile name file   set $name to string contents of file;\n"
+      "      --depth n             set parser maxdepth to n (0 for unbounded);\n"
       "      --args                consume remaining arguments as positional\n"
       "                            string values;\n"
       "      --jsonargs            consume remaining arguments as positional\n"
@@ -296,6 +297,7 @@ int main(int argc, char* argv[]) {
   int ret = JQ_OK_NO_OUTPUT;
   int compiled = 0;
   int parser_flags = 0;
+  int parser_maxdepth = DEFAULT_MAX_PARSING_DEPTH;
   int nfiles = 0;
   int last_result = -1; /* -1 = no result, 0=null or false, 1=true */
   int badwrite;
@@ -441,6 +443,18 @@ int main(int argc, char* argv[]) {
           i++;
         } else if (isoption(&text, 0, "seq", is_short)) {
           options |= SEQ;
+        } else if (isoption(&text, 0, "depth", is_short)) {
+          if (i >= argc - 1) {
+            fprintf(stderr, "%s: --depth takes one parameter\n", progname);
+            die();
+          }
+          int depth = atoi(argv[i+1]);
+          if (depth < 0) {
+            fprintf(stderr, "%s: --depth takes a non-negative number\n", progname);
+            die();
+          }
+          parser_maxdepth = depth;
+          i++;
         } else if (isoption(&text, 0, "stream", is_short)) {
           parser_flags |= JV_PARSE_STREAMING;
         } else if (isoption(&text, 0, "stream-errors", is_short)) {
@@ -483,7 +497,7 @@ int main(int argc, char* argv[]) {
             die();
           }
           if (!jv_object_has(jv_copy(program_arguments), jv_string(argv[i+1]))) {
-            jv data = jv_load_file(argv[i+2], raw);
+            jv data = jv_load_file(argv[i+2], raw, parser_maxdepth);
             if (!jv_is_valid(data)) {
               data = jv_invalid_get_msg(data);
               fprintf(stderr, "%s: Bad JSON in --%s %s %s: %s\n", progname, which,
@@ -591,6 +605,8 @@ int main(int argc, char* argv[]) {
 
   if (!program) usage(2, 1);
 
+  jq_set_parser_maxdepth(jq, parser_maxdepth);
+
   if (options & FROM_FILE) {
     char *program_origin = strdup(program);
     if (program_origin == NULL) {
@@ -598,7 +614,7 @@ int main(int argc, char* argv[]) {
       exit(2);
     }
 
-    jv data = jv_load_file(program, 1);
+    jv data = jv_load_file(program, 1, parser_maxdepth);
     if (!jv_is_valid(data)) {
       data = jv_invalid_get_msg(data);
       fprintf(stderr, "%s: %s\n", progname, jv_string_value(data));
@@ -644,7 +660,7 @@ int main(int argc, char* argv[]) {
   if ((options & RAW_INPUT))
     jq_util_input_set_parser(input_state, NULL, (options & SLURP) ? 1 : 0);
   else
-    jq_util_input_set_parser(input_state, jv_parser_new(parser_flags), (options & SLURP) ? 1 : 0);
+    jq_util_input_set_parser(input_state, jv_parser_new(parser_flags, parser_maxdepth), (options & SLURP) ? 1 : 0);
 
   // Let jq program read from inputs
   jq_set_input_cb(jq, jq_util_input_next_input_cb, input_state);

--- a/tests/shtest
+++ b/tests/shtest
@@ -725,4 +725,28 @@ $VALGRIND $Q $JQ . <<\NUM
 -10E-1000000001
 NUM
 
+# --depth flag
+echo '[["doubly nested"]]' >$d/depth2.json
+
+s='"inner"'
+i=0
+while [ "$i" -lt 257 ]; do
+  s="[$s]"
+  i=$((i + 1))
+done
+echo "$s" >$d/depth257.json
+
+$JQ -- '.' $d/depth2.json # should work
+if $JQ --depth 1 -- '.' $d/depth2.json; then
+  echo "setting --depth 1 did not crash when given deep input"
+  exit 1
+fi
+
+if $JQ -- '.' $d/depth257.json; then
+  echo "default depth of 256 did not crash when given deep input"
+  exit 1
+fi
+$JQ --depth 257 -- '.' $d/depth257.json # should work
+$JQ --depth 0 -- '.' $d/depth257.json # should work
+
 exit 0


### PR DESCRIPTION
Addresses #2846. (I didn't see any contributor guidelines/linting info... please let me know if you'd like me to change anything!)

This PR adds state to two places to track maximum parser depth: in `jq_state` and in `jv_parser`.

It might seem like `jv_parser` is enough on its own, but many other parts of the code parser values holding only a `jq_state`. It's not clear to me that these aren't mostly/entirely raw parses (which wouldn't need to track depth), but it seemed easiest to track the state thoroughly.

There are a few helper functions at the end of `jv_parse.c` that have no handle at all---neither a `jq_state` nor a `jv_parser`. I had these just use the `DEFAULT_MAX_PARSING_DEPTH`. They are _mostly_ for fuzzing, it seems, but `jv_parse` gets called in `main` during option processing. It wouldn't be hard to have this use the current `parser_maxdepth`.