### PR TITLE
website: switch to custom domain jqlang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-- **Official Documentation**: [jqlang.github.io/jq](https://jqlang.github.io/jq)
+- **Official Documentation**: [jqlang.org](https://jqlang.org)
 - **Try jq Online**: [jqplay.org](https://jqplay.org)
 
 ## Installation

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([jq_version], m4_esyscmd_s([scripts/version])))
 
-AC_INIT([jq],[jq_version],[https://github.com/jqlang/jq/issues],[jq],[https://jqlang.github.io/jq])
+AC_INIT([jq],[jq_version],[https://github.com/jqlang/jq/issues],[jq],[https://jqlang.org])
 
 dnl Created autoconf implementation thompson@dtosolutions, 26NOV12
 AC_PREREQ([2.65])

--- a/docs/build_website.py
+++ b/docs/build_website.py
@@ -12,7 +12,7 @@ import shutil
 import yaml
 
 parser = argparse.ArgumentParser()
-parser.add_argument('--root', default='/jq')
+parser.add_argument('--root', default='')
 args = parser.parse_args()
 
 env = Environment(
@@ -26,7 +26,7 @@ def load_yml_file(fn):
         return yaml.safe_load(f)
 
 
-env.globals['url'] = 'https://jqlang.github.io/jq'
+env.globals['url'] = 'https://jqlang.org'
 env.globals['root'] = args.root
 
 env.filters['search_id'] = lambda input: input.replace(r'`', '')

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+jqlang.org

--- a/jq.spec
+++ b/jq.spec
@@ -5,7 +5,7 @@ Name: jq
 Version: %{myver}
 Release: %{myrel}%{?dist}
 Source0: jq-%{myver}.tar.gz
-URL: https://jqlang.github.io/jq
+URL: https://jqlang.org
 License: MIT AND ICU AND CC-BY-3.0
 AutoReqProv: no
 #BuildPrereq: autoconf, libtool, automake, flex, bison, python

--- a/libjq.pc.in
+++ b/libjq.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libjq
-URL: https://jqlang.github.io/jq/
+URL: https://jqlang.org/
 Description: Library to process JSON using a query language
 Version: @VERSION@
 Libs: -L${libdir} -ljq

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@ static void usage(int code, int keep_it_short) {
     "standard output.\n\n"
     "The simplest filter is ., which copies jq's input to its output\n"
     "unmodified except for formatting. For more advanced filters see\n"
-    "the jq(1) manpage (\"man jq\") and/or https://jqlang.github.io/jq/.\n\n"
+    "the jq(1) manpage (\"man jq\") and/or https://jqlang.org/.\n\n"
     "Example:\n\n\t$ echo '{\"foo\": 0}' | jq .\n"
     "\t{\n\t  \"foo\": 0\n\t}\n\n",
     JQ_VERSION, progname, progname, progname);
@@ -119,7 +119,7 @@ static void usage(int code, int keep_it_short) {
 
 static void die() {
   fprintf(stderr, "Use %s --help for help with command-line options,\n", progname);
-  fprintf(stderr, "or see the jq manpage, or online docs  at https://jqlang.github.io/jq\n");
+  fprintf(stderr, "or see the jq manpage, or online docs  at https://jqlang.org\n");
   exit(2);
 }
 


### PR DESCRIPTION
The web site is now live at https://jqlang.org/! Resolves #3219.
