### PR TITLE
Add support for RFC 4648 base64url encoding

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2198,10 +2198,24 @@ sections:
 
             The input is converted to base64 as specified by RFC 4648.
 
+          * `@base64url`:
+
+            The input is converted to base64url without padding as specified
+            by RFC 4648. This no padding version should only be used when the
+            length of the data is known by a referring specification.
+
+          * `@base64urlp`:
+
+            The input is converted to base64url with padding as specified
+            by RFC 4648. This padding version is for general url safe encoding,
+            but be aware padding bytes (`=`) will be percent encoded in urls.
+
           * `@base64d`:
 
             The inverse of `@base64`, input is decoded as specified by RFC 4648.
             Note\: If the decoded string is not UTF-8, the results are undefined.
+            This function decodes the base64 or base64url encodings. If you require
+            strict validation, re-encode the string and check for equality.
 
           This syntax can be combined with string interpolation in a
           useful way. You can follow a `@foo` token with a string

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "July 2025" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -2391,10 +2391,22 @@ The input is escaped suitable for use in a command\-line for a POSIX shell\. If 
 The input is converted to base64 as specified by RFC 4648\.
 .
 .TP
+\fB@base64url\fR:
+.
+.IP
+The input is converted to base64url without padding as specified by RFC 4648\. This no padding version should only be used when the length of the data is known by a referring specification\.
+.
+.TP
+\fB@base64urlp\fR:
+.
+.IP
+The input is converted to base64url with padding as specified by RFC 4648\. This padding version is for general url safe encoding, but be aware padding bytes (\fB=\fR) will be percent encoded in urls\.
+.
+.TP
 \fB@base64d\fR:
 .
 .IP
-The inverse of \fB@base64\fR, input is decoded as specified by RFC 4648\. Note\e: If the decoded string is not UTF\-8, the results are undefined\.
+The inverse of \fB@base64\fR, input is decoded as specified by RFC 4648\. Note\e: If the decoded string is not UTF\-8, the results are undefined\. This function decodes the base64 or base64url encodings\. If you require strict validation, re\-encode the string and check for equality\.
 .
 .P
 This syntax can be combined with string interpolation in a useful way\. You can follow a \fB@foo\fR token with a string literal\. The contents of the string literal will \fInot\fR be escaped\. However, all interpolations made inside that string literal will be escaped\. For instance,

--- a/tests/base64.test
+++ b/tests/base64.test
@@ -36,6 +36,53 @@
 "cWl4YmF6Cg"
 "qixbaz\n"
 
+# base64url encoding (Section 5 of RFC 4648) without padding
+@base64url
+"ab>cd?"
+"YWI-Y2Q_"
+
+@base64url
+"ab>cd?x"
+"YWI-Y2Q_eA"
+
+@base64url
+"ab>cd?xy"
+"YWI-Y2Q_eHk"
+
+@base64url
+"ab>cd?xyz"
+"YWI-Y2Q_eHl6"
+
+# base64url encoding (Section 5 of RFC 4648) with padding
+@base64urlp
+"ab>cd?"
+"YWI-Y2Q_"
+
+@base64urlp
+"ab>cd?x"
+"YWI-Y2Q_eA=="
+
+@base64urlp
+"ab>cd?xy"
+"YWI-Y2Q_eHk="
+
+@base64urlp
+"ab>cd?xyz"
+"YWI-Y2Q_eHl6"
+
+# base64url decoding (Section 5 of RFC 4648)
+@base64d
+"YWI-"
+"ab>"
+
+@base64d
+"Y2Q_"
+"cd?"
+
+@base64d
+"YWI-Y2Q_"
+"ab>cd?"
+
 # invalid base64 characters (whitespace)
 . | try @base64d catch .
 "Not base64 data"

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -69,7 +69,7 @@ jq: error: Invalid escape at line 1, column 4 (while parsing '"\v"') at <top-lev
 null
 "interpolation"
 
-@text,@json,([1,.]|@csv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d)
+@text,@json,([1,.]|@csv,@tsv),@html,(@uri|.,@urid),@sh,(@base64|.,@base64d),(@base64url|.,@base64d),(@base64urlp|.,@base64d)
 "!()<>&'\"\t"
 "!()<>&'\"\t"
 "\"!()<>&'\\\"\\t\""
@@ -79,6 +79,10 @@ null
 "%21%28%29%3C%3E%26%27%22%09"
 "!()<>&'\"\t"
 "'!()<>&'\\''\"\t'"
+"ISgpPD4mJyIJ"
+"!()<>&'\"\t"
+"ISgpPD4mJyIJ"
+"!()<>&'\"\t"
 "ISgpPD4mJyIJ"
 "!()<>&'\"\t"
 


### PR DESCRIPTION
RFC 4648 provides an alternate encoding alphabet using -_ in place of +/ to assist in produce encoded strings which do not require % encoding for including in urls. The nodejs Buffer class supports this encoding for example.

This change adds support for encoding in base64url with padding included (base64urlp) and with padding excluded (base64url). The latter is provided and named to mimic the nodejs version of this encoding.

This change permits base64d to decode either base64 or base64url. This also mimics nodejs which decodes both in either encoding.

Also, add docs and tests for this change.