### PR TITLE
Support true color when setting colors from JQ_COLORS

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -480,6 +480,30 @@ JQ_COLORS='0;30:0;31:0;32:0;33:0;34:1;35:1;36:1;37' \
 } > $d/expect
 cmp $d/color $d/expect
 
+## Set non-default colors only for literals, complex input
+JQ_COLORS='0;37:0;31:0;35:0;34:0;36' \
+  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color
+{
+  printf '\033[1;39m[\033[0m'
+  printf '\033[1;39m{\033[0m'
+  printf '\033[1;34m"a"\033[0m'
+  printf '\033[1;39m:\033[0m'
+  printf '\033[0;35mtrue\033[0m'
+  printf '\033[1;39m,\033[0m'
+  printf '\033[1;34m"b"\033[0m'
+  printf '\033[1;39m:\033[0m'
+  printf '\033[0;31mfalse\033[0m'
+  printf '\033[1;39m}\033[0m'
+  printf '\033[1;39m,\033[0m'
+  printf '\033[0;36m"abc"\033[0m'
+  printf '\033[1;39m,\033[0m'
+  printf '\033[0;34m123\033[0m'
+  printf '\033[1;39m,\033[0m'
+  printf '\033[0;37mnull\033[0m'
+  printf '\033[1;39m]\033[0m\n'
+} > $d/expect
+cmp $d/color $d/expect
+
 ## Default colors, complex input, indented
 $JQ -Cn '[{"a":true,"b":false},"abc",123,null]' > $d/color
 {
@@ -527,33 +551,41 @@ JQ_COLORS='0;30:0;31:0;32:0;33:0;34:1;35:1;36:1;37' \
 } > $d/expect
 cmp $d/color $d/expect
 
-# Check garbage in JQ_COLORS.  We write each color sequence into a 16
-# char buffer that needs to hold ESC [ <color> m NUL, so each color
-# sequence can be no more than 12 chars (bytes).  These emit a warning
-# on stderr.
-set -vx
+## Set true color, complex input, indented
+JQ_COLORS=$(printf '38;2;%s:' \
+  '255;173;173' '255;214;165' '253;255;182' '202;255;191' \
+  '155;246;255' '160;196;255' '189;178;255' '255;198;255') \
+  $JQ -Cn '[{"a":true,"b":false},"abc",123,null]' > $d/color
+{
+  printf '\033[38;2;160;196;255m[\033[0m\n'
+  printf '  \033[38;2;189;178;255m{\033[0m\n'
+  printf '    \033[38;2;255;198;255m"a"\033[0m'
+  printf '\033[38;2;189;178;255m:\033[0m '
+  printf '\033[38;2;253;255;182mtrue\033[0m'
+  printf '\033[38;2;189;178;255m,\033[0m\n'
+  printf '    \033[38;2;255;198;255m"b"\033[0m'
+  printf '\033[38;2;189;178;255m:\033[0m '
+  printf '\033[38;2;255;214;165mfalse\033[0m\n'
+  printf '  \033[38;2;189;178;255m}\033[0m'
+  printf '\033[38;2;160;196;255m,\033[0m\n'
+  printf '  \033[38;2;155;246;255m"abc"\033[0m'
+  printf '\033[38;2;160;196;255m,\033[0m\n'
+  printf '  \033[38;2;202;255;191m123\033[0m'
+  printf '\033[38;2;160;196;255m,\033[0m\n'
+  printf '  \033[38;2;255;173;173mnull\033[0m\n'
+  printf '\033[38;2;160;196;255m]\033[0m\n'
+} > $d/expect
+cmp $d/color $d/expect
+
+# Check invalid JQ_COLORS
 echo 'Failed to set $JQ_COLORS' > $d/expect_warning
 $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/expect
-JQ_COLORS='garbage;30:*;31:,;3^:0;$%:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
-cmp $d/color $d/expect
-cmp $d/warning $d/expect_warning
-JQ_COLORS='1234567890123456789;30:0;31:0;32:0;33:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
-cmp $d/color $d/expect
-cmp $d/warning $d/expect_warning
-JQ_COLORS='1;31234567890123456789:0;31:0;32:0;33:0;34:1;35:1;36' \
-  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
-cmp $d/color $d/expect
-cmp $d/warning $d/expect_warning
-JQ_COLORS='1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456:1234567890123456;1234567890123456' \
-  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
-cmp $d/color $d/expect
-cmp $d/warning $d/expect_warning
-JQ_COLORS="0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:0123456789123:" \
-  $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
-cmp $d/color $d/expect
-cmp $d/warning $d/expect_warning
+for colors in '/' '[30' '30m' '30:31m:32' '30:*:31' 'invalid'; do
+  JQ_COLORS=$colors \
+    $JQ -Ccn '[{"a":true,"b":false},"abc",123,null]' > $d/color 2>$d/warning
+  cmp $d/color $d/expect
+  cmp $d/warning $d/expect_warning
+done
 
 # Check $NO_COLOR
 test_no_color=true


### PR DESCRIPTION
The buffers for colors were fixed-size and we cannot use longer color
definitions like true color, e.g. `JQ_COLORS='38;2;135;200;250'`, or
both foreground and background colors, e.g. `JQ_COLORS='38;5;81;48;5;19'`.
This commit fixes the implementation to support longer color definitions
by allocating the buffers dynamically. This resolves #2426.
