### PR TITLE
actions/attest-build-provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,8 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release Docker image
-        id: attestation
         uses: docker/build-push-action@v6
+        id: build-push
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/jq-') }}
@@ -388,7 +388,7 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.attestation.outputs.digest }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,6 @@ on:
       - "jq-*"
   pull_request:
 
-permissions:
-  id-token: write
-  contents: read
-  attestations: write
-
 jobs:
   linux:
     strategy:
@@ -116,11 +111,6 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
-      - name: attest-build-provenance
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: jq-${{ env.SUFFIX }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -188,11 +178,6 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
-      - name: attest-build-provenance
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: jq-${{ env.SUFFIX }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -267,11 +252,6 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
-      - name: attest-build-provenance
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: jq-${{ env.SUFFIX }}.exe
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -301,13 +281,6 @@ jobs:
           make distcheck
           make dist dist-zip
           git diff --exit-code
-      - name: attest-build-provenance
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            jq-*.tar.gz
-            jq-*.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -395,6 +368,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
       pull-requests: write
     environment: release
     needs: [linux, macos, windows, dist, docker]
@@ -417,6 +392,10 @@ jobs:
           sha256sum jq-* > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-* sha256sum.txt
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: jq-*
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
             test-suite.log
             tests/*.log
       - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: jq-${{ env.SUFFIX }}
@@ -188,6 +189,7 @@ jobs:
             test-suite.log
             tests/*.log
       - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: jq-${{ env.SUFFIX }}
@@ -266,6 +268,7 @@ jobs:
             test-suite.log
             tests/*.log
       - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: jq-${{ env.SUFFIX }}.exe
@@ -299,6 +302,7 @@ jobs:
           make dist dist-zip
           git diff --exit-code
       - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: |
@@ -380,6 +384,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
       - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
       - "jq-*"
   pull_request:
 
+permissions:
+  id-token: write
+  contents: read
+  attestations: write
+
 jobs:
   linux:
     strategy:
@@ -111,6 +116,10 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: jq-${{ env.SUFFIX }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -178,6 +187,10 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: jq-${{ env.SUFFIX }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -252,6 +265,10 @@ jobs:
           path: |
             test-suite.log
             tests/*.log
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: jq-${{ env.SUFFIX }}.exe
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -281,6 +298,12 @@ jobs:
           make distcheck
           make dist dist-zip
           git diff --exit-code
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            jq-*.tar.gz
+            jq-*.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -294,6 +317,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
+      contents: read
+      attestations: write
       packages: write
     needs: linux
     steps:
@@ -329,7 +355,8 @@ jobs:
         id: metadata
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: ${{ startsWith(github.ref, 'refs/tags/jq-')
+          tags: >
+            ${{ startsWith(github.ref, 'refs/tags/jq-')
             && format('type=match,pattern=jq-(.*),group=1,value={0}', github.ref_name)
             || 'type=sha,format=long' }}
       - name: Set up QEMU
@@ -343,6 +370,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release Docker image
+        id: attestation
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -351,6 +379,12 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.attestation.outputs.digest }}
+          push-to-registry: true
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adding https://github.com/actions/attest-build-provenance to the ci builds so that the release assets and docker image for the next release tag generate signed build provenance attestations for workflow artifacts.

