### PR TITLE
Revert "fix: reduce/foreach state variable should not be reset each iteration"

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -831,7 +831,7 @@ block gen_reduce(block source, block matcher, block init, block body) {
   block loop = BLOCK(gen_op_simple(DUPN),
                      source,
                      bind_alternation_matchers(matcher,
-                                  BLOCK(gen_op_bound(LOADV, res_var),
+                                  BLOCK(gen_op_bound(LOADVN, res_var),
                                         body,
                                         gen_op_bound(STOREV, res_var))),
                      gen_op_simple(BACKTRACK));
@@ -855,7 +855,7 @@ block gen_foreach(block source, block matcher, block init, block update, block e
                // in the body to see
                bind_alternation_matchers(matcher,
                             // load the loop state variable
-                            BLOCK(gen_op_bound(LOADV, state_var),
+                            BLOCK(gen_op_bound(LOADVN, state_var),
                                   // generate updated state
                                   update,
                                   // save the updated state for value extraction

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -358,10 +358,6 @@ null
 [1,2,3]
 [1,3,6]
 
-[foreach range(5) as $x (0; .+$x | select($x!=2); [$x,.])]
-null
-[[0,0],[1,1],[3,4],[4,8]]
-
 [limit(3; .[])]
 [11,22,33,44,55,66,77,88,99]
 [11,22,33]
@@ -919,10 +915,6 @@ reduce .[] as $x (0; . + $x) as $x | $x
 reduce . as $n (.; .)
 null
 null
-
-reduce range(5) as $x (0; .+$x | select($x!=2))
-null
-8
 
 # Destructuring
 . as {$a, b: [$c, {$d}]} | [$a, $c, $d]


### PR DESCRIPTION
This reverts 96e8d893c10ed2f7656ccb8cfa39a9a291663a7e. The change
introduced a serious performance regression as reported in #3345.
Fixes #3345.
