### PR TITLE
Update builtin oniguruma to 6.9.10 to suppress clang warnings

### DIFF
--- a/compile-ios.sh
+++ b/compile-ios.sh
@@ -3,7 +3,7 @@
 
 # Defaults
 set -e
-oniguruma='6.9.3'
+oniguruma='6.9.10'
 
 unset CFLAGS
 unset CXXFLAGS


### PR DESCRIPTION
The builtin oniguruma is a bit outdated and we get some compiler warnings with clang.
