### PR TITLE
Allow tests to use slurpfile and rawfile arguments

### DIFF
--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -9,12 +9,12 @@
 #include "jq.h"
 
 static void jv_test();
-static void run_jq_tests(jv, int, FILE *, int, int);
+static void run_jq_tests(jv, jv, int, FILE *, int, int);
 #ifdef HAVE_PTHREAD
 static void run_jq_pthread_tests();
 #endif
 
-int jq_testsuite(jv libdirs, int verbose, int argc, char* argv[]) {
+int jq_testsuite(jv progargs, jv libdirs, int verbose, int argc, char* argv[]) {
   FILE *testdata = stdin;
   int skip = -1;
   int take = -1;
@@ -36,7 +36,7 @@ int jq_testsuite(jv libdirs, int verbose, int argc, char* argv[]) {
       }
     }
   }
-  run_jq_tests(libdirs, verbose, testdata, skip, take);
+  run_jq_tests(progargs, libdirs, verbose, testdata, skip, take);
 #ifdef HAVE_PTHREAD
   run_jq_pthread_tests();
 #endif
@@ -73,7 +73,7 @@ static void test_err_cb(void *data, jv e) {
   jv_free(e);
 }
 
-static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int take) {
+static void run_jq_tests(jv prog_args, jv lib_dirs, int verbose, FILE *testdata, int skip, int take) {
   char prog[4096] = {0};
   char buf[4096];
   struct err_data err_msg;
@@ -133,7 +133,7 @@ static void run_jq_tests(jv lib_dirs, int verbose, FILE *testdata, int skip, int
     int pass = 1;
     tests++;
     printf("Test #%d: '%s' at line number %u\n", tests + tests_to_skip, prog, lineno);
-    int compiled = jq_compile(jq, prog);
+    int compiled = jq_compile_args(jq, prog, jv_copy(prog_args));
 
     if (must_fail) {
       jq_set_error_cb(jq, NULL, NULL);

--- a/src/main.c
+++ b/src/main.c
@@ -38,7 +38,7 @@ extern void jv_tsd_dtoa_ctx_init();
 #include "src/version.h"
 #include "src/config_opts.inc"
 
-int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
+int jq_testsuite(jv prog_args, jv lib_dirs, int verbose, int argc, char* argv[]);
 
 static const char* progname;
 
@@ -573,7 +573,7 @@ int main(int argc, char* argv[]) {
         i++;
         // XXX Pass program_arguments, even a whole jq_state *, through;
         // could be useful for testing
-        ret = jq_testsuite(lib_search_paths,
+        ret = jq_testsuite(program_arguments, lib_search_paths,
                            (options & DUMP_DISASM) || (jq_flags & JQ_DEBUG_TRACE),
                            argc - i, argv + i);
         goto out;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2176,3 +2176,15 @@ try ltrimstr("x") catch "x", try rtrimstr("x") catch "x" | "ok"
 try ["OK", setpath([[1]]; 1)] catch ["KO", .]
 []
 ["KO","Cannot update field at array index of array"]
+
+$data|map(select(type=="object"))|map(.this|select(type=="string"))
+null
+["is a test"]
+
+$raw | try ({type:type,slice:.[16:22]}) catch .
+null
+{"type":"string","slice":"a test"}
+
+.+($data|map(select(.this|type=="string"))|.[0])
+{"foo":"bar"}
+{"foo":"bar","this":"is a test","that":"is too"}

--- a/tests/jqtest
+++ b/tests/jqtest
@@ -2,4 +2,4 @@
 
 . "${0%/*}/setup" "$@"
 
-$VALGRIND $Q $JQ -L "$mods" --run-tests $JQTESTDIR/jq.test
+$VALGRIND $Q $JQ -L "$mods" --slurpfile data "$slurpfile" --rawfile raw "$rawfile" --run-tests $JQTESTDIR/jq.test

--- a/tests/setup
+++ b/tests/setup
@@ -29,6 +29,7 @@ else
 fi
 
 mods=$JQTESTDIR/modules
+slurpfile=$mods/data.json
 
 clean=true
 d=

--- a/tests/setup
+++ b/tests/setup
@@ -29,6 +29,7 @@ else
 fi
 
 mods=$JQTESTDIR/modules
+rawfile=$mods/data.json
 slurpfile=$mods/data.json
 
 clean=true


### PR DESCRIPTION
Fixed it so that `jq` can use `--slurpfile` and `--rawfile` when running tests.
I think it's useful to be able to reference a file containing some data instead of needing to repeatedly copy-paste the same input to different test cases. Particularly since if the input is a larger object, then it's difficult to read since it needs to be all on one line in the test file. 

## Simple example

Given the following files

`raw.csv`
```raw.csv
id,name
1,Alice
2,Bob
```

`slurp.json`
```slurp.json
{"foo":"bar"}
```

and this test file

`myjq.test`
```myjq.test
$raw|split("\n")|.[1]|split(",")|.[1]
null
"Alice"

$slurp|.[0]|.foo
null
"bar"

map(($slurp|.[0]|.foo)+.)
["ista","yonx"]
["barista","baryonx"]
```

then this command 
```sh
jq --rawfile raw ./raw.csv --slurpfile slurp ./slurp.json  --run-tests ./myjq.test
```
should output
```
Test #1: '$raw|split("\n")|.[1]|split(",")|.[1]' at line number 1
Test #2: '$slurp|.[0]|.foo' at line number 5
Test #3: 'map(($slurp|.[0]|.foo)+.)' at line number 9
3 of 3 tests passed (0 malformed, 0 skipped)
```

