### PR TITLE
strftime/1: fix validation of non-string argument with number input

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1599,9 +1599,9 @@ static jv f_strftime(jq_state *jq, jv a, jv b) {
     }
   } else if (jv_get_kind(a) != JV_KIND_ARRAY) {
     return ret_error2(a, b, jv_string("strftime/1 requires parsed datetime inputs"));
-  } else if (jv_get_kind(b) != JV_KIND_STRING) {
-    return ret_error2(a, b, jv_string("strftime/1 requires a string format"));
   }
+  if (jv_get_kind(b) != JV_KIND_STRING)
+    return ret_error2(a, b, jv_string("strftime/1 requires a string format"));
   struct tm tm;
   if (!jv2tm(a, &tm))
     return ret_error(b, jv_string("strftime/1 requires parsed datetime inputs"));
@@ -1630,9 +1630,9 @@ static jv f_strflocaltime(jq_state *jq, jv a, jv b) {
     a = f_localtime(jq, a);
   } else if (jv_get_kind(a) != JV_KIND_ARRAY) {
     return ret_error2(a, b, jv_string("strflocaltime/1 requires parsed datetime inputs"));
-  } else if (jv_get_kind(b) != JV_KIND_STRING) {
-    return ret_error2(a, b, jv_string("strflocaltime/1 requires a string format"));
   }
+  if (jv_get_kind(b) != JV_KIND_STRING)
+    return ret_error2(a, b, jv_string("strflocaltime/1 requires a string format"));
   struct tm tm;
   if (!jv2tm(a, &tm))
     return ret_error(b, jv_string("strflocaltime/1 requires parsed datetime inputs"));

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1580,6 +1580,15 @@ try mktime catch .
 ["a",1,2,3,4,5,6,7]
 "mktime requires parsed datetime inputs"
 
+# oss-fuzz #67403: non-string argument with number input fails assert
+try ["OK", strftime([])] catch ["KO", .]
+0
+["KO","strftime/1 requires a string format"]
+
+try ["OK", strflocaltime({})] catch ["KO", .]
+0
+["KO","strflocaltime/1 requires a string format"]
+
 # module system
 import "a" as foo; import "b" as bar; def fooa: foo::a; [fooa, bar::a, bar::b, foo::a]
 null


### PR DESCRIPTION
There was a incorrect `else`, that caused jq to not ensure that the argument to `strftime/1` is a string when the input is a number; this ends up calling `jv_string_value` on a non-string value, which does not work, and causes an assert failure.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67403
