### PR TITLE
Add ssv output format

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2151,9 +2151,15 @@ sections:
 
           * `@csv`:
 
-            The input must be an array, and it is rendered as CSV
-            with double quotes for strings, and quotes escaped by
-            repetition.
+            The input must be an array, and it is rendered as comma 
+            separated CSV with double quotes for strings, and quotes 
+            escaped by repetition.
+
+          * `@ssv`:
+
+            The input must be an array, and it is rendered as semicolon
+            separated CSV with double quotes for strings, and quotes 
+            escaped by repetition.
 
           * `@tsv`:
 

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2155,7 +2155,7 @@ sections:
             separated CSV with double quotes for strings, and quotes 
             escaped by repetition.
 
-          * `@ssv`:
+          * `@scsv`:
 
             The input must be an array, and it is rendered as semicolon
             separated CSV with double quotes for strings, and quotes 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -2340,7 +2340,13 @@ The inverse of \fB@uri\fR, applies percent\-decoding, by mapping all \fB%XX\fR s
 \fB@csv\fR:
 .
 .IP
-The input must be an array, and it is rendered as CSV with double quotes for strings, and quotes escaped by repetition\.
+The input must be an array, and it is rendered as comma separated CSV with double quotes for strings, and quotes escaped by repetition\.
+.
+.TP
+\fB@ssv\fR:
+.
+.IP
+The input must be an array, and it is rendered as semicolon separated CSV with double quotes for strings, and quotes escaped by repetition\.
 .
 .TP
 \fB@tsv\fR:

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -558,7 +558,7 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
   } else if (!strcmp(fmt_s, "text")) {
     jv_free(fmt);
     return f_tostring(jq, input);
-  } else if (!strcmp(fmt_s, "csv") || !strcmp(fmt_s, "ssv") || !strcmp(fmt_s, "tsv")) {
+  } else if (!strcmp(fmt_s, "csv") || !strcmp(fmt_s, "scsv") || !strcmp(fmt_s, "tsv")) {
     const char *quotes, *sep, *escapings;
     const char *msg;
     if (!strcmp(fmt_s, "csv")) {
@@ -566,8 +566,8 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
       quotes = "\"";
       sep = ",";
       escapings = "\"\"\"\0";
-    } else if (!strcmp(fmt_s, "ssv")) {
-      msg = "cannot be ssv-formatted, only array";
+    } else if (!strcmp(fmt_s, "scsv")) {
+      msg = "cannot be scsv-formatted, only array";
       quotes = "\"";
       sep = ";";
       escapings = "\"\"\"\0";

--- a/src/builtin.c
+++ b/src/builtin.c
@@ -558,13 +558,18 @@ static jv f_format(jq_state *jq, jv input, jv fmt) {
   } else if (!strcmp(fmt_s, "text")) {
     jv_free(fmt);
     return f_tostring(jq, input);
-  } else if (!strcmp(fmt_s, "csv") || !strcmp(fmt_s, "tsv")) {
+  } else if (!strcmp(fmt_s, "csv") || !strcmp(fmt_s, "ssv") || !strcmp(fmt_s, "tsv")) {
     const char *quotes, *sep, *escapings;
     const char *msg;
     if (!strcmp(fmt_s, "csv")) {
       msg = "cannot be csv-formatted, only array";
       quotes = "\"";
       sep = ",";
+      escapings = "\"\"\"\0";
+    } else if (!strcmp(fmt_s, "ssv")) {
+      msg = "cannot be ssv-formatted, only array";
+      quotes = "\"";
+      sep = ";";
       escapings = "\"\"\"\0";
     } else {
       msg = "cannot be tsv-formatted, only array";

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -61,11 +61,12 @@ null
 null
 "interpolation"
 
-@text,@json,([1,.]|@csv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d)
+@text,@json,([1,.]|@csv,@ssv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d)
 "!()<>&'\"\t"
 "!()<>&'\"\t"
 "\"!()<>&'\\\"\\t\""
 "1,\"!()<>&'\"\"\t\""
+"1;\"!()<>&'\"\"\t\""
 "1\t!()<>&'\"\\t"
 "!()&lt;&gt;&amp;&apos;&quot;\t"
 "%21%28%29%3C%3E%26%27%22%09"

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -61,7 +61,7 @@ null
 null
 "interpolation"
 
-@text,@json,([1,.]|@csv,@ssv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d)
+@text,@json,([1,.]|@csv,@scsv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d)
 "!()<>&'\"\t"
 "!()<>&'\"\t"
 "\"!()<>&'\\\"\\t\""


### PR DESCRIPTION
Currently jq supports output in CSV format, however in many parts of Europe the CSV format is in fact semicolon and not comma separated. So I've added a small patch that adds support for semicolon separated CSV files (SSV) while also clarified in the doc and man page that the CSV version is the comma separated one.