### PR TITLE
Define `_BSD_SOURCE` in builtin.c for OpenBSD support

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -5,6 +5,9 @@
 # define _XPG6
 # define __EXTENSIONS__
 #endif
+#ifdef __OpenBSD__
+# define _BSD_SOURCE
+#endif
 #include <sys/time.h>
 #include <stdlib.h>
 #include <stddef.h>

--- a/tests/optional.test
+++ b/tests/optional.test
@@ -12,6 +12,11 @@ last(range(365 * 67)|("1970-03-01T01:02:03Z"|strptime("%Y-%m-%dT%H:%M:%SZ")|mkti
 null
 [2037,1,11,1,2,3,3,41]
 
+# Regression test for #3276
+fromdate
+"2038-01-19T03:14:08Z"
+2147483648
+
 # %e is not available on mingw/WIN32
 strftime("%A, %B %e, %Y")
 1435677542.822351


### PR DESCRIPTION
On OpenBSD, some prototypes are hidden behind `_BSD_SOURCE`.
Defining this variable fixes #3252, and also fixes #3276.
This can be seen as a regression of #2631.
