### PR TITLE
Fix potential null dereference in jv_sort when sort_items returns NULL

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -702,6 +702,9 @@ jv jv_sort(jv objects, jv keys) {
   assert(jv_array_length(jv_copy(objects)) == jv_array_length(jv_copy(keys)));
   int n = jv_array_length(jv_copy(objects));
   struct sort_entry* entries = sort_items(objects, keys);
+  if(!entries){
+    return jv_array();
+  }
   jv ret = jv_array();
   for (int i=0; i<n; i++) {
     jv_free(entries[i].key);


### PR DESCRIPTION
### Summary

This pull request addresses a memory safety issue in the `jv_sort` function, where a potential null pointer dereference may occur if the result of `sort_items` is not properly validated.

### CWE-476: NULL Pointer Dereference

In the original implementation, `jv_sort` assumes that `sort_items(objects, keys)` always returns a valid pointer. However, when the input array is empty (`length == 0`), `sort_items` returns `NULL`.

Subsequent access to `entries[i]` without checking for NULL may lead to:

- segmentation faults
- undefined behavior
- crashes when sorting empty or malformed input

The following static analysis error was reported: