### PR TITLE
Add `--color-field` for per-value highlighting

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -175,6 +175,15 @@ sections:
         Colors can be configured with the `JQ_COLORS` environment
         variable (see below).
 
+      * `--color-field spec`:
+
+        Colorize object string values that match `spec`.
+
+        The `spec` format is `key=value:ansi`, where `ansi` is a partial ANSI
+        SGR sequence such as `1;31` (red) or `1;33` (yellow).
+
+        This option implies `-C`.
+
       * `--tab`:
 
         Use a tab for each indentation level instead of two spaces.

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "December 2025" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -119,6 +119,18 @@ By default, jq outputs colored JSON if writing to a terminal\. You can force it 
 .
 .IP
 Colors can be configured with the \fBJQ_COLORS\fR environment variable (see below)\.
+.
+.TP
+\fB\-\-color\-field spec\fR:
+.
+.IP
+Colorize object string values that match \fBspec\fR\.
+.
+.IP
+The \fBspec\fR format is \fBkey=value:ansi\fR, where \fBansi\fR is a partial ANSI SGR sequence such as \fB1;31\fR (red) or \fB1;33\fR (yellow)\.
+.
+.IP
+This option implies \fB\-C\fR\.
 .
 .TP
 \fB\-\-tab\fR:

--- a/src/jq.h
+++ b/src/jq.h
@@ -72,6 +72,7 @@ jv jq_util_input_get_current_filename(jq_state*);
 jv jq_util_input_get_current_line(jq_state*);
 
 int jq_set_colors(const char *);
+int jq_add_color_field(const char *);
 
 #ifdef __cplusplus
 }

--- a/src/jv_print.c
+++ b/src/jv_print.c
@@ -35,6 +35,16 @@ static const char *colors[] = DEFAULT_COLORS;
 #define COLORS_LEN (sizeof(colors) / sizeof(colors[0]))
 #define FIELD_COLOR (colors[7])
 
+struct color_field_rule {
+  char *key;
+  char *value;
+  char *color;
+};
+
+static struct color_field_rule *color_field_rules = NULL;
+static size_t color_field_rules_len = 0;
+static size_t color_field_rules_cap = 0;
+
 static char *colors_buf = NULL;
 int jq_set_colors(const char *code_str) {
   if (code_str == NULL)
@@ -91,6 +101,74 @@ int jq_set_colors(const char *code_str) {
   default_colors:
   for (; ci < COLORS_LEN; ci++)
     colors[ci] = default_colors[ci];
+  return 1;
+}
+
+static const char *lookup_color_field_rule(const char *key, const char *value) {
+  for (size_t i = 0; i < color_field_rules_len; i++) {
+    if (strcmp(color_field_rules[i].key, key) == 0 &&
+        strcmp(color_field_rules[i].value, value) == 0) {
+      return color_field_rules[i].color;
+    }
+  }
+  return NULL;
+}
+
+int jq_add_color_field(const char *spec) {
+  if (spec == NULL)
+    return 0;
+
+  const char *eq = strchr(spec, '=');
+  const char *colon = strrchr(spec, ':');
+  if (eq == NULL || colon == NULL || eq == spec || colon <= eq + 1)
+    return 0;
+
+  const char *key_start = spec;
+  const char *key_end = eq;
+  const char *value_start = eq + 1;
+  const char *value_end = colon;
+  const char *code = colon + 1;
+
+  if (*code == '\0')
+    return 0;
+
+  size_t code_len = strlen(code);
+  if (strspn(code, "0123456789;") != code_len)
+    return 0;
+
+  size_t key_len = (size_t)(key_end - key_start);
+  size_t value_len = (size_t)(value_end - value_start);
+  if (key_len == 0 || value_len == 0)
+    return 0;
+
+  if (color_field_rules_len == color_field_rules_cap) {
+    size_t new_cap = color_field_rules_cap ? color_field_rules_cap * 2 : 8;
+    struct color_field_rule *new_rules = jv_mem_realloc(color_field_rules, new_cap * sizeof(*new_rules));
+    if (new_rules == NULL)
+      return 0;
+    color_field_rules = new_rules;
+    color_field_rules_cap = new_cap;
+  }
+
+  struct color_field_rule *rule = &color_field_rules[color_field_rules_len];
+  rule->key = jv_mem_alloc(key_len + 1);
+  rule->value = jv_mem_alloc(value_len + 1);
+  rule->color = jv_mem_alloc(code_len + 4);
+  if (rule->key == NULL || rule->value == NULL || rule->color == NULL)
+    return 0;
+
+  memcpy(rule->key, key_start, key_len);
+  rule->key[key_len] = '\0';
+  memcpy(rule->value, value_start, value_len);
+  rule->value[value_len] = '\0';
+
+  rule->color[0] = ESC[0];
+  rule->color[1] = '[';
+  memcpy(rule->color + 2, code, code_len);
+  rule->color[2 + code_len] = 'm';
+  rule->color[3 + code_len] = '\0';
+
+  color_field_rules_len++;
   return 1;
 }
 
@@ -215,12 +293,12 @@ static void put_refcnt(struct dtoa_context* C, int refcnt, FILE *F, jv* S, int T
   put_char(')', F, S, T);
 }
 
-static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FILE* F, jv* S) {
+static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FILE* F, jv* S, const char *forced_color) {
   char buf[JVP_DTOA_FMT_MAX_LEN];
   const char* color = 0;
   double refcnt = (flags & JV_PRINT_REFCOUNT) ? jv_get_refcnt(x) - 1 : -1;
   if ((flags & JV_PRINT_COLOR) && jv_get_kind(x) != JV_KIND_INVALID) {
-    color = colors[(int)jv_get_kind(x) - 1];
+    color = forced_color ? forced_color : colors[(int)jv_get_kind(x) - 1];
     put_str(color, F, S, flags & JV_PRINT_ISATTY);
   }
   if (indent > MAX_PRINT_DEPTH) {
@@ -252,7 +330,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
     break;
   case JV_KIND_NUMBER: {
     if (jvp_number_is_nan(x)) {
-      jv_dump_term(C, jv_null(), flags, indent, F, S);
+      jv_dump_term(C, jv_null(), flags, indent, F, S, NULL);
     } else {
 #ifdef USE_DECNUM
       const char * literal_data = jv_number_get_literal(x);
@@ -297,7 +375,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
         put_char('\n', F, S, flags & JV_PRINT_ISATTY);
         put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
       }
-      jv_dump_term(C, elem, flags, indent + 1, F, S);
+      jv_dump_term(C, elem, flags, indent + 1, F, S, NULL);
     }
     if (flags & JV_PRINT_PRETTY) {
       put_char('\n', F, S, flags & JV_PRINT_ISATTY);
@@ -354,6 +432,12 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
         put_indent(indent + 1, flags, F, S, flags & JV_PRINT_ISATTY);
       }
 
+      const char *forced_value_color = NULL;
+      if ((flags & JV_PRINT_COLOR) && jv_get_kind(value) == JV_KIND_STRING &&
+          jv_get_kind(key) == JV_KIND_STRING) {
+        forced_value_color = lookup_color_field_rule(jv_string_value(key), jv_string_value(value));
+      }
+
       first = 0;
       if (color) put_str(FIELD_COLOR, F, S, flags & JV_PRINT_ISATTY);
       jvp_dump_string(key, flags & JV_PRINT_ASCII, F, S, flags & JV_PRINT_ISATTY);
@@ -367,7 +451,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
         put_char(' ', F, S, flags & JV_PRINT_ISATTY);
       }
 
-      jv_dump_term(C, value, flags, indent + 1, F, S);
+      jv_dump_term(C, value, flags, indent + 1, F, S, forced_value_color);
     }
     if (flags & JV_PRINT_PRETTY) {
       put_char('\n', F, S, flags & JV_PRINT_ISATTY);
@@ -386,7 +470,7 @@ static void jv_dump_term(struct dtoa_context* C, jv x, int flags, int indent, FI
 }
 
 void jv_dumpf(jv x, FILE *f, int flags) {
-  jv_dump_term(tsd_dtoa_context_get(), x, flags, 0, f, 0);
+  jv_dump_term(tsd_dtoa_context_get(), x, flags, 0, f, 0, NULL);
 }
 
 void jv_dump(jv x, int flags) {
@@ -403,7 +487,7 @@ void jv_show(jv x, int flags) {
 
 jv jv_dump_string(jv x, int flags) {
   jv s = jv_string("");
-  jv_dump_term(tsd_dtoa_context_get(), x, flags, 0, 0, &s);
+  jv_dump_term(tsd_dtoa_context_get(), x, flags, 0, 0, &s, NULL);
   return s;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -83,6 +83,8 @@ static void usage(int code, int keep_it_short) {
       "                            using escape sequences;\n"
       "  -S, --sort-keys           sort keys of each object on output;\n"
       "  -C, --color-output        colorize JSON output;\n"
+      "      --color-field spec    colorize object string values matching\n"
+      "                            spec (key=value:ansi), implies -C;\n"
       "  -M, --monochrome-output   disable colored output;\n"
       "      --tab                 use tabs for indentation;\n"
       "      --indent n            use n spaces for indentation (max 7 spaces);\n"
@@ -390,6 +392,17 @@ int main(int argc, char* argv[]) {
           dumpopts &= ~(JV_PRINT_TAB | JV_PRINT_INDENT_FLAGS(7));
         } else if (isoption(&text, 'C', "color-output", is_short)) {
           options |= COLOR_OUTPUT;
+        } else if (isoption(&text, 0, "color-field", is_short)) {
+          if (i >= argc - 1) {
+            fprintf(stderr, "jq: --color-field takes one parameter\n");
+            die();
+          }
+          options |= COLOR_OUTPUT;
+          if (!jq_add_color_field(argv[i + 1])) {
+            fprintf(stderr, "jq: invalid --color-field argument: %s\n", argv[i + 1]);
+            die();
+          }
+          i++;
         } else if (isoption(&text, 'M', "monochrome-output", is_short)) {
           options |= NO_COLOR_OUTPUT;
         } else if (isoption(&text, 'a', "ascii-output", is_short)) {

--- a/tests/shtest
+++ b/tests/shtest
@@ -20,6 +20,18 @@ export SHELL
 unset JQ_COLORS
 unset NO_COLOR
 
+## Test --color-field (per-field value highlighting)
+printf '{"level":"ERROR"}\n' \
+  | $JQ -c --color-field 'level=ERROR:1;31' '.' > $d/out
+printf '\033[1;39m{\033[0m\033[1;34m"level"\033[0m\033[1;39m:\033[0m\033[1;31m"ERROR"\033[0m\033[1;39m}\033[0m\n' > $d/expected
+cmp $d/out $d/expected
+
+# -M should disable coloring even if --color-field is set
+printf '{"level":"ERROR"}\n' \
+  | $JQ -c --color-field 'level=ERROR:1;31' -M '.' > $d/out
+printf '{"level":"ERROR"}\n' > $d/expected
+cmp $d/out $d/expected
+
 if [ -f "$JQBASEDIR/.libs/libinject_errors.so" ]; then
   # Do some simple error injection tests to check that we're handling
   # I/O errors correctly.


### PR DESCRIPTION
Adds a new CLI option to colorize object string values based on key=value rules, intended for structured log fields like level. Includes docs updates, a manpage regen, and tests.