### PR TITLE
Update compile.c to correctly inform user making substitutions with sub("a","b") instead of sub("a";"b")

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -1159,7 +1159,7 @@ static int expand_call_arglist(block* b, jv args, jv *env) {
         else if (curr->op == LOADV)
           locfile_locate(curr->locfile, curr->source, "jq: error: $%s is not defined", curr->symbol);
         else
-          locfile_locate(curr->locfile, curr->source, "jq: error: %s/%d is not defined", curr->symbol, curr->nactuals);
+          locfile_locate(curr->locfile, curr->source, "jq: error: %s/%d is not defined, also happens when you separate arguments by comma (,) instead of semicolon (;)", curr->symbol, curr->nactuals);
         errors++;
         // don't process this instruction if it's not well-defined
         ret = BLOCK(ret, inst_block(curr));


### PR DESCRIPTION
echo '{"f":"a"}' | jq '.f | sub("a","b")'
above line generates the following unclear error message:

jq: error: sub/1 is not defined at &lt;top-level>, line 1:
.f | sub("a","b")     
jq: 1 compile error

This patch is changing the error message to:
jq: error: sub/1 is not defined, also happens when you separate arguments by comma (,) instead of semicolon (;), at &lt;top-level>, line 1:
.f | sub("a","b")     
jq: 1 compile error

because the correct command is:

echo '{"f":"a"}' | jq '.f | sub("a";"b")'