### PR TITLE
Fix behavior of `--slurp --stream` when input has no trailing newline character

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -155,6 +155,13 @@ cmp $d/out $d/expected
 printf "[1,2][3,4]\n" | $JQ -cs add > $d/out 2>&1
 cmp $d/out $d/expected
 
+# Regression test for #3273
+echo "[[[0],1],[[0]],[[0],2],[[0]]]" > $d/expected
+printf "[1][2]" | $JQ -c -s --stream . > $d/out 2>&1
+cmp $d/out $d/expected
+printf "[1][2]\n" | $JQ -c -s --stream . > $d/out 2>&1
+cmp $d/out $d/expected
+
 # Regression test for --raw-output0
 printf "a\0b\0" > $d/expected
 printf '["a", "b"]' | $VALGRIND $Q $JQ --raw-output0 '.[]' > $d/out


### PR DESCRIPTION
This commit fixes a strange behavior of the combination of `--slurp` and
`--stream` flags when the input has no trailing newline character.
This fixes #3273.
