### PR TITLE
Add `--sandbox` flag to prevent dynamic loading of other files/data.

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -297,6 +297,11 @@ sections:
         operations that would allow the filter code to access data other
         than the input data that is explicitly specified in the invocation.
 
+        This flag also hides all environment variables from the enviroment
+        where jq was run by setting `$ENV` and `env` to be an empty object.
+        If you need to pass named arguments to a sandboxed jq filter, use the
+        `--arg` and/or `--argjson` options to pass them explicitly.
+
       * `--binary` / `-b`:
 
         Windows users using WSL, MSYS2, or Cygwin, should use this option
@@ -2018,6 +2023,9 @@ sections:
           set when the jq program started.
 
           `env` outputs an object representing jq's current environment.
+
+          `$ENV` and `env` will be an empty object if jq was run with the
+          `--sandbox` flag.
 
           At the moment there is no builtin for setting environment
           variables.

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -291,6 +291,12 @@ sections:
         Another way to set the exit status is with the `halt_error`
         builtin function.
 
+      * `--sandbox`:
+
+        Prevent the use of modules (`import`/`include`) or any other file
+        operations that would allow the filter code to access data other
+        than the input data that is explicitly specified in the invocation.
+
       * `--binary` / `-b`:
 
         Windows users using WSL, MSYS2, or Cygwin, should use this option

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "March 2024" "" ""
+.TH "JQ" "1" "April 2024" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -221,6 +221,12 @@ Sets the exit status of jq to 0 if the last output value was neither \fBfalse\fR
 .
 .IP
 Another way to set the exit status is with the \fBhalt_error\fR builtin function\.
+.
+.TP
+\fB\-\-sandbox\fR:
+.
+.IP
+Prevent the use of modules (\fBimport\fR/\fBinclude\fR) or any other file operations that would allow the filter code to access data other than the input data that is explicitly specified in the invocation\.
 .
 .TP
 \fB\-\-binary\fR / \fB\-b\fR:

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -228,6 +228,9 @@ Another way to set the exit status is with the \fBhalt_error\fR builtin function
 .IP
 Prevent the use of modules (\fBimport\fR/\fBinclude\fR) or any other file operations that would allow the filter code to access data other than the input data that is explicitly specified in the invocation\.
 .
+.IP
+This flag also hides all environment variables from the enviroment where jq was run by setting \fB$ENV\fR and \fBenv\fR to be an empty object\. If you need to pass named arguments to a sandboxed jq filter, use the \fB\-\-arg\fR and/or \fB\-\-argjson\fR options to pass them explicitly\.
+.
 .TP
 \fB\-\-binary\fR / \fB\-b\fR:
 .
@@ -2193,6 +2196,9 @@ Note that this can be overriden in the command\-line with \fB\-\-arg\fR and rela
 .
 .P
 \fBenv\fR outputs an object representing jq\'s current environment\.
+.
+.P
+\fB$ENV\fR and \fBenv\fR will be an empty object if jq was run with the \fB\-\-sandbox\fR flag\.
 .
 .P
 At the moment there is no builtin for setting environment variables\.

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1137,6 +1137,11 @@ extern char **environ;
 static jv f_env(jq_state *jq, jv input) {
   jv_free(input);
   jv env = jv_object();
+
+  // A sandboxed filter doesn't have access to environment variables,
+  // so in such a case we return the empty object without using environ.
+  if (jq_is_sandbox(jq)) return env;
+
   const char *var, *val;
   for (char **e = environ; *e != NULL; e++) {
     var = e[0];

--- a/src/compile.h
+++ b/src/compile.h
@@ -79,7 +79,7 @@ block block_drop_unreferenced(block body);
 jv block_take_imports(block* body);
 jv block_list_funcs(block body, int omit_underscores);
 
-int block_compile(block, struct bytecode**, struct locfile*, jv);
+int block_compile(block, struct bytecode**, struct locfile*, jv, int is_sandbox);
 
 void block_free(block);
 

--- a/src/execute.c
+++ b/src/execute.c
@@ -41,6 +41,7 @@ struct jq_state {
   unsigned next_label;
 
   int halted;
+  int sandbox;
   jv exit_code;
   jv error_message;
 
@@ -1066,6 +1067,7 @@ jq_state *jq_init(void) {
   jq->curr_frame = 0;
   jq->error = jv_null();
 
+  jq->sandbox = 0;
   jq->halted = 0;
   jq->exit_code = jv_invalid();
   jq->error_message = jv_invalid();
@@ -1319,6 +1321,14 @@ void jq_set_stderr_cb(jq_state *jq, jq_msg_cb cb, void *data) {
 void jq_get_stderr_cb(jq_state *jq, jq_msg_cb *cb, void **data) {
   *cb = jq->stderr_cb;
   *data = jq->stderr_cb_data;
+}
+
+void jq_set_sandbox(jq_state *jq) {
+  jq->sandbox = 1;
+}
+
+int jq_is_sandbox(jq_state *jq) {
+  return jq->sandbox;
 }
 
 void

--- a/src/execute.c
+++ b/src/execute.c
@@ -1246,7 +1246,7 @@ int jq_compile_args(jq_state *jq, const char* str, jv args) {
   if (nerrors == 0) {
     nerrors = builtins_bind(jq, &program);
     if (nerrors == 0) {
-      nerrors = block_compile(program, &jq->bc, locations, args2obj(args));
+      nerrors = block_compile(program, &jq->bc, locations, args2obj(args), jq_is_sandbox(jq));
     }
   } else
     jv_free(args);

--- a/src/jq.h
+++ b/src/jq.h
@@ -30,6 +30,8 @@ void jq_start(jq_state *, jv value, int);
 jv jq_next(jq_state *);
 void jq_teardown(jq_state **);
 
+void jq_set_sandbox(jq_state *);
+int jq_is_sandbox(jq_state *);
 void jq_halt(jq_state *, jv, jv);
 int jq_halted(jq_state *);
 jv jq_get_exit_code(jq_state *);

--- a/src/main.c
+++ b/src/main.c
@@ -106,6 +106,7 @@ static void usage(int code, int keep_it_short) {
       "      --jsonargs            consume remaining arguments as positional\n"
       "                            JSON values;\n"
       "  -e, --exit-status         set exit status code based on the output;\n"
+      "      --sandbox             prevent dynamic access to other files/data;\n"
 #ifdef WIN32
       "  -b, --binary              open input/output streams in binary mode;\n"
 #endif
@@ -473,6 +474,10 @@ int main(int argc, char* argv[]) {
       }
       if (isoption(argv[i], 0, "stream-errors", &short_opts)) {
         parser_flags |= JV_PARSE_STREAMING | JV_PARSE_STREAM_ERRORS;
+        continue;
+      }
+      if (isoption(argv[i], 0, "sandbox", &short_opts)) {
+        jq_set_sandbox(jq);
         continue;
       }
       if (isoption(argv[i], 'e', "exit-status", &short_opts)) {

--- a/tests/shtest
+++ b/tests/shtest
@@ -396,6 +396,28 @@ if $VALGRIND $Q $JQ -L ./tests/modules --sandbox -n 'import "a" as a; empty'; th
     exit 1
 fi
 
+## Test environment variable access
+
+if [ "$(FOO=foo $VALGRIND $Q $JQ -nr '$ENV.FOO')" != foo ]; then
+    echo "couldn't read an environment variable via \$ENV" 1>&2
+    exit 1
+fi
+
+if [ "$(FOO=foo $VALGRIND $Q $JQ --sandbox -nr '$ENV.FOO')" != null ]; then
+    echo "\$ENV should have been empty due to the sandbox flag" 1>&2
+    exit 1
+fi
+
+if [ "$(FOO=foo $VALGRIND $Q $JQ -nr 'env.FOO')" != foo ]; then
+    echo "couldn't read an environment variable via env" 1>&2
+    exit 1
+fi
+
+if [ "$(FOO=foo $VALGRIND $Q $JQ --sandbox -nr 'env.FOO')" != null ]; then
+    echo "env should have been empty due to the sandbox flag" 1>&2
+    exit 1
+fi
+
 ## Halt
 
 if ! $VALGRIND $Q $JQ -n halt; then

--- a/tests/shtest
+++ b/tests/shtest
@@ -381,6 +381,21 @@ if ! $VALGRIND $Q $JQ -L tests/modules -ne 'import "test_bind_order" as check; c
     exit 1
 fi
 
+if HOME="$mods/home1" $VALGRIND $Q $JQ --sandbox -nr fg; then
+    echo "home module was loaded when it should have been prevented by sandbox flag" 1>&2
+    exit 1
+fi
+
+if HOME="$mods/home2" $VALGRIND $Q $JQ --sandbox -n 'include "g"; empty'; then
+    echo "module was included when it should have been prevented by sandbox flag" 1>&2
+    exit 1
+fi
+
+if $VALGRIND $Q $JQ -L ./tests/modules --sandbox -n 'import "a" as a; empty'; then
+    echo "module was imported when it should have been prevented by sandbox flag" 1>&2
+    exit 1
+fi
+
 ## Halt
 
 if ! $VALGRIND $Q $JQ -n halt; then


### PR DESCRIPTION
Some use cases for `jq` may involve accepting untrusted input. See discussion in #1361 for some security considerations that may be relevant for those use cases.

This commit adds a `--sandbox` flag which is meant to mitigate one category of security issue with untrusted input: features of jq which are meant to let the jq filter access files/data other than the direct input data given to the CLI.

Specifically, the new `--sandbox` flag blocks the implicit loading of `$HOME/.jq`, and also blocks the use of `import` and `include` for loading other `jq` files.

If other features are added to `jq` in the future which allow for reading files/data as part of the filter syntax, it is intended that the `--sandbox` flag would also gate access to those.