### PR TITLE
Increase MAX_PARSING_DEPTH to 512

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -11,7 +11,7 @@
 typedef const char* presult;
 
 #ifndef MAX_PARSING_DEPTH
-#define MAX_PARSING_DEPTH (256)
+#define MAX_PARSING_DEPTH (512)
 #endif
 
 #define TRY(x) do {presult msg__ = (x); if (msg__) return msg__; } while(0)


### PR DESCRIPTION
To, I hit error `parse error: Exceeds depth limit for parsing` on reasonable JSON files in production.

This PR fixes this limitation.

