### PR TITLE
@base64d: fix unhandled overflow

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -715,7 +715,7 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
     input = f_tostring(jq, input);
     const unsigned char* data = (const unsigned char*)jv_string_value(input);
     int len = jv_string_length_bytes(jv_copy(input));
-    size_t decoded_len = (3 * len) / 4; // 3 usable bytes for every 4 bytes of input
+    size_t decoded_len = (3 * (size_t)len) / 4; // 3 usable bytes for every 4 bytes of input
     char *result = jv_mem_calloc(decoded_len, sizeof(char));
     memset(result, 0, decoded_len * sizeof(char));
     uint32_t ri = 0;


### PR DESCRIPTION
I replaced `(3*l)/4` with `3*(l/4)` to prevent overflows:

```console
$ ./jq-before -n '238609295*"|||"|@base64d|"."'
src/builtin.c:718:29: runtime error: signed integer overflow: 715827885 * 3 cannot be represented in type 'int'
jq: error: cannot allocate memory
Aborted (core dumped)
```

```console
$ ./jq-after -n '238609295*"|||"|@base64d|"."'
jq: error (at <unknown>): string ("||||||||||...) is not valid base64 data
```

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67640

---

I didn't add a test for this, because this takes ages to run on my laptop even if I use something like
```sh
</dev/zero tr \\0 \| | head -c715827883 | ./jq -R '@base64d|"."
```
to generate the input string, and even without `valgrind`.
