### PR TITLE
util.c: update strptime to revision 1.66

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -824,8 +824,7 @@ recurse:
 #else
             const time_t TIME_MAX = INT64_MAX;
 #endif
-            time_t sse;
-            time_t d;
+            time_t sse, d;
 
             if (*bp < '0' || *bp > '9') {
                 bp = NULL;


### PR DESCRIPTION
As I merged #3071, my fix was upstreamed written in a slightly different way.
Oops! :D
