### PR TITLE
Test daylight time for strflocaltime

### DIFF
--- a/tests/shtest
+++ b/tests/shtest
@@ -728,6 +728,12 @@ if ! $msys && ! $mingw; then
     exit 1
   fi
 
+  if ! r=$(TZ=Europe/Paris $JQ -rn '1750500000 | strflocaltime("%F %T %z %Z")') \
+    || [ "$r" != "2025-06-21 12:00:00 +0200 CEST" ]; then
+    echo "Incorrectly formatted local time"
+    exit 1
+  fi
+
   if ! r=$(TZ=Europe/Paris $JQ -rn '1731627341 | strftime("%F %T %z %Z")') \
     || ( [ "$r" != "2024-11-14 23:35:41 +0000 UTC" ] \
       && [ "$r" != "2024-11-14 23:35:41 +0000 GMT" ] ); then

--- a/tests/shtest
+++ b/tests/shtest
@@ -728,6 +728,7 @@ if ! $msys && ! $mingw; then
     exit 1
   fi
 
+  # Test when DST is in effect: #1912
   if ! r=$(TZ=Europe/Paris $JQ -rn '1750500000 | strflocaltime("%F %T %z %Z")') \
     || [ "$r" != "2025-06-21 12:00:00 +0200 CEST" ]; then
     echo "Incorrectly formatted local time"


### PR DESCRIPTION
Add a test using a time and zone where DST is in effect to confirm the offset and zone name are as expected. The other tests happen to use times when DST is not in effect.

This test would fail in the current release version (jq-1.7.1) but passes since PR #3203 fixed this and other datetime-related issues. This test case covers the behavior described in issue #1912 . 