### PR TITLE
chore: update documentation for --binary option

### DIFF
--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -292,7 +292,8 @@ sections:
 
         Windows users using WSL, MSYS2, or Cygwin, should use this option
         when using a native jq.exe, otherwise jq will turn newlines (LFs)
-        into carriage-return-then-newline (CRLF).
+        into carriage-return-then-newline (CRLF). This is safe to use on
+        supported non-Windows environments.
 
       * `--version` / `-V`:
 


### PR DESCRIPTION
Clarify usage of --binary option for non-Windows users.

This clarification makes it clear that scripters can include -b flag when scripting for cross platform users.