### PR TITLE
Enable dependabot PR to update Pipenv dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+  - package-ecosystem: "pip"
+    directory: "docs/"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Since we use Pipenv to manage docs dependencies, we should update regularly. I'm currently seeing some trouble with the outdated lxml that fails to compile with clang 19.