### PR TITLE
Increase the maximum parsing depth for parsing JSON to 10000

### DIFF
--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -11,7 +11,7 @@
 typedef const char* presult;
 
 #ifndef MAX_PARSING_DEPTH
-#define MAX_PARSING_DEPTH (256)
+#define MAX_PARSING_DEPTH (10000)
 #endif
 
 #define TRY(x) do {presult msg__ = (x); if (msg__) return msg__; } while(0)


### PR DESCRIPTION
This is the same limit as encoding/json in Go and should be sufficient for most use cases.
Closes #2846, closes #3158, and addresses #1214.
