### PR TITLE
Only quote CSV string values if necessary

### DIFF
--- a/tests/jq.test
+++ b/tests/jq.test
@@ -82,6 +82,10 @@ null
 "ISgpPD4mJyIJ"
 "!()<>&'\"\t"
 
+@csv
+["hello", "hello,world", "a\"b", "one\ntwo", "foo, \"bar\nbaz\" end"]
+"hello,\"hello,world\",\"a\"\"b\",\"one\ntwo\",\"foo, \"\"bar\nbaz\"\" end\""
+
 # regression test for #436
 @base64
 "foóbar\n"


### PR DESCRIPTION
Currently all string values are quoted when using the CSV formatter:

```console
$ echo '["hello", "world", "hello,world"]' | jq -r '@csv'
"hello","world","hello,world"
```

This PR changes that to only quote string values when actually needed:

```console
$ echo '["hello", "world", "hello,world"]' | jq -r '@csv'
hello,world,"hello,world"
```

Here is a more extensive example:
```console
$ echo '[0, null, true, "hello", "hello,world", "a\"b", "one\ntwo", "foo, \"bar\nbaz\" end"]' | jq -r '@csv'
0,,true,hello,"hello,world","a""b","one
two","foo, ""bar
baz"" end"
```