### PR TITLE
Add exec/2: posix_spawn

### DIFF
--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3272,10 +3272,11 @@ sections:
       decoration, not even a newline.
 
       Additionally, jq has support for executing "external filters" provided by
-      other executables. This functionality is provided by `exec`, but may not
-      be available on all platforms, and does not necessarily integrate well
-      with other jq features. It is intended to perform smaller processing that
-      is otherwise impossible to perform in jq itself.
+      other executables. This functionality is provided by `exec` and related
+      filters viz. `system`, but may not be available on all platforms, and does
+      not necessarily integrate well with other jq features. It is intended to
+      perform smaller processing that is otherwise impossible to perform in jq
+      itself.
 
       Most jq builtins are referentially transparent, and yield constant
       and repeatable value streams when applied to constant inputs.
@@ -3354,10 +3355,18 @@ sections:
         body: |
 
           Spawns a new process of path with arguments args. Pipes its input
-          converted to a string as the stdin of the process. The output of the
-          process is coalesced and outputted as a string. Note that this output
-          will include any terminating newlines, so you may want to add an
-          rtrim after this filter, or use a wrapper.
+          converted to a string as the stdin of the process. Outputs an object
+          like `{'out': "", "err": "", "status": 0}`, containing the stdout,
+          stderr, and exit code of the process respectively. If the process
+          exits abnormally due to an unhandled signal, it will have a status of
+          "-1" and a "signal" parameter giving the numeric value of the signal
+          that caused the process to terminate.
+
+      - title: "`system(path)`, `system(path; [args…])`"
+        body: |
+
+          Exactly equivalent to an `exec` call with the same arguments, followed
+          by `| .out | rtrim`.
 
   - title: 'Streaming'
     body: |

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3350,7 +3350,7 @@ sections:
 
           Returns the line number of the input currently being filtered.
 
-      - title: "`exec(path; [args…])`"
+      - title: "`exec(path)`, `exec(path; [args…])`"
         body: |
 
           Spawns a new process of path with arguments args. Pipes its input

--- a/docs/content/manual/manual.yml
+++ b/docs/content/manual/manual.yml
@@ -3271,6 +3271,12 @@ sections:
       builtin outputs its input in raw mode to stder with no additional
       decoration, not even a newline.
 
+      Additionally, jq has support for executing "external filters" provided by
+      other executables. This functionality is provided by `exec`, but may not
+      be available on all platforms, and does not necessarily integrate well
+      with other jq features. It is intended to perform smaller processing that
+      is otherwise impossible to perform in jq itself.
+
       Most jq builtins are referentially transparent, and yield constant
       and repeatable value streams when applied to constant inputs.
       This is not true of I/O builtins.
@@ -3343,6 +3349,15 @@ sections:
         body: |
 
           Returns the line number of the input currently being filtered.
+
+      - title: "`exec(path; [args…])`"
+        body: |
+
+          Spawns a new process of path with arguments args. Pipes its input
+          converted to a string as the stdin of the process. The output of the
+          process is coalesced and outputted as a string. Note that this output
+          will include any terminating newlines, so you may want to add an
+          rtrim after this filter, or use a wrapper.
 
   - title: 'Streaming'
     body: |

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3652,6 +3652,9 @@ At this time jq has minimal support for I/O, mostly in the form of control over 
 Two builtins provide minimal output capabilities, \fBdebug\fR, and \fBstderr\fR\. (Recall that a jq program\'s output values are always output as JSON texts on \fBstdout\fR\.) The \fBdebug\fR builtin can have application\-specific behavior, such as for executables that use the libjq C API but aren\'t the jq executable itself\. The \fBstderr\fR builtin outputs its input in raw mode to stder with no additional decoration, not even a newline\.
 .
 .P
+Additionally, jq has support for executing "external filters" provided by other executables\. This functionality is provided by \fBexec\fR, but may not be available on all platforms, and does not necessarily integrate well with other jq features\. It is intended to perform smaller processing that is otherwise impossible to perform in jq itself\.
+.
+.P
 Most jq builtins are referentially transparent, and yield constant and repeatable value streams when applied to constant inputs\. This is not true of I/O builtins\.
 .
 .SS "input"
@@ -3743,6 +3746,9 @@ Returns the name of the file whose input is currently being filtered\. Note that
 .
 .SS "input_line_number"
 Returns the line number of the input currently being filtered\.
+.
+.SS "exec(path; [args…])"
+Spawns a new process of path with arguments args\. Pipes its input converted to a string as the stdin of the process\. The output of the process is coalesced and outputted as a string\. Note that this output will include any terminating newlines, so you may want to add an rtrim after this filter, or use a wrapper\.
 .
 .SH "STREAMING"
 With the \fB\-\-stream\fR option jq can parse input texts in a streaming fashion, allowing jq programs to start processing large JSON texts immediately rather than after the parse completes\. If you have a single JSON text that is 1GB in size, streaming it will allow you to process it much more quickly\.

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3747,7 +3747,7 @@ Returns the name of the file whose input is currently being filtered\. Note that
 .SS "input_line_number"
 Returns the line number of the input currently being filtered\.
 .
-.SS "exec(path; [args…])"
+.SS "exec(path), exec(path; [args…])"
 Spawns a new process of path with arguments args\. Pipes its input converted to a string as the stdin of the process\. The output of the process is coalesced and outputted as a string\. Note that this output will include any terminating newlines, so you may want to add an rtrim after this filter, or use a wrapper\.
 .
 .SH "STREAMING"

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3652,7 +3652,7 @@ At this time jq has minimal support for I/O, mostly in the form of control over 
 Two builtins provide minimal output capabilities, \fBdebug\fR, and \fBstderr\fR\. (Recall that a jq program\'s output values are always output as JSON texts on \fBstdout\fR\.) The \fBdebug\fR builtin can have application\-specific behavior, such as for executables that use the libjq C API but aren\'t the jq executable itself\. The \fBstderr\fR builtin outputs its input in raw mode to stder with no additional decoration, not even a newline\.
 .
 .P
-Additionally, jq has support for executing "external filters" provided by other executables\. This functionality is provided by \fBexec\fR, but may not be available on all platforms, and does not necessarily integrate well with other jq features\. It is intended to perform smaller processing that is otherwise impossible to perform in jq itself\.
+Additionally, jq has support for executing "external filters" provided by other executables\. This functionality is provided by \fBexec\fR and related filters viz\. \fBsystem\fR, but may not be available on all platforms, and does not necessarily integrate well with other jq features\. It is intended to perform smaller processing that is otherwise impossible to perform in jq itself\.
 .
 .P
 Most jq builtins are referentially transparent, and yield constant and repeatable value streams when applied to constant inputs\. This is not true of I/O builtins\.
@@ -3748,7 +3748,10 @@ Returns the name of the file whose input is currently being filtered\. Note that
 Returns the line number of the input currently being filtered\.
 .
 .SS "exec(path), exec(path; [args…])"
-Spawns a new process of path with arguments args\. Pipes its input converted to a string as the stdin of the process\. The output of the process is coalesced and outputted as a string\. Note that this output will include any terminating newlines, so you may want to add an rtrim after this filter, or use a wrapper\.
+Spawns a new process of path with arguments args\. Pipes its input converted to a string as the stdin of the process\. Outputs an object like \fB{\'out\': "", "err": "", "status": 0}\fR, containing the stdout, stderr, and exit code of the process respectively\. If the process exits abnormally due to an unhandled signal, it will have a status of "\-1" and a "signal" parameter giving the numeric value of the signal that caused the process to terminate\.
+.
+.SS "system(path), system(path; [args…])"
+Exactly equivalent to an \fBexec\fR call with the same arguments, followed by \fB| \.out | rtrim\fR\.
 .
 .SH "STREAMING"
 With the \fB\-\-stream\fR option jq can parse input texts in a streaming fashion, allowing jq programs to start processing large JSON texts immediately rather than after the parse completes\. If you have a single JSON text that is 1GB in size, streaming it will allow you to process it much more quickly\.

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -2064,7 +2064,7 @@ static jv f_exec(jq_state *jq, jv input, jv path, jv args) {
 	} else {
 		// POSIX guarantees that this is WIFSIGNALED(ret)
 		obj = jv_object_set(obj, jv_string("status"), jv_number(-1));
-		obj = jv_object_set(obj, jv_string("signal"), jv_number(WSTOPSIG(ret)));
+		obj = jv_object_set(obj, jv_string("signal"), jv_number(WTERMSIG(ret)));
 	}
 	obj = jv_object_set(obj, jv_string("out"), sout);
 	obj = jv_object_set(obj, jv_string("err"), serr);

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1790,10 +1790,10 @@ static jv f_exec(jq_state *jq, jv input, jv path, jv args) {
 	const size_t argc = jv_array_length(jv_copy(args)) + 1;
 	char * argv[argc + 1];
 	jv_array_foreach(args, i, s) {
-		argv[i + 1] = strdup(jv_string_value(s));
+		argv[i + 1] = jv_mem_strdup(jv_string_value(s));
 		jv_free(s);
 	}
-	argv[0] = strdup(jv_string_value(path));
+	argv[0] = jv_mem_strdup(jv_string_value(path));
 	argv[argc] = 0;
 	jv_free(path);
 
@@ -1936,7 +1936,7 @@ static jv f_exec(jq_state *jq, jv input, jv path, jv args) {
 		}
 	}
 	for (size_t i = 0; i < argc; i++) {
-		free(argv[i]);
+		jv_mem_free(argv[i]);
 	}
 	close(fin[0]), close(fout[1]);
 	jv_free(args);
@@ -1969,14 +1969,14 @@ static jv f_exec(jq_state *jq, jv input, jv path, jv args) {
 	}
 
 	jv output = jv_string_empty(0);
-	char *buf = malloc(1024);
+	char *buf = jv_mem_alloc(1024);
 	ssize_t bytes;
 	while ((bytes = read(fout[0], buf, 1024)) > 0) {
 		output = jv_string_append_buf(output, buf, bytes);
 	}
 	// NOTE: if we want to check the read for failures, it'd be done here
 	close(fout[0]);
-	free(buf);
+	jv_mem_free(buf);
 
 	// NOTE: if we want to check waitpid for failures, be careful since
 	// it may be short-lived

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -280,3 +280,5 @@ def IN(s): any(s == .; .);
 def IN(src; s): any(src == s; .);
 
 def exec(path): exec(path; []);
+def system(path; args): exec(path; args) | .out | rtrim ;
+def system(path): system(path; []);

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -278,3 +278,5 @@ def JOIN($idx; stream; idx_expr; join_expr):
   stream | [., $idx[idx_expr]] | join_expr;
 def IN(s): any(s == .; .);
 def IN(src; s): any(src == s; .);
+
+def exec(path): exec(path; []);

--- a/tests/shtest
+++ b/tests/shtest
@@ -689,4 +689,19 @@ $VALGRIND $Q $JQ . <<\NUM
 -10E-1000000001
 NUM
 
+# exec is tested by executing jq
+if ! $msys && ! $mingw; then
+	now=$(date +%s)
+	if ! r=$($VALGRIND $Q $JQ -rn 'exec("'"$JQ_NO_B"'"; ["-rn", "'"$now"'"]) | trim') ||
+		[ "$r" != "$now" ] ; then
+		echo "exec didn't pipe stdout correctly: expected $now but got $r"
+		exit 1
+	fi
+	if ! r=$(echo "$now" | $VALGRIND $Q $JQ -r 'exec("'"$JQ_NO_B"'"; ["-r", "."]) | trim') ||
+		[ "$r" != "$now" ]; then
+		echo "exec didn't pipe input correctly: expected $now but got $r"
+		exit 1
+	fi
+fi
+
 exit 0

--- a/tests/shtest
+++ b/tests/shtest
@@ -692,12 +692,12 @@ NUM
 # exec is tested by executing jq
 if ! $msys && ! $mingw; then
 	now=$(date +%s)
-	if ! r=$($VALGRIND $Q $JQ -rn 'exec("'"$JQ_NO_B"'"; ["-rn", "'"$now"'"]) | trim') ||
+	if ! r=$($VALGRIND $Q $JQ -rn 'exec("'"$JQ_NO_B"'"; ["-rn", "'"$now"'"]) | .out | rtrim') ||
 		[ "$r" != "$now" ] ; then
 		echo "exec didn't pipe stdout correctly: expected $now but got $r"
 		exit 1
 	fi
-	if ! r=$(echo "$now" | $VALGRIND $Q $JQ -r 'exec("'"$JQ_NO_B"'"; ["-r", "."]) | trim') ||
+	if ! r=$(echo "$now" | $VALGRIND $Q $JQ -r 'system("'"$JQ_NO_B"'"; ["-r", "."])') ||
 		[ "$r" != "$now" ]; then
 		echo "exec didn't pipe input correctly: expected $now but got $r"
 		exit 1


### PR DESCRIPTION
This is an initial MVP with quite a few things still missing (such as: better error messages, documentation, tests).
Despite this, it is already feature-complete on POSIX platforms (on Windows it currently reports an "unsupported on this platform" error).

The signature is `anything | exec(path; [args…])`. `path` and all `args` must be strings.
`anything` will be converted to a string if it isn't a string in memory, then piped into the process' stdin.
The output is all stdout of the process.
The exit code is not reported.

Technically, "path" can be a simple name and `$PATH` will be searched. This is because the underlying function is `posix_spawnp`. This can bec hanged easily.

The process does not have access to environment variables. This can be changed as well.

Piping between programs works. Here's an example to try it out: `tostring | exec("seq"; [.]) | exec("wc"; "-l")`
Expected output when inputting numbers is that number, but it notably goes through seq, then line-counting.