### PR TITLE
Implement `--experimental-fileargs` cli option

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -297,6 +297,15 @@ f.json
 EOF
 cmp $d/out $d/expected
 
+# fileargs
+(cd $d; JQ_ENABLE_SNAPSHOT=1 $VALGRIND $Q $JQ -n 'range(3) | _experimental_snapshot(tostring+"-ff.json"; .*2) | empty')
+(cd $d; JQ_ENABLE_SNAPSHOT=1 $VALGRIND $Q $JQ -n --experimental-fileargs '$ARGS.named | add(keys[]),add(.[][])' ?-ff.json >out)
+cat > $d/expected <<'EOF'
+"0-ff.json1-ff.json2-ff.json"
+6
+EOF
+cmp $d/out $d/expected
+
 # debug, stderr
 $VALGRIND $Q $JQ -n '"test", {} | debug, stderr' >/dev/null
 $JQ -n -c -j '"hello\nworld", null, [false, 0], {"foo":["bar"]}, "\n" | stderr' >$d/out 2>$d/err
@@ -352,6 +361,12 @@ fi
 $VALGRIND $JQ -n --jsonargs null -- invalid && EC=$? || EC=$?
 if [ "$EC" -ne 2 ]; then
     echo "--jsonargs exited with wrong exit code, expected 2 got $EC" 1>&2
+    exit 1
+fi
+# fileargs with nonexistent json file
+$VALGRIND $JQ -n --experimental-fileargs null non/existent/file.json && EC=$? || EC=$?
+if [ "$EC" -ne 2 ]; then
+    echo "--fileargs exited with wrong exit code, expected 2 got $EC" 1>&2
     exit 1
 fi
 

--- a/tests/shtest
+++ b/tests/shtest
@@ -275,6 +275,28 @@ grep "Expected string key after '{', not '\\['" $d/err > /dev/null
 echo '{"x":"y",["a","b"]}' | $JQ --stream > /dev/null 2> $d/err || true
 grep "Expected string key after ',' in object, not '\\['" $d/err > /dev/null
 
+## Test IO
+
+# snapshot
+cat <<EOF | (cd $d; JQ_ENABLE_SNAPSHOT=1 $VALGRIND $Q $JQ -r 'to_entries[] | _experimental_snapshot(.key;.value) | .key' >keys)
+{
+  "a.txt": "aaa",
+  "b/b.json": "invalid",
+  "c/c.json": ["not","valid"],
+  "d.json": {"e":10},
+  "f.json": 8
+}
+EOF
+(cd $d; ! cat $(cat keys) keys >out)
+cat > $d/expected <<'EOF'
+aaa{"e":10}8a.txt
+b/b.json
+c/c.json
+d.json
+f.json
+EOF
+cmp $d/out $d/expected
+
 # debug, stderr
 $VALGRIND $Q $JQ -n '"test", {} | debug, stderr' >/dev/null
 $JQ -n -c -j '"hello\nworld", null, [false, 0], {"foo":["bar"]}, "\n" | stderr' >$d/out 2>$d/err


### PR DESCRIPTION
A combination of `--jsonargs` and `--slurpfile`. Slurps all json files passed as a command line argument, and makes them available under `$ARGS.named[filename]`.

```sh
$ jq -n '{"a":"a"}' >a.json
$ jq -n '{"b":"b"}' >b.json
$ jq -n --experimental-fileargs '$ARGS.named' *.json

{
	"a.json": [
		{
			"a": "a"
		}
	],
	"b.json": [
		{
			"b": "b"
		}
	]
}
```

Using this over an `input` builtin allows easy access to filesystem functionality such as `find` and globbing, without having to implement them as jq builtins. Files can also be written-in-place when using snapshots ( #3165 ), since all inputs are read before any writes happen.

Depends on #3165 for tests, marking as draft until that one is merged.