### PR TITLE
Move closer to the standard autotools idiom.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ jq.1
 
 # Generated source
 src/builtin.inc
-src/config_opts.inc
+src/config.h.in
+src/config.h
 *.pc
 
 # Autotools junk
@@ -38,8 +39,6 @@ jq-*.zip
 configure
 aclocal.m4
 Makefile.in
-version.h
-.remake-version-h
 config.cache
 *.rpm
 m4/libtool.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,12 +34,12 @@ ACLOCAL_AMFLAGS = -I config/m4
 # header file creation so we'll use good old make
 if MAINTAINER_MODE
 BUILT_SOURCES = src/lexer.h src/lexer.c src/parser.h src/parser.c \
-                src/builtin.inc src/config_opts.inc src/version.h
+                src/builtin.inc
 src/lexer.c: src/lexer.l
 	$(AM_V_LEX) flex -o src/lexer.c --header-file=src/lexer.h $<
 src/lexer.h: src/lexer.c
 else
-BUILT_SOURCES = src/builtin.inc src/config_opts.inc src/version.h
+BUILT_SOURCES = src/builtin.inc
 .y.c:
 	$(AM_V_YACC) echo "NOT building parser.c!"
 .l.c:
@@ -101,23 +101,6 @@ endif
 
 ### Building the jq binary
 
-# Remake the version.h header file if, and only if, the git ID has changed
-.PHONY: .FORCE
-.FORCE:
-generate_ver = ver="`{ $(srcdir)/scripts/version || echo '$(VERSION)' ; } | sed 's/.*/\#define JQ_VERSION \"&\"/'`"
-.remake-version-h: .FORCE
-	@ $(generate_ver); test "x`cat src/version.h 2>/dev/null`" = "x$$ver" || touch .remake-version-h
-src/version.h: .remake-version-h
-	mkdir -p src
-	$(AM_V_GEN) $(generate_ver); echo "$$ver" > $@
-src/config_opts.inc:
-	mkdir -p src
-	$(AM_V_GEN) if test -x ./config.status; then \
-	  ./config.status --config; \
-	else echo "(unknown)"; \
-	fi | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/"/' -e 's/^/#define JQ_CONFIG /' > $@
-src/main.c: src/version.h src/config_opts.inc
-
 src/builtin.inc: $(srcdir)/src/builtin.jq
 	mkdir -p src
 	$(AM_V_GEN) od -v -A n -t o1 -- $< | \
@@ -128,10 +111,10 @@ src/builtin.inc: $(srcdir)/src/builtin.jq
 	    -e 's/ \([123456789]\)/ 0\1/g' > $@
 src/builtin.o: src/builtin.inc
 
-CLEANFILES = src/version.h .remake-version-h src/builtin.inc src/config_opts.inc
+CLEANFILES = src/builtin.inc
 
 bin_PROGRAMS = jq
-jq_SOURCES = src/main.c src/version.h
+jq_SOURCES = src/main.c
 jq_LDFLAGS = -static-libtool-libs
 jq_LDADD = libjq.la -lm
 
@@ -216,8 +199,7 @@ DOC_FILES = docs/content docs/public docs/templates                     \
 
 EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         jq.1.prebuilt jq.spec src/lexer.c src/lexer.h src/parser.c      \
-        src/parser.h src/version.h src/builtin.jq scripts/version       \
-        libjq.pc                                                        \
+        src/parser.h src/builtin.jq scripts/version libjq.pc            \
         tests/modules/a.jq tests/modules/b/b.jq tests/modules/c/c.jq    \
         tests/modules/c/d.jq tests/modules/data.json                    \
         tests/modules/home1/.jq tests/modules/home2/.jq/g.jq            \

--- a/config/m4/check-math-func.m4
+++ b/config/m4/check-math-func.m4
@@ -2,8 +2,8 @@ dnl AC_CHECK_MATH_FUNC(func)
 AC_DEFUN([AC_CHECK_MATH_FUNC], [
   AC_LANG(C)
   AC_CHECK_LIB([m],[$1],[
-    eval "ac_tr_func=HAVE_[]upcase($1)"
-    AC_DEFINE_UNQUOTED($ac_tr_func)
+    m4_define([ac_tr_func], [HAVE_]m4_toupper($1))
+    AC_DEFINE(ac_tr_func, 1, [Define if you have the $1 math function.])
   ],[
   ])
 ])

--- a/config/m4/find-func-no-libs2.m4
+++ b/config/m4/find-func-no-libs2.m4
@@ -42,7 +42,7 @@ case "$ac_res" in
 	yes)
 	eval "ac_cv_func_$1=yes"
 	eval "LIB_$1="
-	AC_DEFINE_UNQUOTED($ac_tr_func)
+	AC_DEFINE_UNQUOTED($ac_tr_func, 1, [Define if the $1 function is available.])
 	AC_MSG_RESULT([yes])
 	;;
 	no)
@@ -53,8 +53,8 @@ case "$ac_res" in
 	*)
 	eval "ac_cv_func_$1=yes"
 	eval "ac_cv_lib_`echo "$ac_res" | sed 's/-l//'`=yes"
-	AC_DEFINE_UNQUOTED($ac_tr_func)
-	AC_DEFINE_UNQUOTED($ac_tr_lib)
+	AC_DEFINE_UNQUOTED($ac_tr_func, 1, [Define if you have the $1 function.])
+	AC_DEFINE_UNQUOTED($ac_tr_lib, 1, [Define if you have the $2 library.])
 	AC_MSG_RESULT([yes, in $ac_res])
 	;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -111,7 +111,7 @@ AC_ARG_ENABLE([decnum],
    AS_HELP_STRING([--disable-decnum],[disable decnum support]))
 
 AS_IF([test "x$enable_decnum" != "xno"],[
-   AC_DEFINE([USE_DECNUM],1)
+   AC_DEFINE([USE_DECNUM], 1, [Define to enable decnum support.])
 ])
 
 AM_CONDITIONAL([ENABLE_VALGRIND], [test "x$enable_valgrind" != xno])
@@ -125,7 +125,7 @@ AM_CONDITIONAL([ENABLE_ALL_STATIC], [test "x$enable_all_static" = xyes])
 dnl Find pthread, if we have it. We do this first because we may set -pthread on CFLAGS
 dnl which can cause various macros to be defined (__REENTRANT on Darwin, for example)
 AX_PTHREAD([
-   AC_DEFINE([HAVE_PTHREAD], [1])
+   AC_DEFINE([HAVE_PTHREAD], [1], [Define to enable POSIX threads support.])
    LIBS="$PTHREAD_LIBS $LIBS"
    CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
    CC="$PTHREAD_CC"
@@ -242,6 +242,9 @@ AC_C_BIGENDIAN(
    AC_MSG_ERROR(universal endianness not supported)
 )
 
+AC_DEFINE_UNQUOTED([JQ_CONFIG], ["$ac_cs_config"], [The options jq was configured with.])
+AH_BOTTOM([#define JQ_VERSION PACKAGE_VERSION])
+
 dnl Oniguruma
 AC_ARG_WITH([oniguruma],
    [AS_HELP_STRING([--with-oniguruma=prefix],
@@ -291,6 +294,8 @@ AM_CONDITIONAL([WITH_ONIGURUMA], [test "x$with_oniguruma" != xno])
 AC_SUBST([BUNDLER], ["$bundle_cmd"])
 
 AC_CONFIG_MACRO_DIRS([config/m4 m4])
+AC_CONFIG_HEADERS([src/config.h])
+CFLAGS="$CFLAGS --include src/config.h"
 AC_CONFIG_FILES([Makefile libjq.pc])
 AC_OUTPUT
 

--- a/scripts/version
+++ b/scripts/version
@@ -2,7 +2,7 @@
 set -eu
 
 cd "$(dirname "$0")/../"
-test -d .git || exit 1
+test -e .git || exit 1
 
 if git describe --tags --match 'jq-*' >/dev/null 2>&1; then
   git describe --tags --match 'jq-*' --dirty | sed 's/^jq-//'

--- a/src/main.c
+++ b/src/main.c
@@ -35,8 +35,6 @@ extern void jv_tsd_dtoa_ctx_init();
 #include "jq.h"
 #include "jv_alloc.h"
 #include "util.h"
-#include "src/version.h"
-#include "src/config_opts.inc"
 
 int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
 


### PR DESCRIPTION
* Create `src/config.h` instead of passing everything on the compiler command line.

* To reduce the magnitude of this change, add `--include src/config.h` to CFLAGS instead of adding `#include "src/config.h"` at the top of each source file.  Not all compilers support this, but I don't think we care about anything other than gcc and clang at this point.

* Rather than generate `src/config_opts.inc`, emit `JQ_CONFIG` directly into `src/config.h`.

* Rather than generate `src/version.h`, define `JQ_VERSION` as an alias for the standard `PACKAGE_VERSION`.