### PR TITLE
website: remove unused root path on building website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,5 @@ the `Makefile` will be able to generate the jq manpage.  You can just run
 `make jq.1` to build the manpage manually, and `make tests/man.test` to
 update the manual tests.
 
-To build the website, run `pipenv run python3 build_website.py --root /output`
-in the `docs/` directory. To serve them locally, you can run
-`python3 -m http.server`.
+To build the website, run `pipenv run python3 build_website.py` in the `docs/` directory.
+To serve them locally, you can run `python3 -m http.server -d output`.

--- a/docs/build_website.py
+++ b/docs/build_website.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import glob
 import itertools
 from jinja2 import Environment, FileSystemLoader, select_autoescape, pass_context
@@ -10,10 +9,6 @@ import os.path
 import re
 import shutil
 import yaml
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--root', default='')
-args = parser.parse_args()
 
 env = Environment(
     loader=FileSystemLoader('templates'),
@@ -27,8 +22,6 @@ def load_yml_file(fn):
 
 
 env.globals['url'] = 'https://jqlang.org'
-env.globals['root'] = args.root
-
 env.filters['search_id'] = lambda input: input.replace(r'`', '')
 env.filters['section_id'] = lambda input: re.sub(
     r'[^-a-zA-Z0-9_]', '', input.replace(' ', '-')).lower()

--- a/docs/content/download/default.yml
+++ b/docs/content/download/default.yml
@@ -239,9 +239,9 @@ body:
       #### Building the documentation
 
       jq's documentation is compiled into static HTML using Python.
-      To build the docs, run `pipenv run python3 build_website.py --root /output`
+      To build the docs, run `pipenv run python3 build_website.py`
       in the `docs/` directory. To serve them locally, you can run
-      `python3 -m http.server`. You'll need a few Python dependencies,
+      `python3 -m http.server -d output`. You'll need a few Python dependencies,
       which can be installed by following the instructions in `docs/README.md`.
 
       The man page is built by `make jq.1`, or just `make`, also from

--- a/docs/templates/index.html.j2
+++ b/docs/templates/index.html.j2
@@ -8,7 +8,7 @@
     <main id="main" class="container-lg">
       <div class="row">
         <div class="col-md-6 text-center p-3">
-          <h1><img src="{{ root }}/jq.svg" class="img-fluid" alt="jq" width="400" height="220"></h1>
+          <h1><img src="/jq.svg" class="img-fluid" alt="jq" width="400" height="220"></h1>
         </div>
         <div class="col-md-6 d-flex flex-column justify-content-center text-center align-items-center">
           <h2 class="px-1" style="width:16em">{{ blurb }}</h2>
@@ -23,7 +23,7 @@
               <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-macos-amd64" aria-label="Link to download executable: macOS (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (AMD64)</a></li>
               <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-macos-arm64" aria-label="Link to download executable: macOS (ARM64)"><span class="bi bi-download me-2" aria-hidden="true"></span>macOS (ARM64)</a></li>
               <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-windows-amd64.exe" aria-label="Link to download executable: Windows (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>Windows (AMD64)</a></li>
-              <li><a class="dropdown-item" href="{{ root }}/download/">Other platforms, older versions, and source</a></li>
+              <li><a class="dropdown-item" href="/download/">Other platforms, older versions, and source</a></li>
             </ul>
             <a class="btn btn-primary text-nowrap" href="https://jqplay.org" target="_blank" rel="noopener">
               Try online at jqplay.org!<span class="bi bi-box-arrow-up-right ms-1" aria-hidden="true"></span>

--- a/docs/templates/manual.html.j2
+++ b/docs/templates/manual.html.j2
@@ -36,12 +36,12 @@
         <p>
           <em>
             For other versions, see
-            <a href="{{ root }}/manual/v1.7/">1.7</a>,
-            <a href="{{ root }}/manual/v1.6/">1.6</a>,
-            <a href="{{ root }}/manual/v1.5/">1.5</a>,
-            <a href="{{ root }}/manual/v1.4/">1.4</a>,
-            <a href="{{ root }}/manual/v1.3/">1.3</a> or
-            <a href="{{ root }}/manual/dev/">development version</a>.
+            <a href="/manual/v1.7/">1.7</a>,
+            <a href="/manual/v1.6/">1.6</a>,
+            <a href="/manual/v1.5/">1.5</a>,
+            <a href="/manual/v1.4/">1.4</a>,
+            <a href="/manual/v1.3/">1.3</a> or
+            <a href="/manual/dev/">development version</a>.
           </em>
         </p>
         {{ body | markdownify }}
@@ -115,6 +115,6 @@
         {%- endfor %}
       }
     </script>
-    <script src="{{ root }}/js/manual-search.js"></script>
+    <script src="/js/manual-search.js"></script>
   </body>
 </html>

--- a/docs/templates/shared/_head.html.j2
+++ b/docs/templates/shared/_head.html.j2
@@ -5,16 +5,16 @@
     <meta property="og:title" content="{{ headline }}">
     <meta property="og:description" content="jq is a lightweight and flexible command-line JSON processor">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="{{ url }}{{ root }}/icon.png">
+    <meta property="og:image" content="{{ url }}/icon.png">
     <meta property="og:url" content="{{ url }}/{{ permalink }}">
-    <link rel="icon" href="{{ root }}/icon.svg" type="image/svg+xml">
-    <link rel="apple-touch-icon" href="{{ root }}/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png" type="image/png">
     <link rel="canonical" href="{{ url }}/{{ permalink }}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.1/dist/cosmo/bootstrap.min.css"
       integrity="sha384-dulfW0vmzZ638jigSgZXvDxMmd70GCnIv6oa+riKq6Kk4E0MKf7qmBfwP02wltv5" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
       integrity="sha384-Ay26V7L8bsJTsX9Sxclnvsn+hkdiwRnrjZJXqKmkIDobPgIIWBOVguEcQQLDuhfN" crossorigin="anonymous">
-    <link rel="stylesheet" href="{{ root }}/css/style.css" type="text/css">
+    <link rel="stylesheet" href="/css/style.css" type="text/css">
     <script>
       (function() {
         function setTheme(mediaQuery) {

--- a/docs/templates/shared/_navbar.html.j2
+++ b/docs/templates/shared/_navbar.html.j2
@@ -10,16 +10,16 @@
           aria-controls="navbar-collapse" aria-expanded="false" aria-label="Toggle page navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
-        <a class="navbar-brand" href="{{ root }}/" aria-label="Top page"><img src="{{ root }}/jq.svg" alt="jq logo" style="height:1.5rem"></a>
+        <a class="navbar-brand" href="/" aria-label="Top page"><img src="/jq.svg" alt="jq logo" style="height:1.5rem"></a>
         <div id="navbar-collapse" class="offcanvas offcanvas-start navbar-collapse w-auto" aria-labelledby="navbar-title">
           <div class="offcanvas-header">
             <h3 id="navbar-title" class="me-3">jq</h3>
             <button type="button" class="d-md-none btn-close" data-bs-dismiss="offcanvas" aria-label="Close page navigation"></button>
           </div>
           <ul class="offcanvas-body navbar-nav me-auto text-nowrap">
-            <li class="nav-item d-md-none"><a class="nav-link{% if not navitem %} active{% endif %}"{% if not navitem %} aria-current="page"{% endif %} href="{{ root }}/">Top page</a></li>
+            <li class="nav-item d-md-none"><a class="nav-link{% if not navitem %} active{% endif %}"{% if not navitem %} aria-current="page"{% endif %} href="/">Top page</a></li>
             {%- for item in ['tutorial', 'download', 'manual'] %}
-            <li class="nav-item"><a class="nav-link{% if item == navitem %} active{% endif %}"{% if item == navitem %} aria-current="page"{% endif %} href="{{ root }}/{{ item }}/">{{ item | capitalize }}</a></li>
+            <li class="nav-item"><a class="nav-link{% if item == navitem %} active{% endif %}"{% if item == navitem %} aria-current="page"{% endif %} href="/{{ item }}/">{{ item | capitalize }}</a></li>
             {%- endfor %}
             <li class="nav-item"><a class="nav-link" href="https://github.com/jqlang/jq" target="_blank" rel="noopener">GitHub</a></li>
             <li class="nav-item"><a class="nav-link" href="https://github.com/jqlang/jq/issues" target="_blank" rel="noopener">Issues</a></li>


### PR DESCRIPTION
We no longer use the `--root` option of `build_website.py` since we have
moved to jqlang.org (from jqlang.github.io/jq where the root was `/jq`).
We don't need the option on local development either since `http.server`
has the `-d` option to specify the directory to serve from.
