### PR TITLE
Modified _modify method to not hold | onto reference

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -18,6 +18,7 @@ def _modify(paths; update):
       | null
       | label $out
       | ($dot[0] | getpath($p)) as $v
+      | setpath([0] + $p; null)
       | (
           (   $$$$v
             | update


### PR DESCRIPTION
- Fixes #2706 
- Updated _modify method so use set path before updating