### PR TITLE
Revert "Move closer to the standard autotools idiom. (#3187)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,7 @@ jq.1
 
 # Generated source
 src/builtin.inc
-src/config.h.in
-src/config.h
+src/config_opts.inc
 *.pc
 
 # Autotools junk
@@ -39,6 +38,8 @@ jq-*.zip
 configure
 aclocal.m4
 Makefile.in
+version.h
+.remake-version-h
 config.cache
 *.rpm
 m4/libtool.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,12 +34,12 @@ ACLOCAL_AMFLAGS = -I config/m4
 # header file creation so we'll use good old make
 if MAINTAINER_MODE
 BUILT_SOURCES = src/lexer.h src/lexer.c src/parser.h src/parser.c \
-                src/builtin.inc
+                src/builtin.inc src/config_opts.inc src/version.h
 src/lexer.c: src/lexer.l
 	$(AM_V_LEX) flex -o src/lexer.c --header-file=src/lexer.h $<
 src/lexer.h: src/lexer.c
 else
-BUILT_SOURCES = src/builtin.inc
+BUILT_SOURCES = src/builtin.inc src/config_opts.inc src/version.h
 .y.c:
 	$(AM_V_YACC) echo "NOT building parser.c!"
 .l.c:
@@ -101,6 +101,23 @@ endif
 
 ### Building the jq binary
 
+# Remake the version.h header file if, and only if, the git ID has changed
+.PHONY: .FORCE
+.FORCE:
+generate_ver = ver="`{ $(srcdir)/scripts/version || echo '$(VERSION)' ; } | sed 's/.*/\x23define JQ_VERSION \"&\"/'`"
+.remake-version-h: .FORCE
+	@ $(generate_ver); test "x`cat src/version.h 2>/dev/null`" = "x$$ver" || touch .remake-version-h
+src/version.h: .remake-version-h
+	mkdir -p src
+	$(AM_V_GEN) $(generate_ver); echo "$$ver" > $@
+src/config_opts.inc:
+	mkdir -p src
+	$(AM_V_GEN) if test -x ./config.status; then \
+	  ./config.status --config; \
+	else echo "(unknown)"; \
+	fi | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/"/' -e 's/^/#define JQ_CONFIG /' > $@
+src/main.c: src/version.h src/config_opts.inc
+
 src/builtin.inc: $(srcdir)/src/builtin.jq
 	mkdir -p src
 	$(AM_V_GEN) od -v -A n -t o1 -- $< | \
@@ -111,7 +128,7 @@ src/builtin.inc: $(srcdir)/src/builtin.jq
 	    -e 's/ \([123456789]\)/ 0\1/g' > $@
 src/builtin.o: src/builtin.inc
 
-CLEANFILES = src/builtin.inc
+CLEANFILES = src/version.h .remake-version-h src/builtin.inc src/config_opts.inc
 
 bin_PROGRAMS = jq
 jq_SOURCES = src/main.c
@@ -198,7 +215,8 @@ DOC_FILES = docs/content docs/public docs/templates                     \
 
 EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         jq.1.prebuilt jq.spec src/lexer.c src/lexer.h src/parser.c      \
-        src/parser.h src/builtin.jq scripts/version libjq.pc            \
+        src/parser.h src/version.h src/builtin.jq scripts/version       \
+        libjq.pc                                                        \
         tests/modules/a.jq tests/modules/b/b.jq tests/modules/c/c.jq    \
         tests/modules/c/d.jq tests/modules/data.json                    \
         tests/modules/home1/.jq tests/modules/home2/.jq/g.jq            \

--- a/configure.ac
+++ b/configure.ac
@@ -242,9 +242,6 @@ AC_C_BIGENDIAN(
    AC_MSG_ERROR(universal endianness not supported)
 )
 
-AC_DEFINE_UNQUOTED([JQ_CONFIG], ["$ac_cs_config"], [The options jq was configured with.])
-AH_BOTTOM([#define JQ_VERSION PACKAGE_VERSION])
-
 dnl Oniguruma
 AC_ARG_WITH([oniguruma],
    [AS_HELP_STRING([--with-oniguruma=prefix],
@@ -294,8 +291,6 @@ AM_CONDITIONAL([WITH_ONIGURUMA], [test "x$with_oniguruma" != xno])
 AC_SUBST([BUNDLER], ["$bundle_cmd"])
 
 AC_CONFIG_MACRO_DIRS([config/m4 m4])
-AC_CONFIG_HEADERS([src/config.h])
-CFLAGS="$CFLAGS --include src/config.h"
 AC_CONFIG_FILES([Makefile libjq.pc])
 AC_OUTPUT
 

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,8 @@ extern void jv_tsd_dtoa_ctx_init();
 #include "jq.h"
 #include "jv_alloc.h"
 #include "util.h"
+#include "src/version.h"
+#include "src/config_opts.inc"
 
 int jq_testsuite(jv lib_dirs, int verbose, int argc, char* argv[]);
 


### PR DESCRIPTION
This partially reverts commit d8463c25491b6150d748155ac530a3205d072e37.
Revert reason: version string should be updated more often.
