### PR TITLE
fix: reduce/foreach state variable should not be reset each iteration

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -832,7 +832,7 @@ block gen_reduce(block source, block matcher, block init, block body) {
   block loop = BLOCK(gen_op_simple(DUPN),
                      source,
                      bind_alternation_matchers(matcher,
-                                  BLOCK(gen_op_bound(LOADVN, res_var),
+                                  BLOCK(gen_op_bound(LOADV, res_var),
                                         body,
                                         gen_op_bound(STOREV, res_var))),
                      gen_op_simple(BACKTRACK));
@@ -854,7 +854,7 @@ block gen_foreach(block source, block matcher, block init, block update, block e
                      // in the body to see
                      bind_alternation_matchers(matcher,
                                   // load the loop state variable
-                                  BLOCK(gen_op_bound(LOADVN, state_var),
+                                  BLOCK(gen_op_bound(LOADV, state_var),
                                         // generate updated state
                                         update,
                                         // save the updated state for value extraction

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -322,6 +322,10 @@ null
 [{"a":1}, {"b":2}, {"a":3, "b":4}]
 [-1, -1, -4]
 
+[foreach range(5) as $x (0; .+$x | select($x!=2); [$x,.])]
+null
+[[0,0],[1,1],[3,4],[4,8]]
+
 [limit(3; .[])]
 [11,22,33,44,55,66,77,88,99]
 [11,22,33]
@@ -824,6 +828,10 @@ null
 reduce . as $n (.; .)
 null
 null
+
+reduce range(5) as $x (0; .+$x | select($x!=2))
+null
+8
 
 # Destructuring
 . as {$a, b: [$c, {$d}]} | [$a, $c, $d]


### PR DESCRIPTION
When the UPDATE query in a reduce or foreach syntax does not emit
a value, it should simply skip updating the state variable. But
currently it resets the state variable to null.
