### PR TITLE
Disable shared libraries on macOS to avoid conflict with -all-static

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
             --disable-docs \
             --disable-valgrind \
             --with-oniguruma=builtin \
+            --disable-shared \
             --enable-static \
             --enable-all-static \
             CFLAGS="-O2 -pthread -fstack-protector-all"


### PR DESCRIPTION
After merging #3212, libtool warns that complete static linking is impossible
in this configuration on macOS. We are not interested in building shared
libraries on macOS, so I disabled on CI to suppress the warning (it is disabled
already on Windows). I also noticed that `--enable-static` on macOS is no-op
because macOS does not provide static system libraries. But I left it as it is
for consistency.
