### PR TITLE
Fix NULL dereference in tsd_dtoa_context_get by using jv_mem_alloc an…

### DIFF
--- a/src/jv_dtoa_tsd.c
+++ b/src/jv_dtoa_tsd.c
@@ -40,9 +40,10 @@ inline struct dtoa_context *tsd_dtoa_context_get(void) {
   pthread_once(&dtoa_ctx_once, jv_tsd_dtoa_ctx_init); // cannot fail
   struct dtoa_context *ctx = (struct dtoa_context*)pthread_getspecific(dtoa_ctx_key);
   if (!ctx) {
-    ctx = malloc(sizeof(struct dtoa_context));
+    ctx = jv_mem_alloc(sizeof(struct dtoa_context));
     jvp_dtoa_context_init(ctx);
     if (pthread_setspecific(dtoa_ctx_key, ctx) != 0) {
+      jv_mem_free(ctx);
       fprintf(stderr, "error: cannot set thread specific data");
       abort();
     }


### PR DESCRIPTION
Describe the bug

In the function ** located in **, a memory allocation is performed via ``:

ctx = malloc(sizeof(struct dtoa_context));
jvp_dtoa_context_init(ctx); // <- no NULL check before usage

However, the return value from malloc() is used immediately without checking for NULL. If malloc fails and returns NULL, the subsequent call to jvp_dtoa_context_init(ctx) causes a NULL pointer dereference, which leads to a crash.

Expected behavior

The code should check if malloc() has returned NULL before using the pointer. If allocation fails, the program should safely abort using memory_exhausted() as defined in the jq project, which is used consistently elsewhere to handle memory issues.

Actual behavior

Currently, the function dereferences a potentially NULL pointer from malloc() without any safeguard, leading to undefined behavior or crashes in low-memory conditions.

How to Reproduce

Force memory exhaustion in an environment running jq (e.g., via ulimit or stress tools) and trigger tsd_dtoa_context_get() by calling a floating point operation that invokes dtoa formatting. Observe a segmentation fault due to NULL pointer dereference.

Proposed Fix

Replace malloc with jv_mem_alloc which internally calls malloc and invokes memory_exhausted() on failure, ensuring safe program termination without undefined behavior:

- ctx = malloc(sizeof(struct dtoa_context));
+ ctx = jv_mem_alloc(sizeof(struct dtoa_context));

Justification for the Fix

jv_mem_alloc is a wrapper used across jq for safe memory allocation.

It ensures that if allocation fails, the error is reported and the program is safely aborted.

Prevents undefined behavior and maintains code consistency.

No change in logic or control flow for successful allocations.

Summary

This PR fixes a NULL pointer dereference vulnerability in tsd_dtoa_context_get() by replacing malloc with jv_mem_alloc, ensuring safer and consistent memory handling across the codebase.

