### PR TITLE
source ~/.jq file on windows (fixes #3104)

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3691,7 +3691,8 @@ sections:
       For example, with `-L$HOME/.jq` a module `foo` can be found in
       `$HOME/.jq/foo.jq` and `$HOME/.jq/foo/foo.jq`.
 
-      If `$HOME/.jq` is a file, it is sourced into the main program.
+      If `.jq` exists in the user's home directory, and is a file (not a
+      directory), it is automatically sourced into the main program.
 
     entries:
       - title: "`import RelativePathString as NAME [<metadata>];`"

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -4109,7 +4109,7 @@ Consecutive components with the same name are not allowed to avoid ambiguities (
 For example, with \fB\-L$HOME/\.jq\fR a module \fBfoo\fR can be found in \fB$HOME/\.jq/foo\.jq\fR and \fB$HOME/\.jq/foo/foo\.jq\fR\.
 .
 .P
-If \fB$HOME/\.jq\fR is a file, it is sourced into the main program\.
+If \fB\.jq\fR exists in the user\'s home directory, and is a file (not a directory), it is automatically sourced into the main program\.
 .
 .SS "import RelativePathString as NAME [<metadata>];"
 Imports a module found at the given path relative to a directory in a search path\. A \fB\.jq\fR suffix will be added to the relative path string\. The module\'s symbols are prefixed with \fBNAME::\fR\.

--- a/tests/shtest
+++ b/tests/shtest
@@ -359,6 +359,17 @@ if [ "$(HOME="$mods/home1" $VALGRIND $Q $JQ -nr fg)" != foobar ]; then
     exit 1
 fi
 
+if $msys || $mingw; then
+    HOME_BAK=$HOME
+    unset HOME
+    if [ "$(USERPROFILE="$mods/home1" $VALGRIND $Q $JQ -nr foo)" != baz ]; then
+        echo "Bug #3104 regressed (sourcing %USERPROFILE%/.jq on Windows)" 1>&2
+        exit 1
+    fi
+    export HOME=$HOME_BAK
+    unset HOME_BAK
+fi
+
 if [ $(HOME="$mods/home1" $VALGRIND $Q $JQ --debug-dump-disasm -n fg | grep '^[a-z]' | wc -l) -ne 3 ]; then
     echo "Binding too many defs into program" 1>&2
     exit 1


### PR DESCRIPTION
Sourcing of `~/.jq` (file) was hardwired to use the `HOME` environment variable, which is not defined when running in a native Windows shell (PowerShell, CMD).  This change lets it check the `USERPROFILE` environment variable and other standard fallbacks.  `HOME` still has priority if it is set (e.g., in MSYS2 shell).