### PR TITLE
Include column number in parser and compiler error messages

### DIFF
--- a/src/locfile.c
+++ b/src/locfile.c
@@ -82,8 +82,9 @@ void locfile_locate(struct locfile* l, location loc, const char* fmt, ...) {
     jv_free(m1);
     return;
   }
-  jv m2 = jv_string_fmt("%s at %s, line %d:\n%.*s%*s", jv_string_value(m1),
-                        jv_string_value(l->fname), startline + 1,
+  jv m2 = jv_string_fmt("%s at %s, line %d, column %d:\n%.*s%*s",
+                        jv_string_value(m1), jv_string_value(l->fname),
+                        startline + 1, loc.start - offset + 1,
                         locfile_line_length(l, startline), l->data + offset,
                         loc.start - offset, "");
   jv_free(m1);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -117,11 +117,11 @@ null
 
 %%FAIL
 {(0):1}
-jq: error: Cannot use number (0) as object key at <top-level>, line 1:
+jq: error: Cannot use number (0) as object key at <top-level>, line 1, column 2:
 
 %%FAIL
 {non_const:., (0):1}
-jq: error: Cannot use number (0) as object key at <top-level>, line 1:
+jq: error: Cannot use number (0) as object key at <top-level>, line 1, column 15:
 
 #
 # Field access, piping
@@ -300,7 +300,7 @@ null
 
 %%FAIL
 . as $foo | break $foo
-jq: error: $*label-foo is not defined at <top-level>, line 1:
+jq: error: $*label-foo is not defined at <top-level>, line 1, column 13:
 
 [.[]|[.,1]|until(.[0] < 1; [.[0] - 1, .[1] * .[0]])|.[1]]
 [1,2,3,4,5]
@@ -506,11 +506,11 @@ null
 
 %%FAIL IGNORE MSG
 . as [] | null
-jq: error: syntax error, unexpected ']', expecting '$' or '[' or '{' (Unix shell quoting issues?) at <top-level>, line 1:
+jq: error: syntax error, unexpected ']', expecting '$' or '[' or '{' (Unix shell quoting issues?) at <top-level>, line 1, column 7:
 
 %%FAIL IGNORE MSG
 . as {} | null
-jq: error: syntax error, unexpected '}' (Unix shell quoting issues?) at <top-level>, line 1:
+jq: error: syntax error, unexpected '}' (Unix shell quoting issues?) at <top-level>, line 1, column 7:
 
 # [.,(.[] | {x:.},.),.,.[]]
 
@@ -1738,27 +1738,27 @@ null
 
 %%FAIL
 module (.+1); 0
-jq: error: Module metadata must be constant at <top-level>, line 1:
+jq: error: Module metadata must be constant at <top-level>, line 1, column 1:
 
 %%FAIL
 module []; 0
-jq: error: Module metadata must be an object at <top-level>, line 1:
+jq: error: Module metadata must be an object at <top-level>, line 1, column 1:
 
 %%FAIL
 include "a" (.+1); 0
-jq: error: Module metadata must be constant at <top-level>, line 1:
+jq: error: Module metadata must be constant at <top-level>, line 1, column 1:
 
 %%FAIL
 include "a" []; 0
-jq: error: Module metadata must be an object at <top-level>, line 1:
+jq: error: Module metadata must be an object at <top-level>, line 1, column 1:
 
 %%FAIL
 include "\ "; 0
-jq: error: Invalid escape at line 1, column 4 (while parsing '"\ "') at <top-level>, line 1:
+jq: error: Invalid escape at line 1, column 4 (while parsing '"\ "') at <top-level>, line 1, column 10:
 
 %%FAIL
 include "\(a)"; 0
-jq: error: Import path must be constant at <top-level>, line 1:
+jq: error: Import path must be constant at <top-level>, line 1, column 9:
 
 modulemeta
 "c"
@@ -1774,11 +1774,11 @@ modulemeta | .defs | length
 
 %%FAIL IGNORE MSG
 import "syntaxerror" as e; .
-jq: error: syntax error, unexpected ';', expecting $end (Unix shell quoting issues?) at /home/nico/ws/jq/tests/modules/syntaxerror/syntaxerror.jq, line 1:
+jq: error: syntax error, unexpected ';', expecting $end (Unix shell quoting issues?) at /home/nico/ws/jq/tests/modules/syntaxerror/syntaxerror.jq, line 1, column 8:
 
 %%FAIL IGNORE MSG
 %::wat
-jq: error: syntax error, unexpected '%', expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
+jq: error: syntax error, unexpected '%', expecting $end (Unix shell quoting issues?) at <top-level>, line 1, column 1:
 
 import "test_bind_order" as check; check::check
 null
@@ -1846,7 +1846,7 @@ null
 
 %%FAIL IGNORE MSG
 }
-jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
+jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1, column 1:
 
 (.[{}] = 0)?
 null


### PR DESCRIPTION
Suggestion for issue:
https://github.com/jqlang/jq/issues/3256

Open for improvements :)

Resolves #1027, resolves #2334, and resolves #3256.