### PR TITLE
jq_fuzz_execute: limit oniguruma depth to 1024

### DIFF
--- a/tests/jq_fuzz_execute.cpp
+++ b/tests/jq_fuzz_execute.cpp
@@ -3,6 +3,12 @@
 
 #include "jq.h"
 #include "jv.h"
+#include "oniguruma.h"
+
+extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
+  onig_set_parse_depth_limit(1024);
+  return 0;
+}
 
 // Fuzzer inspired by /src/jq_test.c
 // The goal is to have the fuzzer execute the functions:


### PR DESCRIPTION
Fixes #3375 - I'll also fix the oss-fuzz build for this in a PR