### PR TITLE
declare static arrays const where possible

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1463,7 +1463,7 @@ static jv f_strptime(jq_state *jq, jv a, jv b) {
 
 static int jv2tm(jv a, struct tm *tm) {
   memset(tm, 0, sizeof(*tm));
-  static size_t offsets[] = {
+  static const size_t offsets[] = {
     offsetof(struct tm, tm_year),
     offsetof(struct tm, tm_mon),
     offsetof(struct tm, tm_mday),

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -29,12 +29,12 @@
 // the last color is used for object keys.
 static char color_bufs[8][16];
 static const char *color_bufps[8];
-static const char* def_colors[] =
+static const char *const def_colors[] =
   {COL("0;90"),    COL("0;39"),      COL("0;39"),     COL("0;39"),
    COL("0;32"),    COL("1;39"),      COL("1;39"),     COL("1;34")};
 #define FIELD_COLOR (colors[7])
 
-static const char **colors = def_colors;
+static const char *const *colors = def_colors;
 
 int
 jq_set_colors(const char *c)

--- a/src/util.c
+++ b/src/util.c
@@ -533,32 +533,32 @@ static const unsigned char *find_string(const unsigned char *, int *, const char
 static char* utc = "UTC";
 #endif
 /* RFC-822/RFC-2822 */
-static const char* const nast[] = {
+static const char *const nast[] = {
        "EST",    "CST",    "MST",    "PST",    "\0\0\0"
 };
-static const char* const nadt[] = {
+static const char *const nadt[] = {
        "EDT",    "CDT",    "MDT",    "PDT",    "\0\0\0"
 };
-static const char* weekday_name[] =
+static const char *const weekday_name[] =
 {
     "Sunday", "Monday", "Tuesday", "Wednesday",
     "Thursday", "Friday", "Saturday"
 };
-static const char* ab_weekday_name[] =
+static const char *const ab_weekday_name[] =
 {
     "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
 };
-static const char* month_name[] =
+static const char *const month_name[] =
 {
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
 };
-static const char* ab_month_name[] =
+static const char *const ab_month_name[] =
 {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };
-static const char* am_pm[] = {"AM", "PM"};
+static const char *const am_pm[] = {"AM", "PM"};
 
 
 /*


### PR DESCRIPTION
Some static arrays that could be readonly memory were declared mutable.
