### PR TITLE
Fix calloc error on `@base64d` format (ref #3280)

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -734,11 +734,7 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
     input = f_tostring(jq, input);
     const unsigned char* data = (const unsigned char*)jv_string_value(input);
     int len = jv_string_length_bytes(jv_copy(input));
-    if (len == 0) {
-      jv_free(input);
-      return jv_string("");
-    }
-    size_t decoded_len = (3 * (size_t)len) / 4; // 3 usable bytes for every 4 bytes of input
+    size_t decoded_len = MAX((3 * (size_t)len) / 4, 1); // 3 usable bytes for every 4 bytes of input
     char *result = jv_mem_calloc(decoded_len, sizeof(char));
     uint32_t ri = 0;
     int input_bytes_read=0;

--- a/src/compile.c
+++ b/src/compile.c
@@ -6,6 +6,7 @@
 #include "bytecode.h"
 #include "locfile.h"
 #include "jv_alloc.h"
+#include "util.h"
 
 /*
   The intermediate representation for jq filters is as a sequence of
@@ -1352,7 +1353,7 @@ int block_compile(block b, struct bytecode** out, struct locfile* lf, jv args) {
   bc->globals = jv_mem_alloc(sizeof(struct symbol_table));
   int ncfunc = count_cfunctions(b);
   bc->globals->ncfunctions = 0;
-  bc->globals->cfunctions = jv_mem_calloc(ncfunc ? ncfunc : 1, sizeof(struct cfunction));
+  bc->globals->cfunctions = jv_mem_calloc(MAX(ncfunc, 1), sizeof(struct cfunction));
   bc->globals->cfunc_names = jv_array();
   bc->debuginfo = jv_object_set(jv_object(), jv_string("name"), jv_null());
   jv env = jv_invalid();

--- a/tests/base64.test
+++ b/tests/base64.test
@@ -24,6 +24,10 @@
 ""
 
 @base64d
+"="
+""
+
+@base64d
 "Zm/Ds2Jhcgo="
 "foóbar\n"
 


### PR DESCRIPTION
This commit fixes a regression of a8ce2ff, e.g. `"=" | @base64d`.
