### PR TITLE
Fix docs for `strptime(fmt)`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ you have `pipenv` installed, you can install the dependencies by running
 Also, you may need to run `virtualenv -p /usr/bin/python3 venv/` and
 then `source venv/bin/activate`, and only then `pipenv sync`.
 
-Once this is done, rerun `./configure` in the jq root directory and then
+Once this is done, rerun `./configure --enable-docs` in the jq root directory and then
 the `Makefile` will be able to generate the jq manpage.  You can just run
 `make jq.1` to build the manpage manually, and `make tests/man.test` to
 update the manual tests.

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2258,7 +2258,7 @@ sections:
 
           The `strptime(fmt)` builtin parses input strings matching the
           `fmt` argument.  The output is in the "broken down time"
-          representation consumed by `gmtime` and output by `mktime`.
+          representation consumed by `mktime` and output by `gmtime`.
 
           The `strftime(fmt)` builtin formats a time (GMT) with the
           given format.  The `strflocaltime` does the same, but using

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -1763,7 +1763,7 @@ sections:
 
           The `strptime(fmt)` builtin parses input strings matching the
           `fmt` argument.  The output is in the "broken down time"
-          representation consumed by `gmtime` and output by `mktime`.
+          representation consumed by `mktime` and output by `gmtime`.
 
           The `strftime(fmt)` builtin formats a time with the given
           format.

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -1973,7 +1973,7 @@ sections:
 
           The `strptime(fmt)` builtin parses input strings matching the
           `fmt` argument.  The output is in the "broken down time"
-          representation consumed by `gmtime` and output by `mktime`.
+          representation consumed by `mktime` and output by `gmtime`.
 
           The `strftime(fmt)` builtin formats a time (GMT) with the
           given format.  The `strflocaltime` does the same, but using

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -2207,7 +2207,7 @@ sections:
 
           The `strptime(fmt)` builtin parses input strings matching the
           `fmt` argument.  The output is in the "broken down time"
-          representation consumed by `gmtime` and output by `mktime`.
+          representation consumed by `mktime` and output by `gmtime`.
 
           The `strftime(fmt)` builtin formats a time (GMT) with the
           given format.  The `strflocaltime` does the same, but using

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -2446,7 +2446,7 @@ The \fBlocaltime\fR builtin works like the \fBgmtime\fR builtin, but using the l
 The \fBmktime\fR builtin consumes "broken down time" representations of time output by \fBgmtime\fR and \fBstrptime\fR\.
 .
 .P
-The \fBstrptime(fmt)\fR builtin parses input strings matching the \fBfmt\fR argument\. The output is in the "broken down time" representation consumed by \fBgmtime\fR and output by \fBmktime\fR\.
+The \fBstrptime(fmt)\fR builtin parses input strings matching the \fBfmt\fR argument\. The output is in the "broken down time" representation consumed by \fBmktime\fR and output by \fBgmtime\fR\.
 .
 .P
 The \fBstrftime(fmt)\fR builtin formats a time (GMT) with the given format\. The \fBstrflocaltime\fR does the same, but using the local timezone setting\.


### PR DESCRIPTION
* `strptime(fmt)` returns the "broken down time" representation
* `mktime` consumes the "broken down time" representation and produces a Unix timestamp
* `gmtime` consumes a Unix timestamp and produces the "broken down time" representation

However, the docs for `strptime(fmt)` mixed up the functionality of `mktime` and `gmtime`.