### PR TITLE
Fix `rtrimstr("")` always output `""`

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -75,7 +75,7 @@ def todateiso8601: strftime("%Y-%m-%dT%H:%M:%SZ");
 def fromdate: fromdateiso8601;
 def todate: todateiso8601;
 def ltrimstr($left): if startswith($left) then .[$left | length:] end;
-def rtrimstr($right): if endswith($right) then .[:$right | -length] end;
+def rtrimstr($right): if endswith($right) then .[:length - ($right | length)] end;
 def trimstr($val): ltrimstr($val) | rtrimstr($val);
 def match(re; mode): _match_impl(re; mode; false)|.[];
 def match($val): ($val|type) as $vt | if $vt == "string" then match($val; null)

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1512,6 +1512,18 @@ split("")
 ["fo", "foo", "barfoo", "foobarfoo", "foob"]
 ["fo","","bar","bar","b"]
 
+[.[]|ltrimstr("")]
+["a", "xx", ""]
+["a", "xx", ""]
+
+[.[]|rtrimstr("")]
+["a", "xx", ""]
+["a", "xx", ""]
+
+[.[]|trimstr("")]
+["a", "xx", ""]
+["a", "xx", ""]
+
 [(index(","), rindex(",")), indices(",")]
 "a,bc,def,ghij,klmno"
 [1,13,[1,4,8,13]]


### PR DESCRIPTION
Example
---
**Before this fix**:

```sh
$ jq -n '"foo"|rtrimstr("")'
""
```

**After this fix**:

```sh
$ jq -n '"foo"|rtrimstr("")'
"foo"
```
