### PR TITLE
docs: Use a better input example in the streaming section

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3384,8 +3384,8 @@ sections:
 
       Several builtins are provided to make handling streams easier.
 
-      The examples below use the streamed form of `[0,[1]]`, which is
-      `[[0],0],[[1,0],1],[[1,0]],[[1]]`.
+      The examples below use the streamed form of `[1,[2]]`, which is
+      `[[0],1],[[1,0],2],[[1,0]],[[1]]`.
 
       Streaming forms include `[<path>, <leaf-value>]` (to indicate any
       scalar value, empty array, or empty object), and `[<path>]` (to

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3384,8 +3384,8 @@ sections:
 
       Several builtins are provided to make handling streams easier.
 
-      The examples below use the streamed form of `[1,[2]]`, which is
-      `[[0],1],[[1,0],2],[[1,0]],[[1]]`.
+      The examples below use the streamed form of `["a",["b"]]`, which is
+      `[[0],"a"],[[1,0],"b"],[[1,0]],[[1]]`.
 
       Streaming forms include `[<path>, <leaf-value>]` (to indicate any
       scalar value, empty array, or empty object), and `[<path>]` (to
@@ -3402,9 +3402,9 @@ sections:
           given streaming expression.
 
         examples:
-          - program: 'truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])'
+          - program: 'truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]])'
             input: '1'
-            output: ['[[0],2]', '[[0]]']
+            output: ['[[0],"b"]', '[[0]]']
 
       - title: "`fromstream(stream_expression)`"
         body: |
@@ -3413,9 +3413,9 @@ sections:
           outputs.
 
         examples:
-          - program: 'fromstream(1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]]))'
+          - program: 'fromstream(1|truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]]))'
             input: 'null'
-            output: ['[2]']
+            output: ['["b"]']
 
       - title: "`tostream`"
         body: |

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -3317,8 +3317,8 @@ sections:
 
       Several builtins are provided to make handling streams easier.
 
-      The examples below use the streamed form of `[0,[1]]`, which is
-      `[[0],0],[[1,0],1],[[1,0]],[[1]]`.
+      The examples below use the streamed form of `[1,[2]]`, which is
+      `[[0],1],[[1,0],2],[[1,0]],[[1]]`.
 
       Streaming forms include `[<path>, <leaf-value>]` (to indicate any
       scalar value, empty array, or empty object), and `[<path>]` (to

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -3317,8 +3317,8 @@ sections:
 
       Several builtins are provided to make handling streams easier.
 
-      The examples below use the streamed form of `[1,[2]]`, which is
-      `[[0],1],[[1,0],2],[[1,0]],[[1]]`.
+      The examples below use the streamed form of `["a",["b"]]`, which is
+      `[[0],"a"],[[1,0],"b"],[[1,0]],[[1]]`.
 
       Streaming forms include `[<path>, <leaf-value>]` (to indicate any
       scalar value, empty array, or empty object), and `[<path>]` (to
@@ -3335,9 +3335,9 @@ sections:
           given streaming expression.
 
         examples:
-          - program: "truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])"
+          - program: 'truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]])'
             input: "1"
-            output: ["[[0],2]", "[[0]]"]
+            output: ['[[0],"b"]', '[[0]]']
 
       - title: "`fromstream(stream_expression)`"
         body: |
@@ -3346,9 +3346,9 @@ sections:
           outputs.
 
         examples:
-          - program: "fromstream(1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]]))"
+          - program: 'fromstream(1|truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]]))'
             input: "null"
-            output: ["[2]"]
+            output: ['["b"]']
 
       - title: "`tostream`"
         body: |

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3791,7 +3791,7 @@ However, streaming isn\'t easy to deal with as the jq program will have \fB[<pat
 Several builtins are provided to make handling streams easier\.
 .
 .P
-The examples below use the streamed form of \fB[1,[2]]\fR, which is \fB[[0],1],[[1,0],2],[[1,0]],[[1]]\fR\.
+The examples below use the streamed form of \fB["a",["b"]]\fR, which is \fB[[0],"a"],[[1,0],"b"],[[1,0]],[[1]]\fR\.
 .
 .P
 Streaming forms include \fB[<path>, <leaf\-value>]\fR (to indicate any scalar value, empty array, or empty object), and \fB[<path>]\fR (to indicate the end of an array or object)\. Future versions of jq run with \fB\-\-stream\fR and \fB\-\-seq\fR may output additional forms such as \fB["error message"]\fR when an input text fails to parse\.
@@ -3803,9 +3803,9 @@ Consumes a number as input and truncates the corresponding number of path elemen
 .
 .nf
 
-jq \'truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])\'
+jq \'truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]])\'
    1
-=> [[0],2], [[0]]
+=> [[0],"b"], [[0]]
 .
 .fi
 .
@@ -3818,9 +3818,9 @@ Outputs values corresponding to the stream expression\'s outputs\.
 .
 .nf
 
-jq \'fromstream(1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]]))\'
+jq \'fromstream(1|truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]]))\'
    null
-=> [2]
+=> ["b"]
 .
 .fi
 .

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "January 2025" "" ""
+.TH "JQ" "1" "May 2025" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -3791,7 +3791,7 @@ However, streaming isn\'t easy to deal with as the jq program will have \fB[<pat
 Several builtins are provided to make handling streams easier\.
 .
 .P
-The examples below use the streamed form of \fB[0,[1]]\fR, which is \fB[[0],0],[[1,0],1],[[1,0]],[[1]]\fR\.
+The examples below use the streamed form of \fB[1,[2]]\fR, which is \fB[[0],1],[[1,0],2],[[1,0]],[[1]]\fR\.
 .
 .P
 Streaming forms include \fB[<path>, <leaf\-value>]\fR (to indicate any scalar value, empty array, or empty object), and \fB[<path>]\fR (to indicate the end of an array or object)\. Future versions of jq run with \fB\-\-stream\fR and \fB\-\-seq\fR may output additional forms such as \fB["error message"]\fR when an input text fails to parse\.

--- a/tests/man.test
+++ b/tests/man.test
@@ -942,14 +942,14 @@ def while(cond; update): def _while: if cond then ., (update | _while) else empt
 1
 [1,2,4,8,16,32,64]
 
-truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]])
+truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]])
 1
-[[0],2]
+[[0],"b"]
 [[0]]
 
-fromstream(1|truncate_stream([[0],1],[[1,0],2],[[1,0]],[[1]]))
+fromstream(1|truncate_stream([[0],"a"],[[1,0],"b"],[[1,0]],[[1]]))
 null
-[2]
+["b"]
 
 . as $dot|fromstream($dot|tostream)|.==$dot
 [0,[1,{"a":1},{"b":2}]]


### PR DESCRIPTION
["a",["b"]] seems better than [1,[2]] as the string values won't be
confusable with the indexes in <path>.

Suggested by itchyny <itchyny@cybozu.co.jp> in review commentary.¹

¹ <https://github.com/jqlang/jq/pull/3317#issuecomment-2870889151>

-----

Closes #3317.