### PR TITLE
fix: make last(empty) yield no output values

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3067,9 +3067,12 @@ sections:
           Note that `nth(n; expr)` doesn't support negative values of `n`.
 
         examples:
-          - program: '[first(range(.)), last(range(.)), nth(./2; range(.))]'
+          - program: '[first(range(.)), last(range(.)), nth(5; range(.))]'
             input: '10'
             output: ['[0,9,5]']
+          - program: '[first(empty), last(empty), nth(5; empty)]'
+            input: 'null'
+            output: ['[]']
 
       - title: "`first`, `last`, `nth(n)`"
         body: |

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3475,9 +3475,13 @@ The \fBnth(n; expr)\fR function extracts the nth value output by \fBexpr\fR\. No
 .
 .nf
 
-jq \'[first(range(\.)), last(range(\.)), nth(\./2; range(\.))]\'
+jq \'[first(range(\.)), last(range(\.)), nth(5; range(\.))]\'
    10
 => [0,9,5]
+
+jq \'[first(empty), last(empty), nth(5; empty)]\'
+   null
+=> []
 .
 .fi
 .

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -170,7 +170,6 @@ def all(condition): all(.[]; condition);
 def any(condition): any(.[]; condition);
 def all: all(.[]; .);
 def any: any(.[]; .);
-def last(g): reduce g as $item (null; $item);
 def nth($n; g):
   if $n < 0 then error("nth doesn't support negative indices")
   else first(skip($n; g)) end;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -362,6 +362,10 @@ null
 10
 [0,9]
 
+[first(range(.)), last(range(.))]
+0
+[]
+
 [nth(0,5,9,10,15; range(.)), try nth(-1; range(.)) catch .]
 10
 [0,5,9,"nth doesn't support negative indices"]

--- a/tests/man.test
+++ b/tests/man.test
@@ -881,9 +881,13 @@ false
 [0,1,2,3,4,5,6,7,8,9]
 [3,4,5,6,7,8,9]
 
-[first(range(.)), last(range(.)), nth(./2; range(.))]
+[first(range(.)), last(range(.)), nth(5; range(.))]
 10
 [0,9,5]
+
+[first(empty), last(empty), nth(5; empty)]
+null
+[]
 
 [range(.)]|[first, last, nth(5)]
 10


### PR DESCRIPTION
This patch fixes `last/1` to produce no output value when the argument yields nothing. For example, `[last(empty)]` and `[last(range(0))]` now produce `[]` instead of `[null]`. I fixed the issue using byte-coded definition, to avoid unnecessary value boxing. This closes #1869 and closes #3177.
