### PR TITLE
Fixed minor typo in docs

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3333,7 +3333,7 @@ sections:
 
           Outputs one new input.
 
-          Note that when using `input` it is generally be necessary to
+          Note that when using `input` it is generally necessary to
           invoke jq with the `-n` command-line option, otherwise
           the first entity will be lost.
 

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -3239,7 +3239,7 @@ sections:
 
           Outputs one new input.
 
-          Note that when using `input` it is generally be necessary to
+          Note that when using `input` it is generally necessary to
           invoke jq with the `-n` command-line option, otherwise
           the first entity will be lost.
 

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3333,7 +3333,7 @@ sections:
 
           Outputs one new input.
 
-          Note that when using `input` it is generally be necessary to
+          Note that when using `input` it is generally necessary to
           invoke jq with the `-n` command-line option, otherwise
           the first entity will be lost.
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3729,7 +3729,7 @@ Most jq builtins are referentially transparent, and yield constant and repeatabl
 Outputs one new input\.
 .
 .P
-Note that when using \fBinput\fR it is generally be necessary to invoke jq with the \fB\-n\fR command\-line option, otherwise the first entity will be lost\.
+Note that when using \fBinput\fR it is generally necessary to invoke jq with the \fB\-n\fR command\-line option, otherwise the first entity will be lost\.
 .
 .IP "" 4
 .


### PR DESCRIPTION
I was browsing the man pages and noticed a minor typo, so made a quick PR to fix it. Let me know if there's anything else I need to do.