### PR TITLE
workflows: actions/attest-build-provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
+      contents: read
+      attestations: write
       packages: write
     needs: linux
     steps:
@@ -329,7 +332,8 @@ jobs:
         id: metadata
         with:
           images: ghcr.io/${{ github.repository }}
-          tags: ${{ startsWith(github.ref, 'refs/tags/jq-')
+          tags: >
+            ${{ startsWith(github.ref, 'refs/tags/jq-')
             && format('type=match,pattern=jq-(.*),group=1,value={0}', github.ref_name)
             || 'type=sha,format=long' }}
       - name: Set up QEMU
@@ -344,6 +348,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release Docker image
         uses: docker/build-push-action@v6
+        id: build-push
         with:
           context: .
           push: ${{ startsWith(github.ref, 'refs/tags/jq-') }}
@@ -351,11 +356,20 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+      - name: attest-build-provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true
 
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
       pull-requests: write
     environment: release
     needs: [linux, macos, windows, dist, docker]
@@ -378,6 +392,10 @@ jobs:
           sha256sum jq-* > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-* sha256sum.txt
+      - name: attest-build-provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: jq-*
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,6 @@ jobs:
       id-token: write
       attestations: write
       pull-requests: write
-      actions: write
     environment: release
     needs: [linux, macos, windows, dist, docker]
     if: startsWith(github.ref, 'refs/tags/jq-')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,7 @@ jobs:
       id-token: write
       attestations: write
       pull-requests: write
+      actions: write
     environment: release
     needs: [linux, macos, windows, dist, docker]
     if: startsWith(github.ref, 'refs/tags/jq-')
@@ -380,6 +381,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: jq-*
           merge-multiple: true
       - name: Upload release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-      - name: Docker attest-build-provenance
+      - name: Generate signed attestations
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
@@ -393,7 +393,7 @@ jobs:
           sha256sum jq-* > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-* sha256sum.txt
-      - name: Release attest-build-provenance
+      - name: Generate signed attestations
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: jq-*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
       - name: Generate signed attestations
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/jq-')
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ghcr.io/${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm64,linux/mips64le,linux/ppc64le,linux/riscv64,linux/s390x
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-      - name: attest-build-provenance
+      - name: Docker attest-build-provenance
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v2
         with:
@@ -392,7 +392,7 @@ jobs:
           sha256sum jq-* > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-* sha256sum.txt
-      - name: attest-build-provenance
+      - name: Release attest-build-provenance
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: jq-*


### PR DESCRIPTION
Adding https://github.com/actions/attest-build-provenance to the ci builds so that the release assets and docker image for the next release tag generate signed build provenance attestations for workflow artifacts.