### PR TITLE
jv_setpath: fix leak when indexing an array with an array

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -417,6 +417,7 @@ jv jv_setpath(jv root, jv path, jv value) {
   // to null first.
   root = jv_set(root, jv_copy(pathcurr), jv_null());
   if (!jv_is_valid(root)) {
+    jv_free(subroot);
     jv_free(pathcurr);
     jv_free(pathrest);
     jv_free(value);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2169,3 +2169,10 @@ try ltrimstr("x") catch "x", try rtrimstr("x") catch "x" | "ok"
 ["ko","endswith() requires string inputs"]
 ["ok",""]
 ["ko","endswith() requires string inputs"]
+
+
+# oss-fuzz #66061: setpath/2 leaks when indexing array with array
+
+try ["OK", setpath([[1]]; 1)] catch ["KO", .]
+[]
+["KO","Cannot update field at array index of array"]


### PR DESCRIPTION
`arrays[arrays]` is a special case of "INDEX" that actually returns an
array containing the indices in which the array that is being indexed
contains the start of the key array.

So array keys, for array values, are a kind of key that can be "got",
but not "set". `jv_setpath()` was not freeing the value it "got" from
indexing that key, in case the following "set" on that key failed,
resulting in a leak.

    $ ./jq -n '[] | setpath([[1]]; 1)'
    jq: error (at <unknown>): Cannot update field at array index of array

    =================================================================
    ==953483==ERROR: LeakSanitizer: detected memory leaks

    Direct leak of 272 byte(s) in 1 object(s) allocated from:
        #0 0x725f4d4e1359 in __interceptor_malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
        #1 0x5ec17b1a7438 in jv_mem_alloc src/jv_alloc.c:141

    SUMMARY: AddressSanitizer: 272 byte(s) leaked in 1 allocation(s).

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66061

---

This one was hard to figure out because oss-fuzz really didn't do a
great job minimising the reproducer, and the stacktrace was not very
helpful.
After figuring out the leak was in `jv_setpath()`, and it had something
to do with using an array key, I had to keep track of copies/frees in
`jv_setpath()` on a piece of paper while stepping the code with gdb to
find the leak! :^)
