### PR TITLE
Fix and refactor scan-build workflow to run on the master branch

### DIFF
--- a/.github/workflows/scanbuild.yml
+++ b/.github/workflows/scanbuild.yml
@@ -1,75 +1,47 @@
-name: Linux Clang scan-build Static Analyzer Build
+name: Clang scan-build Static Analyzer Build
 
 on:
-    # Don't do this for PRs.  It eats up minutes.
-    push:
-      branches:
-         - 'master'
-         - 'scan-build'
-      paths:
-         - '.github/workflows/scanbuild.yml'
+  push:
+    branches:
+      - master
 
 jobs:
-    unix:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                name: [linux-clang]
-                include:
-                    - name: linux-clang
-                      os: ubuntu-latest
-                      compiler: clang
-                      cflags: ''
-        steps:
-            - name: Clone repository
-              uses: actions/checkout@v4
-            - name: Open Submodule(s)
-              run: |
-                git submodule update --init --recursive
-            - name: Install packages
-              if: startsWith(matrix.os, 'ubuntu')
-              run: |
-                sudo apt-get update -qq
-                sudo apt-get install -y automake autoconf bison flex gdb python3 valgrind clang-tools
-            - name: Prep
-              run: |
-                #pyenv global 3.6.7
-                #pip3 install pipenv
-                #(cd docs && pipenv sync)
-                #if [ -n "$COVERAGE" ]; then pip install --user cpp-coveralls; fi
-                echo SHELL=$SHELL
-                echo PATH=$PATH
-                which bison
-                bison --version
-
-            - name: Build
-              env:
-                CC: ${{ matrix.compiler }}
-                MAKEVARS: ${{ matrix.makevars }}
-              run: |
-                autoreconf -i
-                ./configure --with-oniguruma=builtin --enable-valgrind $COVERAGE
-                scan-build --keep-going make -j4
-            - name: Test
-              env:
-                CC: ${{ matrix.compiler }}
-                MAKEVARS: ${{ matrix.makevars }}
-              run: |
-                ulimit -c unlimited
-                scan-build --keep-going make -j4 check
-            - name: Core dump stacks
-              run: |
-                echo "thread apply all bt" > /tmp/x
-                find . -name core -print | while read core; do gdb -batch -x x `file "$core"|sed -e "s/^[^']*'//" -e "s/[ '].*$//"` "$core"; done
-                if [ "$(find . -name core -print | wc -l)" -gt 0 ]; then false; fi
-            - name: Test logs
-              if: ${{ failure() }}
-              run: |
-                cat test-suite.log
-                cat tests/*.log
-            - name: Upload Logs
-              uses: actions/upload-artifact@v4
-              with:
-                name: Scan-Build Reports
-                path: '/tmp/scan-build*/'
+  scan-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y automake autoconf gdb valgrind clang clang-tools
+          echo "CC=clang" >> "$GITHUB_ENV"
+      - name: Build
+        run: |
+          autoreconf -i
+          ./configure --enable-valgrind CFLAGS="-g -O0"
+          scan-build --keep-going --exclude vendor/ make -j"$(nproc)"
+      - name: Test
+        run: |
+          ulimit -c unlimited
+          scan-build --keep-going --exclude vendor/ make -j"$(nproc)" check
+      - name: Core dump stacks
+        run: |
+          if [[ -f core ]]; then
+            gdb -batch -ex "thread apply all bt" \
+              "$(file core | sed "s/^[^']*'//; s/[ '].*$//")" core
+            exit 1
+          fi
+      - name: Test logs
+        if: ${{ failure() }}
+        run: |
+          cat test-suite.log tests/*.log
+      - name: Upload Logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: Scan-Build Reports
+          path: /tmp/scan-build*
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
I fixed the scan-build workflow to run on the master branch. The workflow mistakenly configured as it runs only when the workflow file is updated. I also refactored the workflow a bit. Tested on my fork: https://github.com/itchyny/jq/actions/runs/15124790716.