### PR TITLE
Escape some code parts in manual.

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -1011,15 +1011,15 @@ sections:
 
           The key difference between `map(f)` and `map_values(f)` is
           that the former simply forms an array from all the values of
-          `($x|f)` for each value, $x, in the input array or object,
+          `($x|f)` for each value, `$x`, in the input array or object,
           but `map_values(f)` only uses `first($x|f)`.
 
           Specifically, for object inputs, `map_values(f)` constructs
           the output object by examining in turn the value of
-          `first(.[$k]|f)` for each key, $k, of the input.  If this
+          `first(.[$k]|f)` for each key, `$k`, of the input.  If this
           expression produces no values, then the corresponding key
           will be dropped; otherwise, the output object will have that
-          value at the key, $k.
+          value at the key, `$k`.
 
           Here are some examples to clarify the behavior of `map` and
           `map_values` when applied to arrays. These examples assume the
@@ -2292,13 +2292,13 @@ sections:
 
           jq provides a few SQL-style operators.
 
-          * INDEX(stream; index_expression):
+          * `INDEX(stream; index_expression)`:
 
             This builtin produces an object whose keys are computed by
             the given index expression applied to each value from the
             given stream.
 
-          * JOIN($idx; stream; idx_expr; join_expr):
+          * `JOIN($idx; stream; idx_expr; join_expr)`:
 
             This builtin joins the values from the given stream to the
             given index.  The index's keys are computed by applying the
@@ -2307,22 +2307,22 @@ sections:
             value from the index is fed to the given join expression to
             produce each result.
 
-          * JOIN($idx; stream; idx_expr):
+          * `JOIN($idx; stream; idx_expr)`:
 
             Same as `JOIN($idx; stream; idx_expr; .)`.
 
-          * JOIN($idx; idx_expr):
+          * `JOIN($idx; idx_expr)`:
 
             This builtin joins the input `.` to the given index, applying
             the given index expression to `.` to compute the index key.
             The join operation is as described above.
 
-          * IN(s):
+          * `IN(s)`:
 
             This builtin outputs `true` if `.` appears in the given
             stream, otherwise it outputs `false`.
 
-          * IN(source; s):
+          * `IN(source; s)`:
 
             This builtin outputs `true` if any value in the source stream
             appears in the second stream, otherwise it outputs `false`.
@@ -2844,7 +2844,7 @@ sections:
               {"title": "First post", "author": "Anonymous Coward"}
               {"title": "A well-written article", "author": "Person McPherson"}
 
-          We use a variable, $names, to store the realnames object, so that we
+          We use a variable, `$names`, to store the realnames object, so that we
           can refer to it later when looking up author usernames:
 
               .realnames as $names | .posts[] | {title, author: $names[.author]}

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -999,15 +999,15 @@ sections:
 
           The key difference between `map(f)` and `map_values(f)` is
           that the former simply forms an array from all the values of
-          `($x|f)` for each value, $x, in the input array or object,
+          `($x|f)` for each value, `$x`, in the input array or object,
           but `map_values(f)` only uses `first($x|f)`.
 
           Specifically, for object inputs, `map_values(f)` constructs
           the output object by examining in turn the value of
-          `first(.[$k]|f)` for each key, $k, of the input.  If this
+          `first(.[$k]|f)` for each key, `$k`, of the input.  If this
           expression produces no values, then the corresponding key
           will be dropped; otherwise, the output object will have that
-          value at the key, $k.
+          value at the key, `$k`.
 
           Here are some examples to clarify the behavior of `map` and
           `map_values` when applied to arrays. These examples assume the
@@ -2239,13 +2239,13 @@ sections:
 
           jq provides a few SQL-style operators.
 
-          * INDEX(stream; index_expression):
+          * `INDEX(stream; index_expression)`:
 
             This builtin produces an object whose keys are computed by
             the given index expression applied to each value from the
             given stream.
 
-          * JOIN($idx; stream; idx_expr; join_expr):
+          * `JOIN($idx; stream; idx_expr; join_expr)`:
 
             This builtin joins the values from the given stream to the
             given index.  The index's keys are computed by applying the
@@ -2254,22 +2254,22 @@ sections:
             value from the index is fed to the given join expression to
             produce each result.
 
-          * JOIN($idx; stream; idx_expr):
+          * `JOIN($idx; stream; idx_expr)`:
 
             Same as `JOIN($idx; stream; idx_expr; .)`.
 
-          * JOIN($idx; idx_expr):
+          * `JOIN($idx; idx_expr)`:
 
             This builtin joins the input `.` to the given index, applying
             the given index expression to `.` to compute the index key.
             The join operation is as described above.
 
-          * IN(s):
+          * `IN(s)`:
 
             This builtin outputs `true` if `.` appears in the given
             stream, otherwise it outputs `false`.
 
-          * IN(source; s):
+          * `IN(source; s)`:
 
             This builtin outputs `true` if any value in the source stream
             appears in the second stream, otherwise it outputs `false`.
@@ -2789,7 +2789,7 @@ sections:
               {"title": "First post", "author": "Anonymous Coward"}
               {"title": "A well-written article", "author": "Person McPherson"}
 
-          We use a variable, $names, to store the realnames object, so that we
+          We use a variable, `$names`, to store the realnames object, so that we
           can refer to it later when looking up author usernames:
 
               .realnames as $names | .posts[] | {title, author: $names[.author]}

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "November 2024" "" ""
+.TH "JQ" "1" "January 2025" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -1007,10 +1007,10 @@ In the absence of errors, \fBmap(f)\fR always outputs an array whereas \fBmap_va
 When the input to \fBmap_values(f)\fR is an object, the output object has the same keys as the input object except for those keys whose values when piped to \fBf\fR produce no values at all\.
 .
 .P
-The key difference between \fBmap(f)\fR and \fBmap_values(f)\fR is that the former simply forms an array from all the values of \fB($x|f)\fR for each value, $x, in the input array or object, but \fBmap_values(f)\fR only uses \fBfirst($x|f)\fR\.
+The key difference between \fBmap(f)\fR and \fBmap_values(f)\fR is that the former simply forms an array from all the values of \fB($x|f)\fR for each value, \fB$x\fR, in the input array or object, but \fBmap_values(f)\fR only uses \fBfirst($x|f)\fR\.
 .
 .P
-Specifically, for object inputs, \fBmap_values(f)\fR constructs the output object by examining in turn the value of \fBfirst(\.[$k]|f)\fR for each key, $k, of the input\. If this expression produces no values, then the corresponding key will be dropped; otherwise, the output object will have that value at the key, $k\.
+Specifically, for object inputs, \fBmap_values(f)\fR constructs the output object by examining in turn the value of \fBfirst(\.[$k]|f)\fR for each key, \fB$k\fR, of the input\. If this expression produces no values, then the corresponding key will be dropped; otherwise, the output object will have that value at the key, \fB$k\fR\.
 .
 .P
 Here are some examples to clarify the behavior of \fBmap\fR and \fBmap_values\fR when applied to arrays\. These examples assume the input is \fB[1]\fR in all cases:
@@ -2481,37 +2481,37 @@ jq \'strptime("%Y\-%m\-%dT%H:%M:%SZ")|mktime\'
 jq provides a few SQL\-style operators\.
 .
 .TP
-INDEX(stream; index_expression):
+\fBINDEX(stream; index_expression)\fR:
 .
 .IP
 This builtin produces an object whose keys are computed by the given index expression applied to each value from the given stream\.
 .
 .TP
-JOIN($idx; stream; idx_expr; join_expr):
+\fBJOIN($idx; stream; idx_expr; join_expr)\fR:
 .
 .IP
 This builtin joins the values from the given stream to the given index\. The index\'s keys are computed by applying the given index expression to each value from the given stream\. An array of the value in the stream and the corresponding value from the index is fed to the given join expression to produce each result\.
 .
 .TP
-JOIN($idx; stream; idx_expr):
+\fBJOIN($idx; stream; idx_expr)\fR:
 .
 .IP
 Same as \fBJOIN($idx; stream; idx_expr; \.)\fR\.
 .
 .TP
-JOIN($idx; idx_expr):
+\fBJOIN($idx; idx_expr)\fR:
 .
 .IP
 This builtin joins the input \fB\.\fR to the given index, applying the given index expression to \fB\.\fR to compute the index key\. The join operation is as described above\.
 .
 .TP
-IN(s):
+\fBIN(s)\fR:
 .
 .IP
 This builtin outputs \fBtrue\fR if \fB\.\fR appears in the given stream, otherwise it outputs \fBfalse\fR\.
 .
 .TP
-IN(source; s):
+\fBIN(source; s)\fR:
 .
 .IP
 This builtin outputs \fBtrue\fR if any value in the source stream appears in the second stream, otherwise it outputs \fBfalse\fR\.
@@ -3144,7 +3144,7 @@ We want to produce the posts with the author field containing a real name, as in
 .IP "" 0
 .
 .P
-We use a variable, $names, to store the realnames object, so that we can refer to it later when looking up author usernames:
+We use a variable, \fB$names\fR, to store the realnames object, so that we can refer to it later when looking up author usernames:
 .
 .IP "" 4
 .


### PR DESCRIPTION
This is needed to make the Markdown -> HTML conversion work with Pandoc, see https://github.com/jqlang/jq/issues/3183.