### PR TITLE
Update jq_fuzz_load_file.c: Add missing include unistd.h

### DIFF
--- a/tests/jq_fuzz_load_file.c
+++ b/tests/jq_fuzz_load_file.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "jv.h"
 


### PR DESCRIPTION
This is needed for clang-18:

```
tests/jq_fuzz_load_file.c:9:42: error: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    9 |   sprintf(filename, "/tmp/libfuzzer.%d", getpid());
      |                                          ^
tests/jq_fuzz_load_file.c:24:3: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   24 |   unlink(filename);
      |   ^
2 errors generated.
ERROR:__main__:Building fuzzers failed.
