### PR TITLE
main.c: remove a FIXME

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -479,7 +479,6 @@ int main(int argc, char* argv[]) {
         options |= EXIT_STATUS;
         if (!short_opts) continue;
       }
-      // FIXME: For --arg* we should check that the varname is acceptable
       if (isoption(argv[i], 0, "args", &short_opts)) {
         further_args_are_strings = 1;
         further_args_are_json = 0;


### PR DESCRIPTION
Using an "invalid" variable name is fine, it just means you will only be
able to access that argument from $ARGS.named
