### PR TITLE
build: fix insecure RUNPATH

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -115,11 +115,10 @@ CLEANFILES = src/builtin.inc
 
 bin_PROGRAMS = jq
 jq_SOURCES = src/main.c
-jq_LDFLAGS = -static-libtool-libs
 jq_LDADD = libjq.la -lm
 
 if ENABLE_ALL_STATIC
-jq_LDFLAGS += -all-static
+jq_LDFLAGS = -all-static
 endif
 
 ### Tests (make check)


### PR DESCRIPTION
In Gentoo -static-libtool-libs causes a QA Notice.

 * QA Notice: The following files contain insecure RUNPATHs
 *  Please file a bug about this at https://bugs.gentoo.org/
 *  with the maintainer of the package.
 *   /var/tmp/portage/app-misc/jq-1.7.1/image/usr/bin/jqn    RPATH: /var/tmp/portage/app-misc/jq-1.7.1/work/jq-jq-1.7.1/.libs

Gentoo-Issue: https://bugs.gentoo.org/945698