### PR TITLE
Improve reliability of NO_COLOR tests.

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -14,6 +14,9 @@ JQ="$JQ -b"
 
 PATH=$JQBASEDIR:$PATH $JQBASEDIR/tests/jq-f-test.sh > /dev/null
 
+SHELL=/bin/sh
+export SHELL
+
 if [ -f "$JQBASEDIR/.libs/libinject_errors.so" ]; then
   # Do some simple error injection tests to check that we're handling
   # I/O errors correctly.

--- a/tests/shtest
+++ b/tests/shtest
@@ -586,17 +586,17 @@ if $test_no_color && command -v script >/dev/null 2>&1; then
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  NO_COLOR= faketty $JQ_NO_B -n . > $d/color
+  faketty env NO_COLOR= $JQ_NO_B -n . > $d/color
   printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  NO_COLOR=1 faketty $JQ_NO_B -n . > $d/color
+  faketty env NO_COLOR=1 $JQ_NO_B -n . > $d/color
   printf 'null\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  NO_COLOR=1 faketty $JQ_NO_B -Cn . > $d/color
+  faketty env NO_COLOR=1 $JQ_NO_B -Cn . > $d/color
   printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color


### PR DESCRIPTION
Use `env` to ensure that `NO_COLOR` is set to the desired value (or unset) regardless of any initialization that may occur when `script` forks a shell to run jq in.