### PR TITLE
Use codepoint index for indices/1, index/1 and rindex/1

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -1274,15 +1274,21 @@ jv jv_string_indexes(jv j, jv k) {
   assert(JVP_HAS_KIND(k, JV_KIND_STRING));
   const char *jstr = jv_string_value(j);
   const char *idxstr = jv_string_value(k);
-  const char *p;
+  const char *p, *lp;
   int jlen = jv_string_length_bytes(jv_copy(j));
   int idxlen = jv_string_length_bytes(jv_copy(k));
   jv a = jv_array();
 
   if (idxlen != 0) {
-    p = jstr;
+    int n = 0;
+    p = lp = jstr;
     while ((p = _jq_memmem(p, (jstr + jlen) - p, idxstr, idxlen)) != NULL) {
-      a = jv_array_append(a, jv_number(p - jstr));
+      while (lp < p) {
+        lp += jvp_utf8_decode_length(*lp);
+        n++;
+      }
+
+      a = jv_array_append(a, jv_number(n));
       p++;
     }
   }

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1345,6 +1345,22 @@ indices(", ")
 "a,b, cd,e, fgh, ijkl"
 [3,9,14]
 
+index("!")
+"здравствуй мир!"
+14
+
+.[:rindex("x")]
+"正xyz"
+"正"
+
+indices("o")
+"🇬🇧oo"
+[2,3]
+
+indices("o")
+"ƒoo"
+[1,2]
+
 [.[]|split(",")]
 ["a, bc, def, ghij, jklmn, a,b, c,d, e,f", "a,b,c,d, e,f,g,h"]
 [["a"," bc"," def"," ghij"," jklmn"," a","b"," c","d"," e","f"],["a","b","c","d"," e","f","g","h"]]


### PR DESCRIPTION
Previsouly byte index was used.

Fixes #1430, fixes #1624, fixes #3064.