### PR TITLE
Implement `_experimental_snapshot/2`

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -275,6 +275,28 @@ grep "Expected string key after '{', not '\\['" $d/err > /dev/null
 echo '{"x":"y",["a","b"]}' | $JQ --stream > /dev/null 2> $d/err || true
 grep "Expected string key after ',' in object, not '\\['" $d/err > /dev/null
 
+## Test IO
+
+# snapshot
+cat <<EOF | (cd $d; JQ_ENABLE_SNAPSHOT=1 $VALGRIND $Q $JQ -r 'to_entries[] | _experimental_snapshot(.key;.value) | .key' >keys)
+{
+  "a.txt": "aaa",
+  "b/b.json": "invalid",
+  "c/c.json": ["not","valid"],
+  "d.json": {"e":10},
+  "f.json": 8
+}
+EOF
+(cd $d; ! cat $(cat keys) keys >out)
+cat > $d/expected <<'EOF'
+aaa{"e":10}8a.txt
+b/b.json
+c/c.json
+d.json
+f.json
+EOF
+cmp $d/out $d/expected
+
 # debug, stderr
 $VALGRIND $Q $JQ -n '"test", {} | debug, stderr' >/dev/null
 $JQ -n -c -j '"hello\nworld", null, [false, 0], {"foo":["bar"]}, "\n" | stderr' >$d/out 2>$d/err


### PR DESCRIPTION
Enables writing to files from within jq scripts.

Resolves #3153

The scary name and lack of documentation should serve to inform users that its behavior is subject to breaking changes, and should therefore not be used in production scripts for the time being.

At the moment, this builtin performs a dry run by default. To actually write any data to disk, set the environment variable `JQ_ENABLE_SNAPSHOT=1`. A proper sandboxing interface is outside the scope of this PR, please refer to the link below instead:
* #3092

I've renamed this builtin to `snapshot/2` to highlight the fact that script execution is unaffected by the results of the file writing process (dry run, success, failure), allowing scripts that use it to remain constant and repeatable.

This allows the language to maintain referential transparency even when interacting with the outside world.