### PR TITLE
Fix redundant subexpression in Generators and iterators example in doc

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3223,9 +3223,8 @@ sections:
                     def _range:
                         if (by > 0 and . < upto) or (by < 0 and . > upto)
                         then ., ((.+by)|_range)
-                        else . end;
-                    if by == 0 then init else init|_range end |
-                    select((by > 0 and . < upto) or (by < 0 and . > upto));
+                        else empty end;
+                    if init == upto then empty elif by == 0 then init else init|_range end;
                 range(0; 10; 3)'
             input: 'null'
             output: ['0', '3', '6', '9']

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3644,7 +3644,7 @@ All jq functions can be generators just by using builtin generators\. It is also
 .
 .nf
 
-jq \'def range(init; upto; by): def _range: if (by > 0 and \. < upto) or (by < 0 and \. > upto) then \., ((\.+by)|_range) else \. end; if by == 0 then init else init|_range end | select((by > 0 and \. < upto) or (by < 0 and \. > upto)); range(0; 10; 3)\'
+jq \'def range(init; upto; by): def _range: if (by > 0 and \. < upto) or (by < 0 and \. > upto) then \., ((\.+by)|_range) else empty end; if init == upto then empty elif by == 0 then init else init|_range end; range(0; 10; 3)\'
    null
 => 0, 3, 6, 9
 

--- a/tests/man.test
+++ b/tests/man.test
@@ -927,7 +927,7 @@ foreach .[] as $item (0; . + 1; {index: ., $item})
 {"index":2,"item":"bar"}
 {"index":3,"item":"baz"}
 
-def range(init; upto; by): def _range: if (by > 0 and . < upto) or (by < 0 and . > upto) then ., ((.+by)|_range) else . end; if by == 0 then init else init|_range end | select((by > 0 and . < upto) or (by < 0 and . > upto)); range(0; 10; 3)
+def range(init; upto; by): def _range: if (by > 0 and . < upto) or (by < 0 and . > upto) then ., ((.+by)|_range) else empty end; if init == upto then empty elif by == 0 then init else init|_range end; range(0; 10; 3)
 null
 0
 3


### PR DESCRIPTION
Fixes #3222.
`jq 'def range(init; upto; by): def _range: if (by > 0 and . < upto) or (by < 0 and . > upto) then ., ((.+by)|_range) else . end; if by == 0 then init else init|_range end | select((by > 0 and . < upto) or (by < 0 and . > upto)); range(0; 10; 3)'`
Can be simplified and corrected to:
`jq 'def range(init; upto; by): def _range: if (by > 0 and . < upto) or (by < 0 and . > upto) then ., ((.+by)|_range) else empty end; if init == upto then empty elif by == 0 then init else init|_range end; range(0; 10; 3)'`