### PR TITLE
Support $XDG_CONFIG_HOME in module search path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -220,6 +220,8 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/modules/a.jq tests/modules/b/b.jq tests/modules/c/c.jq    \
         tests/modules/c/d.jq tests/modules/data.json                    \
         tests/modules/home1/.jq tests/modules/home2/.jq/g.jq            \
+        tests/modules/home3/.config/jq/cfg.jq                           \
+        tests/modules/home3/.jq/priority_test.jq                        \
         tests/modules/lib/jq/e/e.jq tests/modules/lib/jq/f.jq           \
         tests/modules/shadow1.jq tests/modules/shadow2.jq               \
         tests/modules/syntaxerror/syntaxerror.jq                        \
@@ -227,6 +229,8 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/modules/test_bind_order0.jq                               \
         tests/modules/test_bind_order1.jq                               \
         tests/modules/test_bind_order2.jq                               \
+        tests/modules/xdg1/jq/xdg.jq                                    \
+        tests/modules/xdg2/jq/priority_test.jq                          \
         tests/onig.supp tests/local.supp                                \
         tests/setup tests/torture/input0.json                           \
         tests/optional.test tests/man.test tests/manonig.test           \

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3708,6 +3708,13 @@ sections:
       For paths starting with `~/`, the user's home directory is
       substituted for `~`.
 
+      For paths starting with `$XDG_CONFIG_HOME/`, the value of the
+      environment variable `$XDG_CONFIG_HOME` is substituted for
+      `$XDG_CONFIG_HOME`. If the variable is not defined, `$HOME/.config`
+      is used as the default on non-Windows platforms. On Windows, these
+      paths are removed from the search path if the variable is not
+      defined.
+
       For paths starting with `$ORIGIN/`, the directory where the jq
       executable is located is substituted for `$ORIGIN`.
 
@@ -3719,8 +3726,8 @@ sections:
       the default is appended.
 
       The default search path is the search path given to the `-L`
-      command-line option, else `["~/.jq", "$ORIGIN/../lib/jq",
-      "$ORIGIN/../lib"]`.
+      command-line option, else `["~/.jq", "$XDG_CONFIG_HOME/jq",
+      "$ORIGIN/../lib/jq", "$ORIGIN/../lib"]`.
 
       Null and empty string path elements terminate search path
       processing.

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3708,12 +3708,11 @@ sections:
       For paths starting with `~/`, the user's home directory is
       substituted for `~`.
 
-      For paths starting with `$XDG_CONFIG_HOME/`, the value of the
-      environment variable `$XDG_CONFIG_HOME` is substituted for
-      `$XDG_CONFIG_HOME`. If the variable is not defined, `$HOME/.config`
-      is used as the default on non-Windows platforms. On Windows, these
-      paths are removed from the search path if the variable is not
-      defined.
+      For paths starting with `$JQ_CONFIG_HOME/`, `$JQ_CONFIG_HOME` is
+      resolved as follows: if the environment variable `$XDG_CONFIG_HOME`
+      is set and non-empty, `$XDG_CONFIG_HOME/jq` is used if the directory
+      exists; on non-Windows platforms, `~/.config/jq` is used if the
+      directory exists; otherwise, `~/.jq` is used as a fallback.
 
       For paths starting with `$ORIGIN/`, the directory where the jq
       executable is located is substituted for `$ORIGIN`.
@@ -3726,7 +3725,7 @@ sections:
       the default is appended.
 
       The default search path is the search path given to the `-L`
-      command-line option, else `["~/.jq", "$XDG_CONFIG_HOME/jq",
+      command-line option, else `["$JQ_CONFIG_HOME",
       "$ORIGIN/../lib/jq", "$ORIGIN/../lib"]`.
 
       Null and empty string path elements terminate search path

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "January 2026" "" ""
+.TH "JQ" "1" "February 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -4143,7 +4143,7 @@ Paths in the search path are subject to various substitutions\.
 For paths starting with \fB~/\fR, the user\'s home directory is substituted for \fB~\fR\.
 .
 .P
-For paths starting with \fB$XDG_CONFIG_HOME/\fR, the value of the environment variable \fB$XDG_CONFIG_HOME\fR is substituted for \fB$XDG_CONFIG_HOME\fR\. If the variable is not defined, \fB$HOME/\.config\fR is used as the default on non\-Windows platforms\. On Windows, these paths are removed from the search path if the variable is not defined\.
+For paths starting with \fB$JQ_CONFIG_HOME/\fR, \fB$JQ_CONFIG_HOME\fR is resolved as follows: if the environment variable \fB$XDG_CONFIG_HOME\fR is set and non\-empty, \fB$XDG_CONFIG_HOME/jq\fR is used if the directory exists; on non\-Windows platforms, \fB~/\.config/jq\fR is used if the directory exists; otherwise, \fB~/\.jq\fR is used as a fallback\.
 .
 .P
 For paths starting with \fB$ORIGIN/\fR, the directory where the jq executable is located is substituted for \fB$ORIGIN\fR\.
@@ -4155,7 +4155,7 @@ For paths starting with \fB\./\fR or paths that are \fB\.\fR, the path of the in
 Import directives can optionally specify a search path to which the default is appended\.
 .
 .P
-The default search path is the search path given to the \fB\-L\fR command\-line option, else \fB["~/\.jq", "$XDG_CONFIG_HOME/jq", "$ORIGIN/\.\./lib/jq", "$ORIGIN/\.\./lib"]\fR\.
+The default search path is the search path given to the \fB\-L\fR command\-line option, else \fB["$JQ_CONFIG_HOME", "$ORIGIN/\.\./lib/jq", "$ORIGIN/\.\./lib"]\fR\.
 .
 .P
 Null and empty string path elements terminate search path processing\.

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "January 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -4143,6 +4143,9 @@ Paths in the search path are subject to various substitutions\.
 For paths starting with \fB~/\fR, the user\'s home directory is substituted for \fB~\fR\.
 .
 .P
+For paths starting with \fB$XDG_CONFIG_HOME/\fR, the value of the environment variable \fB$XDG_CONFIG_HOME\fR is substituted for \fB$XDG_CONFIG_HOME\fR\. If the variable is not defined, \fB$HOME/\.config\fR is used as the default on non\-Windows platforms\. On Windows, these paths are removed from the search path if the variable is not defined\.
+.
+.P
 For paths starting with \fB$ORIGIN/\fR, the directory where the jq executable is located is substituted for \fB$ORIGIN\fR\.
 .
 .P
@@ -4152,7 +4155,7 @@ For paths starting with \fB\./\fR or paths that are \fB\.\fR, the path of the in
 Import directives can optionally specify a search path to which the default is appended\.
 .
 .P
-The default search path is the search path given to the \fB\-L\fR command\-line option, else \fB["~/\.jq", "$ORIGIN/\.\./lib/jq", "$ORIGIN/\.\./lib"]\fR\.
+The default search path is the search path given to the \fB\-L\fR command\-line option, else \fB["~/\.jq", "$XDG_CONFIG_HOME/jq", "$ORIGIN/\.\./lib/jq", "$ORIGIN/\.\./lib"]\fR\.
 .
 .P
 Null and empty string path elements terminate search path processing\.

--- a/src/linker.c
+++ b/src/linker.c
@@ -48,7 +48,7 @@ static int path_is_relative(jv p) {
 // in the following order:
 // 1. lib_path
 // 2. -L paths passed in on the command line (from jq_state*) or builtin list
-static jv build_lib_search_chain(jq_state *jq, jv search_path, jv jq_origin, jv lib_origin) {
+static jv build_lib_search_chain(jq_state *jq, jv search_path, jv xdg_config_home, jv jq_origin, jv lib_origin) {
   assert(jv_get_kind(search_path) == JV_KIND_ARRAY);
   jv expanded = jv_array();
   jv expanded_elt;
@@ -66,6 +66,15 @@ static jv build_lib_search_chain(jq_state *jq, jv search_path, jv jq_origin, jv 
     }
     if (strcmp(".",jv_string_value(path)) == 0) {
       expanded_elt = jv_copy(path);
+    } else if (strncmp("$XDG_CONFIG_HOME/",jv_string_value(path),sizeof("$XDG_CONFIG_HOME/") - 1) == 0) {
+      if (jv_is_valid(xdg_config_home)) {
+        expanded_elt = jv_string_fmt("%s/%s",
+                                 jv_string_value(xdg_config_home),
+                                 jv_string_value(path) + sizeof ("$XDG_CONFIG_HOME/") - 1);
+      } else {
+        // Remove $XDG_CONFIG_HOME/* from the search path if $XDG_CONFIG_HOME is not defined.
+        expanded_elt = jv_null();
+      }
     } else if (strncmp("$ORIGIN/",jv_string_value(path),sizeof("$ORIGIN/") - 1) == 0) {
       expanded_elt = jv_string_fmt("%s/%s",
                                jv_string_value(jq_origin),
@@ -82,6 +91,7 @@ static jv build_lib_search_chain(jq_state *jq, jv search_path, jv jq_origin, jv 
     expanded = jv_array_append(expanded, expanded_elt);
     jv_free(path);
   }
+  jv_free(xdg_config_home);
   jv_free(jq_origin);
   jv_free(lib_origin);
   jv_free(search_path);
@@ -133,9 +143,10 @@ static jv jv_basename(jv name) {
 }
 
 // Asummes validated relative path to module
-static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv jq_origin, jv lib_origin) {
+static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv xdg_config_home, jv jq_origin, jv lib_origin) {
   if (!jv_is_valid(rel_path)) {
     jv_free(search);
+    jv_free(xdg_config_home);
     jv_free(jq_origin);
     jv_free(lib_origin);
     return rel_path;
@@ -143,6 +154,7 @@ static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv 
   if (jv_get_kind(rel_path) != JV_KIND_STRING) {
     jv_free(rel_path);
     jv_free(search);
+    jv_free(xdg_config_home);
     jv_free(jq_origin);
     jv_free(lib_origin);
     return jv_invalid_with_msg(jv_string_fmt("Module path must be a string"));
@@ -150,6 +162,7 @@ static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv 
   if (jv_get_kind(search) != JV_KIND_ARRAY) {
     jv_free(rel_path);
     jv_free(search);
+    jv_free(xdg_config_home);
     jv_free(jq_origin);
     jv_free(lib_origin);
     return jv_invalid_with_msg(jv_string_fmt("Module search path must be an array"));
@@ -159,7 +172,7 @@ static jv find_lib(jq_state *jq, jv rel_path, jv search, const char *suffix, jv 
   int ret;
 
   // Ideally we should cache this somewhere
-  search = build_lib_search_chain(jq, search, jq_origin, lib_origin);
+  search = build_lib_search_chain(jq, search, xdg_config_home, jq_origin, lib_origin);
   jv err = jv_array_get(jv_copy(search), 1);
   search = jv_array_get(search, 0);
 
@@ -241,7 +254,7 @@ static jv default_search(jq_state *jq, jv value) {
 }
 
 // XXX Split this into a util that takes a callback, and then...
-static int process_dependencies(jq_state *jq, jv jq_origin, jv lib_origin, block *src_block, struct lib_loading_state *lib_state) {
+static int process_dependencies(jq_state *jq, jv xdg_config_home, jv jq_origin, jv lib_origin, block *src_block, struct lib_loading_state *lib_state) {
   jv deps = block_take_imports(src_block);
   block bk = *src_block;
   int nerrors = 0;
@@ -270,7 +283,7 @@ static int process_dependencies(jq_state *jq, jv jq_origin, jv lib_origin, block
     // dep is now freed; do not reuse
 
     // find_lib does a lot of work that could be cached...
-    jv resolved = find_lib(jq, relpath, search, is_data ? ".json" : ".jq", jv_copy(jq_origin), jv_copy(lib_origin));
+    jv resolved = find_lib(jq, relpath, search, is_data ? ".json" : ".jq", jv_copy(xdg_config_home), jv_copy(jq_origin), jv_copy(lib_origin));
     // XXX ...move the rest of this into a callback.
     if (!jv_is_valid(resolved)) {
       jv_free(as);
@@ -282,6 +295,7 @@ static int process_dependencies(jq_state *jq, jv jq_origin, jv lib_origin, block
       jq_report_error(jq, jv_string_fmt("jq: error: %s\n",jv_string_value(emsg)));
       jv_free(emsg);
       jv_free(deps);
+      jv_free(xdg_config_home);
       jv_free(jq_origin);
       jv_free(lib_origin);
       return 1;
@@ -321,6 +335,7 @@ static int process_dependencies(jq_state *jq, jv jq_origin, jv lib_origin, block
     jv_free(as);
   }
   jv_free(lib_origin);
+  jv_free(xdg_config_home);
   jv_free(jq_origin);
   jv_free(deps);
   return nerrors;
@@ -359,7 +374,8 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
     locfile_free(src);
     if (nerrors == 0) {
       char *lib_origin = strdup(jv_string_value(lib_path));
-      nerrors += process_dependencies(jq, jq_get_jq_origin(jq),
+      nerrors += process_dependencies(jq, get_xdg_config_home(),
+                                      jq_get_jq_origin(jq),
                                       jv_string(dirname(lib_origin)),
                                       &program, lib_state);
       free(lib_origin);
@@ -382,7 +398,7 @@ out:
 // as we do in process_dependencies.
 jv load_module_meta(jq_state *jq, jv mod_relpath) {
   // We can't know the caller's origin; we could though, if it was passed in
-  jv lib_path = find_lib(jq, validate_relpath(mod_relpath), jq_get_lib_dirs(jq), ".jq", jq_get_jq_origin(jq), jv_null());
+  jv lib_path = find_lib(jq, validate_relpath(mod_relpath), jq_get_lib_dirs(jq), ".jq", get_xdg_config_home(), jq_get_jq_origin(jq), jv_null());
   if (!jv_is_valid(lib_path))
     return lib_path;
   jv meta = jv_null();
@@ -432,7 +448,7 @@ int load_program(jq_state *jq, struct locfile* src, block *out_block) {
     jv_free(home);
   }
 
-  nerrors = process_dependencies(jq, jq_get_jq_origin(jq), jq_get_prog_origin(jq), &program, &lib_state);
+  nerrors = process_dependencies(jq, get_xdg_config_home(), jq_get_jq_origin(jq), jq_get_prog_origin(jq), &program, &lib_state);
   block libs = gen_noop();
   for (uint64_t i = 0; i < lib_state.ct; ++i) {
     free(lib_state.names[i]);

--- a/src/main.c
+++ b/src/main.c
@@ -570,8 +570,7 @@ int main(int argc, char* argv[]) {
 
   if (jv_get_kind(lib_search_paths) == JV_KIND_NULL) {
     // Default search path list
-    lib_search_paths = JV_ARRAY(jv_string("~/.jq"),
-                                jv_string("$XDG_CONFIG_HOME/jq"),
+    lib_search_paths = JV_ARRAY(jv_string("$JQ_CONFIG_HOME"),
                                 jv_string("$ORIGIN/../lib/jq"),
                                 jv_string("$ORIGIN/../lib"));
   }

--- a/src/main.c
+++ b/src/main.c
@@ -571,6 +571,7 @@ int main(int argc, char* argv[]) {
   if (jv_get_kind(lib_search_paths) == JV_KIND_NULL) {
     // Default search path list
     lib_search_paths = JV_ARRAY(jv_string("~/.jq"),
+                                jv_string("$XDG_CONFIG_HOME/jq"),
                                 jv_string("$ORIGIN/../lib/jq"),
                                 jv_string("$ORIGIN/../lib"));
   }

--- a/src/util.c
+++ b/src/util.c
@@ -126,6 +126,26 @@ jv get_home(void) {
   return ret;
 }
 
+// Get $XDG_CONFIG_HOME, fallbacking to $HOME/.config on non-Windows platforms.
+jv get_xdg_config_home(void) {
+  char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+  if (xdg_config_home && xdg_config_home[0]) {
+    return jv_string(xdg_config_home);
+  }
+
+#ifndef WIN32
+  // Fallback to $HOME/.config on non-Windows platforms.
+  jv home = get_home();
+  if (jv_is_valid(home)) {
+    jv ret = jv_string_fmt("%s/.config", jv_string_value(home));
+    jv_free(home);
+    return ret;
+  }
+  jv_free(home);
+#endif
+
+  return jv_invalid_with_msg(jv_string("No $XDG_CONFIG_HOME available"));
+}
 
 jv jq_realpath(jv path) {
   int path_max;

--- a/src/util.h
+++ b/src/util.h
@@ -15,7 +15,7 @@
 
 jv expand_path(jv);
 jv get_home(void);
-jv get_xdg_config_home(void);
+jv get_config_home(void);
 jv jq_realpath(jv);
 
 /*

--- a/src/util.h
+++ b/src/util.h
@@ -15,6 +15,7 @@
 
 jv expand_path(jv);
 jv get_home(void);
+jv get_xdg_config_home(void);
 jv jq_realpath(jv);
 
 /*

--- a/tests/modules/home3/.config/jq/cfg.jq
+++ b/tests/modules/home3/.config/jq/cfg.jq
@@ -1,0 +1,1 @@
+def test: "bar";

--- a/tests/modules/home3/.jq/priority_test.jq
+++ b/tests/modules/home3/.jq/priority_test.jq
@@ -1,0 +1,1 @@
+def test: "qux";

--- a/tests/modules/xdg1/jq/xdg.jq
+++ b/tests/modules/xdg1/jq/xdg.jq
@@ -1,0 +1,1 @@
+def test: "foo";

--- a/tests/modules/xdg2/jq/priority_test.jq
+++ b/tests/modules/xdg2/jq/priority_test.jq
@@ -1,0 +1,1 @@
+def test: "baz";

--- a/tests/shtest
+++ b/tests/shtest
@@ -382,9 +382,9 @@ if [ "$(HOME=/nonexistent XDG_CONFIG_HOME="$mods/xdg1" $VALGRIND $Q $JQ -nr 'inc
     echo "Failed to load module from \$XDG_CONFIG_HOME/jq/" 1>&2
     exit 1
 fi
-## ~/.jq/ should be searched before $XDG_CONFIG_HOME/jq/
-if [ "$(HOME="$mods/home3" XDG_CONFIG_HOME="$mods/xdg2" $VALGRIND $Q $JQ -nr 'include "priority_test"; test')" != "qux" ]; then
-    echo "~/.jq/ should take priority over \$XDG_CONFIG_HOME/jq/" 1>&2
+## $JQ_CONFIG_HOME/jq/ should be searched before ~/.jq/
+if [ "$(HOME="$mods/home3" XDG_CONFIG_HOME="$mods/xdg2" $VALGRIND $Q $JQ -nr 'include "priority_test"; test')" != "baz" ]; then
+    echo "\$JQ_CONFIG_HOME/jq/ should take priority over ~/.jq/" 1>&2
     exit 1
 fi
 if $msys || $mingw; then
@@ -399,14 +399,19 @@ if $msys || $mingw; then
         exit 1
     fi
 else
-    ## If $XDG_CONFIG_HOME is unset, fallback to $HOME/.config/jq/
+    ## If $XDG_CONFIG_HOME is unset and $HOME/.config/jq exists, fallback to $HOME/.config/jq/
     if [ "$(unset XDG_CONFIG_HOME; HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test')" != "bar" ]; then
         echo "Failed to fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is unset" 1>&2
         exit 1
     fi
-    ## If $XDG_CONFIG_HOME is an empty string, fallback to $HOME/.config/jq/
+    ## If $XDG_CONFIG_HOME is an empty string and $HOME/.config/jq exists, fallback to $HOME/.config/jq/
     if [ "$(XDG_CONFIG_HOME="" HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test')" != "bar" ]; then
         echo "Failed to fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is empty" 1>&2
+        exit 1
+    fi
+    ## If $HOME/.config/jq does not exist, do not fallback to $HOME/.config/
+    if unset XDG_CONFIG_HOME; HOME="$mods/home1" $VALGRIND $Q $JQ -nr 'include "cfg"; test' 2>/dev/null; then
+        echo "Should not fallback to \$HOME/.config/ when \$HOME/.config/jq does not exist" 1>&2
         exit 1
     fi
 fi

--- a/tests/shtest
+++ b/tests/shtest
@@ -375,6 +375,42 @@ if ! HOME="$mods/home2" $VALGRIND $Q $JQ -n 'include "g"; empty'; then
     exit 1
 fi
 
+# Test handling of $XDG_CONFIG_HOME.
+
+## If $XDG_CONFIG_HOME is set, load module from $XDG_CONFIG_HOME/jq/
+if [ "$(HOME=/nonexistent XDG_CONFIG_HOME="$mods/xdg1" $VALGRIND $Q $JQ -nr 'include "xdg"; test')" != "foo" ]; then
+    echo "Failed to load module from \$XDG_CONFIG_HOME/jq/" 1>&2
+    exit 1
+fi
+## ~/.jq/ should be searched before $XDG_CONFIG_HOME/jq/
+if [ "$(HOME="$mods/home3" XDG_CONFIG_HOME="$mods/xdg2" $VALGRIND $Q $JQ -nr 'include "priority_test"; test')" != "qux" ]; then
+    echo "~/.jq/ should take priority over \$XDG_CONFIG_HOME/jq/" 1>&2
+    exit 1
+fi
+if $msys || $mingw; then
+    ## If $XDG_CONFIG_HOME is unset, do not fallback to $HOME/.config/jq/
+    if unset XDG_CONFIG_HOME; HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test' 2>/dev/null; then
+        echo "Windows should not fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is unset" 1>&2
+        exit 1
+    fi
+    ## If $XDG_CONFIG_HOME is an empty string, do not fallback to $HOME/.config/jq/
+    if XDG_CONFIG_HOME="" HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test' 2>/dev/null; then
+        echo "Windows should not fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is empty" 1>&2
+        exit 1
+    fi
+else
+    ## If $XDG_CONFIG_HOME is unset, fallback to $HOME/.config/jq/
+    if [ "$(unset XDG_CONFIG_HOME; HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test')" != "bar" ]; then
+        echo "Failed to fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is unset" 1>&2
+        exit 1
+    fi
+    ## If $XDG_CONFIG_HOME is an empty string, fallback to $HOME/.config/jq/
+    if [ "$(XDG_CONFIG_HOME="" HOME="$mods/home3" $VALGRIND $Q $JQ -nr 'include "cfg"; test')" != "bar" ]; then
+        echo "Failed to fallback to \$HOME/.config/jq/ when \$XDG_CONFIG_HOME is empty" 1>&2
+        exit 1
+    fi
+fi
+
 cd "$JQBASEDIR" # so that relative library paths are guaranteed correct
 if ! $VALGRIND $Q $JQ -L ./tests/modules -ne 'import "test_bind_order" as check; check::check==true'; then
     echo "Issue #817 regression?" 1>&2


### PR DESCRIPTION
# Overview

Add support for the `$XDG_CONFIG_HOME` environment variable in module search path, following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/).

Related issue: #2966 

# Changes

Expand `$JQ_CONFIG_HOME` in module search path like `$ORIGIN`.

The actual value is resolved as follows:

1. `$XDG_CONFIG_HOME/jq` if the environment variable `$XDG_CONFIG_HOME` is set and the directory exists
2. Non-Windows platforms: `$HOME/.config/jq` if the directory exists
3. `$HOME/.jq`

In addition, the default module search path is changed:

- `~/.jq` → `$JQ_CONFIG_HOME` (changed)
- `$ORIGIN/../lib/jq`
- `$ORIGIN/../lib`


## Original Changes

> [!note]
> This section describes the original changes before code review.

Expand `$XDG_CONFIG_HOME/` in module search path to the value of the environment variable `$XDG_CONFIG_HOME` like `$ORIGIN`.

If `$XDG_CONFIG_HOME` is unset or empty,

- Non-Windows: falls back to `$HOME/.config`, which is suggested by XDG Base Directory Specification
- Windows: removes the path from search path list

In addition, add `$XDG_CONFIG_HOME/jq` to the default module search path. Search order is as follows:

- `~/.jq`
- `$XDG_CONFIG_HOME/jq` (added)
- `$ORIGIN/../lib/jq`
- `$ORIGIN/../lib`

`~/.jq` takes priority over `$XDG_CONFIG_HOME/jq` to keep compatibility.

# References

- [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/)
