### PR TITLE
Add a build step to deal with spurious compile errors when building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ docker run --rm -i -v "$PWD:$PWD" -w "$PWD" ghcr.io/jqlang/jq:latest '.version' 
 #### Instructions
 
 ```console
-git submodule update --init # if building from git to get oniguruma
-autoreconf -i               # if building from git
+git submodule update --init    # if building from git to get oniguruma
+autoreconf -i                  # if building from git
 ./configure --with-oniguruma=builtin
-make clean        # if upgrading from a version previously built from source
+make clean                     # if upgrading from a version previously built from source
 make -j8
 make check
 sudo make install

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker run --rm -i -v "$PWD:$PWD" -w "$PWD" ghcr.io/jqlang/jq:latest '.version' 
 git submodule update --init # if building from git to get oniguruma
 autoreconf -i               # if building from git
 ./configure --with-oniguruma=builtin
+make clean        # if upgrading from a version previously built from source
 make -j8
 make check
 sudo make install


### PR DESCRIPTION
When I tried to build a new version in the same working directory I'd used to build a previous version, I saw build errors. After a few attempts, I remembered that "make clean" might get past the problem. It seems like a nice thing to suggest to everyone who might fall into the same trap.