### PR TITLE
EACH: fix leak when an error is triggered by non-last element of object

### DIFF
--- a/src/execute.c
+++ b/src/execute.c
@@ -781,8 +781,10 @@ jv jq_next(jq_state *jq) {
       }
 
       if (!keep_going || raising) {
-        if (keep_going)
+        if (keep_going) {
+          jv_free(key);
           jv_free(value);
+        }
         jv_free(container);
         goto do_backtrack;
       } else if (is_last) {

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -178,6 +178,11 @@ map(try .a[] catch ., try .a.[] catch ., .a[]?, .a.[]?)
 [{"a": [1,2]}, {"a": 123}]
 [1,2,1,2,1,2,1,2,"Cannot iterate over number (123)","Cannot iterate over number (123)"]
 
+# oss-fuzz #66070: objects[] leaks if a non-last element throws an error
+try ["OK", (.[] | error)] catch ["KO", .]
+{"a":["b"],"c":["d"]}
+["KO",["b"]]
+
 #
 # Negative array indices
 #


### PR DESCRIPTION
Object keys are strings, so they need to be freed.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66070
