### PR TITLE
tests: quote `.[]` in shtest which can break syntax highlight

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -140,10 +140,10 @@ cmp $d/out $d/expected
 
 # Regression test for --raw-output0
 printf "a\0b\0" > $d/expected
-printf '["a", "b"]' | $VALGRIND $Q $JQ --raw-output0 .[] > $d/out
+printf '["a", "b"]' | $VALGRIND $Q $JQ --raw-output0 '.[]' > $d/out
 cmp $d/out $d/expected
 printf "a\0" > $d/expected
-if printf '["a", "c\\u0000d", "b"]' | $VALGRIND $Q $JQ --raw-output0 .[] > $d/out; then
+if printf '["a", "c\\u0000d", "b"]' | $VALGRIND $Q $JQ --raw-output0 '.[]' > $d/out; then
   echo "Should exit error on string containing NUL with --raw-output0" 1>&2
   exit 1
 elif [ $? -ne 5 ]; then


### PR DESCRIPTION
I would like to quote `.[]` query in shtest because it currently breaks syntax highlight in the Vim editor. Yes, I know it is a problem of syntax highlighting, but not sure I can fix it, so I would like to avoid use of bare square brackets in the shell script.
