### PR TITLE
Fix `--indent 0` implicitly enabling compact-output

### DIFF
--- a/src/jv.h
+++ b/src/jv.h
@@ -226,7 +226,7 @@ enum jv_print_flags {
   JV_PRINT_SPACE2   = 1024,
 };
 #define JV_PRINT_INDENT_FLAGS(n) \
-    ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) == 0 ? 0 : (n) << 8 | JV_PRINT_PRETTY)
+    ((n) < 0 || (n) > 7 ? JV_PRINT_TAB | JV_PRINT_PRETTY : (n) << 8 | JV_PRINT_PRETTY)
 void jv_dumpf(jv, FILE *f, int flags);
 void jv_dump(jv, int flags);
 void jv_show(jv, int flags);

--- a/tests/shtest
+++ b/tests/shtest
@@ -725,4 +725,33 @@ $VALGRIND $Q $JQ . <<\NUM
 -10E-1000000001
 NUM
 
+# test for --indent and --compact-output -- #1465
+printf '[1,2]\n' > $d/expected
+$JQ --compact-output -n "[1,2]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n1,\n2\n]\n' > $d/expected
+$JQ --indent 0 -n "[1,2]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n 1,\n 2\n]\n' > $d/expected
+$JQ --indent 1 -n "[1,2]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n     1,\n     2\n]\n' > $d/expected
+$JQ --indent 5 -n "[1,2]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n{\n"a": 1\n}\n]\n' > $d/expected
+$JQ --indent 0 -n "[{a:1}]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n {\n  "a": 1\n }\n]\n' > $d/expected
+$JQ --indent 1 -n "[{a:1}]" > $d/out
+cmp $d/out $d/expected
+
+printf '[\n      {\n            "a": 1\n      }\n]\n' > $d/expected
+$JQ --indent 6 -n "[{a:1}]" > $d/out
+cmp $d/out $d/expected
+
 exit 0


### PR DESCRIPTION
Cherry-pick of #2256 and #3202 with modifications.
Fixes #1465 and also fixes #2498.
Closes #2256 and also closes #3202.