### PR TITLE
Replace jqplay.org with play.jqlang.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Documentation
 
 - **Official Documentation**: [jqlang.org](https://jqlang.org)
-- **Try jq Online**: [jqplay.org](https://jqplay.org)
+- **Try jq Online**: [play.jqlang.org](https://play.jqlang.org)
 
 ## Installation
 
@@ -17,13 +17,16 @@ Download the latest releases from the [GitHub release page](https://github.com/j
 
 Pull the [jq image](https://github.com/jqlang/jq/pkgs/container/jq) to start quickly with Docker.
 
-
 #### Run with Docker
+
 ##### Example: Extracting the version from a `package.json` file
+
 ```bash
 docker run --rm -i ghcr.io/jqlang/jq:latest < package.json '.version'
 ```
+
 ##### Example: Extracting the version from a `package.json` file with a mounted volume
+
 ```bash
 docker run --rm -i -v "$PWD:$PWD" -w "$PWD" ghcr.io/jqlang/jq:latest '.version' package.json
 ```

--- a/docs/templates/index.html.j2
+++ b/docs/templates/index.html.j2
@@ -25,8 +25,8 @@
               <li><a class="dropdown-item" href="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-windows-amd64.exe" aria-label="Link to download executable: Windows (AMD64)"><span class="bi bi-download me-2" aria-hidden="true"></span>Windows (AMD64)</a></li>
               <li><a class="dropdown-item" href="/download/">Other platforms, older versions, and source</a></li>
             </ul>
-            <a class="btn btn-primary text-nowrap" href="https://jqplay.org" target="_blank" rel="noopener">
-              Try online at jqplay.org!<span class="bi bi-box-arrow-up-right ms-1" aria-hidden="true"></span>
+            <a class="btn btn-primary text-nowrap" href="https://play.jqlang.org" rel="noopener">
+              Try online!
             </a>
           </div>
         </div>

--- a/docs/templates/manual.html.j2
+++ b/docs/templates/manual.html.j2
@@ -86,7 +86,7 @@
                   </tr>
                   {%- endfor %}
                   <tr class="d-print-none">
-                    <th><a href="https://jqplay.org/?q={{ example.program | urlencode }}&j={{ example.input | urlencode }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">Run<span class="bi bi-box-arrow-up-right ms-2" aria-hidden="true"></span></a></th>
+                    <th><a href="https://play.jqlang.org/?q={{ example.program | urlencode }}&j={{ example.input | urlencode }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">Run<span class="bi bi-box-arrow-up-right ms-2" aria-hidden="true"></span></a></th>
                     <td></td>
                   </tr>
                 </table>

--- a/docs/templates/shared/_navbar.html.j2
+++ b/docs/templates/shared/_navbar.html.j2
@@ -23,7 +23,7 @@
             {%- endfor %}
             <li class="nav-item"><a class="nav-link" href="https://github.com/jqlang/jq" target="_blank" rel="noopener">GitHub</a></li>
             <li class="nav-item"><a class="nav-link" href="https://github.com/jqlang/jq/issues" target="_blank" rel="noopener">Issues</a></li>
-            <li class="nav-item"><a class="nav-link" href="https://jqplay.org" target="_blank" rel="noopener">Try online!</a></li>
+            <li class="nav-item"><a class="nav-link" href="https://play.jqlang.org" rel="noopener">Try online!</a></li>
             <li class="nav-item"><a class="nav-link" href="https://raw.githubusercontent.com/jqlang/jq/master/NEWS.md" target="_blank" rel="noopener">News</a></li>
           </ul>
         </div>


### PR DESCRIPTION
As discussed in [GitHub Discussion #3244](https://github.com/jqlang/jq/discussions/3244), we are migrating jqplay to the jqlang GitHub organization. This PR updates all references from `jqplay.org` to `play.jqlang.org` to reflect the new official domain.

For continuity, all `jqplay.org/*` requests are already configured to redirect to `play.jqlang.org` and will remain so for the foreseeable future.