### PR TITLE
return version even if not using git sources

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -2,12 +2,17 @@
 set -eu
 
 cd "$(dirname "$0")/../"
-test -d .git || exit 1
 
-if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
-  git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+if test -d .git; then
+  if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
+    git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'
+  else
+    branch=$(git rev-parse --abbrev-ref HEAD)
+    commit=$(git describe --always --dirty)
+    echo "${branch}-${commit}"
+  fi
+elif [[ "$(basename $(pwd))" =~ ^jq-jq-([0-9]+\.[0-9]+(\.[0-9]+)?)$ ]]; then
+  echo ${BASH_REMATCH[1]}
 else
-  branch=$(git rev-parse --abbrev-ref HEAD)
-  commit=$(git describe --always --dirty)
-  echo "${branch}-${commit}"
+  exit 1
 fi

--- a/scripts/version
+++ b/scripts/version
@@ -11,8 +11,8 @@ if test -d .git; then
     commit=$(git describe --always --dirty)
     echo "${branch}-${commit}"
   fi
-elif [[ "$(basename $(pwd))" =~ ^jq-jq-([0-9]+\.[0-9]+(\.[0-9]+)?)$ ]]; then
-  echo ${BASH_REMATCH[1]}
+elif [[ "$(basename $(pwd))" =~ ^jq-(jq-)?([0-9]+\.[0-9]+(\.[0-9]+)?)$ ]]; then
+  echo ${BASH_REMATCH[2]}
 else
   exit 1
 fi


### PR DESCRIPTION
Downloading the source tarball from GitHub lacks .git structure and the version will be blank.  This fixes it by using the directory name which contains the version.

This is currently impacting Fedora packaging, and potentially other distros if they use GitHub source tarballs.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2277743