### PR TITLE
jv_unique: don't leak non-unique elements that are not returned

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -749,6 +749,7 @@ jv jv_unique(jv objects, jv keys) {
   for (int i = 0; i < n; i++) {
     if (jv_equal(jv_copy(curr_key), jv_copy(entries[i].key))) {
       jv_free(entries[i].key);
+      jv_free(entries[i].object);
     } else {
       jv_free(curr_key);
       curr_key = entries[i].key;


### PR DESCRIPTION
    $ ./jq -- 'unique_by(length)' <<< '[1,[2],3]'
    [
      1,
      3
    ]

    =================================================================
    ==32494==ERROR: LeakSanitizer: detected memory leaks

    Direct leak of 272 byte(s) in 1 object(s) allocated from:
        #0 0x7fd864955207 in malloc /usr/src/debug/sys-devel/gcc-14.2.1_p20241221/gcc-14-20241221/libsanitizer/asan/asan_malloc_linux.cpp:69
        #1 0x7fd86458894c in jv_mem_alloc src/jv_alloc.c:142

    Indirect leak of 42 byte(s) in 1 object(s) allocated from:
        #0 0x7fd864955207 in malloc /usr/src/debug/sys-devel/gcc-14.2.1_p20241221/gcc-14-20241221/libsanitizer/asan/asan_malloc_linux.cpp:69
        #1 0x7fd86458894c in jv_mem_alloc src/jv_alloc.c:142

    SUMMARY: AddressSanitizer: 314 byte(s) leaked in 2 allocation(s).

fixup from 95ee663b284550aab25b244d7c352738458bd8cd

Fixes https://issues.oss-fuzz.com/issues/400741251
