### PR TITLE
jv.h: define empty JV_{,V}PRINTF_LIKE macros if __GNUC__ is not defined

### DIFF
--- a/src/jv.h
+++ b/src/jv.h
@@ -113,6 +113,9 @@ jv jv_array_indexes(jv, jv);
   __attribute__ ((__format__( __printf__, fmt_arg_num, args_num)))
 #define JV_VPRINTF_LIKE(fmt_arg_num) \
   __attribute__ ((__format__( __printf__, fmt_arg_num, 0)))
+#else
+#define JV_PRINTF_LIKE(fmt_arg_num, args_num)
+#define JV_VPRINTF_LIKE(fmt_arg_num)
 #endif
 
 


### PR DESCRIPTION
Fixes #3159

Reported-by: Hsiang-Ying Fu
