### PR TITLE
Add `strptime` fallback not only for Windows

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -59,7 +59,7 @@ const void *_jq_memmem(const void *haystack, size_t haystacklen,
 
 #include <time.h>
 
-#if defined(WIN32) && !defined(HAVE_STRPTIME)
+#ifndef HAVE_STRPTIME
 char* strptime(const char *buf, const char *fmt, struct tm *tm);
 #endif
 


### PR DESCRIPTION
SerenityOS is missing `strptime` and currently uses a [patch](https://github.com/SerenityOS/serenity/blob/master/Ports/jq/patches/0002-Fallback-to-bundled-strptime-implementation.patch) to enable the fallback in 1.7.1. #3008 removed the WIN32 check in `util.c` but not in `util.h`.

This changes the check in `util.h` as well. With this SerenityOS can drop its [patch](https://github.com/SerenityOS/serenity/blob/master/Ports/jq/patches/0002-Fallback-to-bundled-strptime-implementation.patch) in the next `jq` release.

