### PR TITLE
jq --in-place semantics

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -152,6 +152,40 @@ sections:
 
         Like `-r` but jq won't print a newline after each output.
 
+      * `--in-place` / `-i`:
+
+        Edit one file in place by writing output to a temporary file in
+        the same directory, then renaming it over the original.
+
+        This follows `sed -i`-style direct-file usage:
+
+        * the input file is also the output target;
+        * exactly one input file argument is required;
+        * stdin (`-`) is rejected;
+        * using multiple input files is rejected;
+        * combining with `--null-input` / `-n` is rejected.
+
+        On jq compile/runtime/system errors, jq leaves the original file
+        unchanged and removes temporary output.
+
+        Examples:
+
+        * Increment a field and keep output compact:
+
+          `jq -c --in-place '.count += 1' state.json`
+
+        * Normalize key order in-place:
+
+          `jq -S --in-place '.' config.json`
+
+        * Slurp multiple JSON texts from one file, transform once, write back:
+
+          `jq -s --in-place 'map(.enabled = true)' records.json`
+
+        * Produce non-JSON text in-place (valid, but replaces file with raw text):
+
+          `jq -r --in-place '.items[]' items.json`
+
       * `--ascii-output` / `-a`:
 
         jq usually outputs non-ASCII Unicode codepoints as UTF-8, even

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -168,7 +168,11 @@ sections:
         On jq compile/runtime/system errors, jq leaves the original file
         unchanged and removes temporary output.
 
-        Examples:
+        Example usage patterns:
+
+        * Update a package version from a shell variable:
+
+          `jq -i ".version = ${VER}" package.json`
 
         * Increment a field and keep output compact:
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "February 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -100,9 +100,55 @@ Like \fB\-r\fR but jq will print NUL instead of newline after each output\. This
 Like \fB\-r\fR but jq won\'t print a newline after each output\.
 .
 .TP
-\fB\-\-ascii\-output\fR / \fB\-a\fR:
+\fB\-\-in\-place\fR / \fB\-i\fR:
 .
 .IP
+Edit one file in place by writing output to a temporary file in the same directory, then renaming it over the original\.
+.
+.IP
+This follows \fBsed \-i\fR\-style direct\-file usage:
+.
+.IP "\(bu" 4
+the input file is also the output target;
+.
+.IP "\(bu" 4
+exactly one input file argument is required;
+.
+.IP "\(bu" 4
+stdin (\fB\-\fR) is rejected;
+.
+.IP "\(bu" 4
+using multiple input files is rejected;
+.
+.IP "\(bu" 4
+combining with \fB\-\-null\-input\fR / \fB\-n\fR is rejected\.
+.
+.IP "" 0
+.
+.P
+On jq compile/runtime/system errors, jq leaves the original file unchanged and removes temporary output\.
+.
+.P
+Examples:
+.
+.IP "\(bu" 4
+Increment a field and keep output compact:\fBjq \-c \-\-in\-place \'\.count += 1\' state\.json\fR
+.
+.IP "\(bu" 4
+Normalize key order in\-place:\fBjq \-S \-\-in\-place \'\.\' config\.json\fR
+.
+.IP "\(bu" 4
+Slurp multiple JSON texts from one file, transform once, write back:\fBjq \-s \-\-in\-place \'map(\.enabled = true)\' records\.json\fR
+.
+.IP "\(bu" 4
+Produce non\-JSON text in\-place (valid, but replaces file with raw text):\fBjq \-r \-\-in\-place \'\.items[]\' items\.json\fR
+.
+.IP "\(bu" 4
+\fB\-\-ascii\-output\fR / \fB\-a\fR:
+.
+.IP "" 0
+.
+.P
 jq usually outputs non\-ASCII Unicode codepoints as UTF\-8, even if the input specified them as escape sequences (like "\eu03bc")\. Using this option, you can force jq to produce pure ASCII output with every non\-ASCII character replaced with the equivalent escape sequence\.
 .
 .TP

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "February 2026" "" ""
+.TH "JQ" "1" "March 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -129,7 +129,10 @@ combining with \fB\-\-null\-input\fR / \fB\-n\fR is rejected\.
 On jq compile/runtime/system errors, jq leaves the original file unchanged and removes temporary output\.
 .
 .P
-Examples:
+Example usage patterns:
+.
+.IP "\(bu" 4
+Update a package version from a shell variable:\fBjq \-i "\.version = ${VER}" package\.json\fR
 .
 .IP "\(bu" 4
 Increment a field and keep output compact:\fBjq \-c \-\-in\-place \'\.count += 1\' state\.json\fR

--- a/src/main.c
+++ b/src/main.c
@@ -358,6 +358,9 @@ int main(int argc, char* argv[]) {
   int options = 0;
   const char *in_place_input = NULL;
   char *in_place_tmp = NULL;
+#ifdef WIN32
+  int binary_mode = 0;
+#endif
 
 #ifdef HAVE_SETLOCALE
   (void) setlocale(LC_ALL, "");
@@ -482,6 +485,7 @@ int main(int argc, char* argv[]) {
           }
         } else if (isoption(&text, 'b', "binary", is_short)) {
 #ifdef WIN32
+          binary_mode = 1;
           fflush(stdout);
           fflush(stderr);
           _setmode(fileno(stdin),  _O_BINARY);
@@ -705,7 +709,12 @@ int main(int argc, char* argv[]) {
       ret = JQ_ERROR_SYSTEM;
       goto out;
     }
-    if (freopen(in_place_tmp, "w", stdout) == NULL) {
+    const char *in_place_mode = "w";
+#ifdef WIN32
+    if (binary_mode)
+      in_place_mode = "wb";
+#endif
+    if (freopen(in_place_tmp, in_place_mode, stdout) == NULL) {
       fprintf(stderr, "jq: error: cannot redirect output for --in-place: %s\n", strerror(errno));
       unlink(in_place_tmp);
       ret = JQ_ERROR_SYSTEM;

--- a/src/main.c
+++ b/src/main.c
@@ -720,6 +720,10 @@ int main(int argc, char* argv[]) {
       ret = JQ_ERROR_SYSTEM;
       goto out;
     }
+#ifdef WIN32
+    if (binary_mode)
+      _setmode(fileno(stdout), _O_BINARY);
+#endif
     // In-place output is written to a file, not an interactive terminal.
     dumpopts &= ~JV_PRINT_ISATTY;
     if (!(options & COLOR_OUTPUT))

--- a/src/main.c
+++ b/src/main.c
@@ -610,6 +610,10 @@ int main(int argc, char* argv[]) {
       fprintf(stderr, "jq: --in-place requires exactly one input file\n");
       die();
     }
+    if (options & PROVIDE_NULL) {
+      fprintf(stderr, "jq: --in-place cannot be used with --null-input\n");
+      die();
+    }
 
     size_t tlen = strlen(in_place_input) + sizeof(".XXXXXX");
     in_place_tmp = malloc(tlen);

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ static void usage(int code, int keep_it_short) {
       "Command options:\n"
       "  -n, --null-input          use `null` as the single input value;\n"
       "  -R, --raw-input           read each line as string instead of JSON;\n"
+      "  -i, --in-place            update the input file in place;\n"
       "  -s, --slurp               read all inputs into an array and use it as\n"
       "                            the single input value;\n"
       "  -c, --compact-output      compact instead of pretty-printed output;\n"
@@ -104,7 +105,6 @@ static void usage(int code, int keep_it_short) {
       "      --jsonargs            consume remaining arguments as positional\n"
       "                            JSON values;\n"
       "  -e, --exit-status         set exit status code based on the output;\n"
-      "  -i, --in-place            update the input file in place;\n"
 #ifdef WIN32
       "  -b, --binary              open input/output streams in binary mode;\n"
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -612,7 +612,12 @@ int main(int argc, char* argv[]) {
     }
 
     size_t tlen = strlen(in_place_input) + sizeof(".XXXXXX");
-    in_place_tmp = jv_mem_alloc(tlen);
+    in_place_tmp = malloc(tlen);
+    if (in_place_tmp == NULL) {
+      fprintf(stderr, "jq: error: out of memory\n");
+      ret = JQ_ERROR_SYSTEM;
+      goto out;
+    }
     int n = snprintf(in_place_tmp, tlen, "%s.XXXXXX", in_place_input);
     assert(n > 0 && (size_t)n < tlen);
 
@@ -763,7 +768,7 @@ out:
     } else {
       unlink(in_place_tmp);
     }
-    jv_mem_free(in_place_tmp);
+    free(in_place_tmp);
   }
 
   jv_free(ARGS);

--- a/src/main.c
+++ b/src/main.c
@@ -655,6 +655,10 @@ int main(int argc, char* argv[]) {
       ret = JQ_ERROR_SYSTEM;
       goto out;
     }
+    // In-place output is written to a file, not an interactive terminal.
+    dumpopts &= ~JV_PRINT_ISATTY;
+    if (!(options & COLOR_OUTPUT))
+      dumpopts &= ~JV_PRINT_COLOR;
   }
 
   if (options & FROM_FILE) {

--- a/tests/shtest
+++ b/tests/shtest
@@ -136,6 +136,24 @@ $VALGRIND $Q $JQ -c -i '.+1' $d/inplace-numbers.json
 printf '2\n3\n' > $d/expected
 cmp $d/inplace-numbers.json $d/expected
 
+# Make sure in-place output is not terminal-colorized by default
+test_in_place_color=true
+$msys  && test_in_place_color=false
+$mingw && test_in_place_color=false
+if $test_in_place_color && command -v script >/dev/null 2>&1; then
+  if script -qc echo /dev/null >/dev/null 2>&1; then
+    faketty() { script -qec "$*" /dev/null; }
+  else # macOS
+    faketty() { script -q /dev/null "$@" /dev/null |
+      sed 's/^\x5E\x44\x08\x08//'; }
+  fi
+
+  printf '{"x":1}\n' > $d/inplace-color.json
+  faketty $JQ_NO_B --in-place '.x = 2' $d/inplace-color.json > /dev/null
+  printf '{\n  "x": 2\n}\n' > $d/expected
+  cmp $d/inplace-color.json $d/expected
+fi
+
 # sed-like unhappy paths from issue discussions
 ret=0
 if $JQ --in-place '.+1' > /dev/null 2>&1; then

--- a/tests/shtest
+++ b/tests/shtest
@@ -140,14 +140,19 @@ cmp $d/inplace-numbers.json $d/expected
 test_in_place_color=true
 $msys  && test_in_place_color=false
 $mingw && test_in_place_color=false
+have_faketty=false
 if $test_in_place_color && command -v script >/dev/null 2>&1; then
   if script -qc echo /dev/null >/dev/null 2>&1; then
     faketty() { script -qec "$*" /dev/null; }
-  else # macOS
+    have_faketty=true
+  elif script -q /dev/null echo >/dev/null 2>&1; then # macOS
     faketty() { script -q /dev/null "$@" /dev/null |
       sed 's/^\x5E\x44\x08\x08//'; }
+    have_faketty=true
   fi
+fi
 
+if $have_faketty; then
   printf '{"x":1}\n' > $d/inplace-color.json
   faketty $JQ_NO_B --in-place '.x=2' $d/inplace-color.json > /dev/null
   printf '{\n  "x": 2\n}\n' > $d/expected

--- a/tests/shtest
+++ b/tests/shtest
@@ -149,7 +149,7 @@ if $test_in_place_color && command -v script >/dev/null 2>&1; then
   fi
 
   printf '{"x":1}\n' > $d/inplace-color.json
-  faketty $JQ_NO_B --in-place '.x = 2' $d/inplace-color.json > /dev/null
+  faketty $JQ_NO_B --in-place '.x=2' $d/inplace-color.json > /dev/null
   printf '{\n  "x": 2\n}\n' > $d/expected
   cmp $d/inplace-color.json $d/expected
 fi

--- a/tests/shtest
+++ b/tests/shtest
@@ -136,6 +136,16 @@ $VALGRIND $Q $JQ -c -i '.+1' $d/inplace-numbers.json
 printf '2\n3\n' > $d/expected
 cmp $d/inplace-numbers.json $d/expected
 
+# sed-like unhappy paths from issue discussions
+ret=0
+if $JQ --in-place '.+1' > /dev/null 2>&1; then
+  echo "--in-place must reject missing input file argument" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 2 ]
+
 ret=0
 if printf '1\n' | $JQ --in-place '.+1' - > /dev/null 2>&1; then
   echo "--in-place must reject stdin as input file" 1>&2
@@ -159,6 +169,56 @@ printf '1\n' > $d/expected
 cmp $d/inplace-a.json $d/expected
 printf '2\n' > $d/expected
 cmp $d/inplace-b.json $d/expected
+
+ret=0
+if $JQ -n --in-place '.+1' $d/inplace-a.json > /dev/null 2>&1; then
+  echo "--in-place must reject --null-input" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 2 ]
+
+# Preserve original file on compile and runtime errors
+printf '{"k":1}\n' > $d/inplace-error.json
+ret=0
+if $JQ --in-place '.+=' $d/inplace-error.json > /dev/null 2>&1; then
+  echo "--in-place should fail on compile error" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 3 ]
+printf '{"k":1}\n' > $d/expected
+cmp $d/inplace-error.json $d/expected
+
+ret=0
+if $JQ --in-place 'error("boom")' $d/inplace-error.json > /dev/null 2>&1; then
+  echo "--in-place should fail on runtime error" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 5 ]
+printf '{"k":1}\n' > $d/expected
+cmp $d/inplace-error.json $d/expected
+
+# mkstemp failure path: non-writable directory
+mkdir $d/inplace-ro
+printf '1\n' > $d/inplace-ro/file.json
+chmod 0555 $d/inplace-ro
+ret=0
+if $JQ --in-place '.+1' $d/inplace-ro/file.json > /dev/null 2>&1; then
+  echo "--in-place should fail when temp file cannot be created" 1>&2
+  chmod 0755 $d/inplace-ro
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 2 ]
+chmod 0755 $d/inplace-ro
+printf '1\n' > $d/expected
+cmp $d/inplace-ro/file.json $d/expected
 
 
 # Regression test for #951

--- a/tests/shtest
+++ b/tests/shtest
@@ -226,21 +226,23 @@ printf '{"k":1}\n' > $d/expected
 cmp $d/inplace-error.json $d/expected
 
 # mkstemp failure path: non-writable directory
-mkdir $d/inplace-ro
-printf '1\n' > $d/inplace-ro/file.json
-chmod 0555 $d/inplace-ro
-ret=0
-if $JQ --in-place '.+1' $d/inplace-ro/file.json > /dev/null 2>&1; then
-  echo "--in-place should fail when temp file cannot be created" 1>&2
+if ! $msys && ! $mingw; then
+  mkdir $d/inplace-ro
+  printf '1\n' > $d/inplace-ro/file.json
+  chmod 0555 $d/inplace-ro
+  ret=0
+  if $JQ --in-place '.+1' $d/inplace-ro/file.json > /dev/null 2>&1; then
+    echo "--in-place should fail when temp file cannot be created" 1>&2
+    chmod 0755 $d/inplace-ro
+    exit 1
+  else
+    ret=$?
+  fi
+  [ $ret -eq 2 ]
   chmod 0755 $d/inplace-ro
-  exit 1
-else
-  ret=$?
+  printf '1\n' > $d/expected
+  cmp $d/inplace-ro/file.json $d/expected
 fi
-[ $ret -eq 2 ]
-chmod 0755 $d/inplace-ro
-printf '1\n' > $d/expected
-cmp $d/inplace-ro/file.json $d/expected
 
 
 # Regression test for #951

--- a/tests/shtest
+++ b/tests/shtest
@@ -125,6 +125,41 @@ printf "$data" | $JQ --exit-status 'select(.i==2) | false' > /dev/null 2>&1 || r
 [ $ret -eq 1 ]
 printf "$data" | $JQ --exit-status 'select(.i==2) | true' > /dev/null 2>&1
 
+# Test --in-place / -i (no backup suffix argument needed)
+printf '{"n":1}\n' > $d/inplace.json
+$VALGRIND $Q $JQ -c --in-place '.n += 1' $d/inplace.json
+printf '{"n":2}\n' > $d/expected
+cmp $d/inplace.json $d/expected
+
+printf '1\n2\n' > $d/inplace-numbers.json
+$VALGRIND $Q $JQ -c -i '.+1' $d/inplace-numbers.json
+printf '2\n3\n' > $d/expected
+cmp $d/inplace-numbers.json $d/expected
+
+ret=0
+if printf '1\n' | $JQ --in-place '.+1' - > /dev/null 2>&1; then
+  echo "--in-place must reject stdin as input file" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 2 ]
+
+printf '1\n' > $d/inplace-a.json
+printf '2\n' > $d/inplace-b.json
+ret=0
+if $JQ --in-place '.+1' $d/inplace-a.json $d/inplace-b.json > /dev/null 2>&1; then
+  echo "--in-place must reject multiple input files" 1>&2
+  exit 1
+else
+  ret=$?
+fi
+[ $ret -eq 2 ]
+printf '1\n' > $d/expected
+cmp $d/inplace-a.json $d/expected
+printf '2\n' > $d/expected
+cmp $d/inplace-b.json $d/expected
+
 
 # Regression test for #951
 printf '"a\n' > $d/input

--- a/tests/shtest
+++ b/tests/shtest
@@ -142,12 +142,11 @@ $msys  && test_in_place_color=false
 $mingw && test_in_place_color=false
 have_faketty=false
 if $test_in_place_color && command -v script >/dev/null 2>&1; then
-  if script -qc echo /dev/null >/dev/null 2>&1; then
-    faketty() { script -qec "$*" /dev/null; }
+  if script -qec true /dev/null >/dev/null 2>&1; then
+    faketty() { script -qec "$*" /dev/null >/dev/null; }
     have_faketty=true
-  elif script -q /dev/null echo >/dev/null 2>&1; then # macOS
-    faketty() { script -q /dev/null "$@" /dev/null |
-      sed 's/^\x5E\x44\x08\x08//'; }
+  elif script -q /dev/null true >/dev/null 2>&1; then # macOS/BSD
+    faketty() { script -q /dev/null "$@" >/dev/null; }
     have_faketty=true
   fi
 fi


### PR DESCRIPTION
Add `--in-place` editing mode to `jq` with `sed -i` semantics.

This PR implements the `--in-place` option, allowing `jq` to modify a single input file directly, similar to `sed -i`. It ensures atomic updates by writing to a temporary file and then renaming it, preserving original file permissions and handling errors gracefully.

# Historical context / references

Original feature request: https://github.com/jqlang/jq/issues/105
Prior attempt: https://github.com/jqlang/jq/pull/2616
Original -i implementation in jq history by @nicowilliams (commit 01fc816, later removed in b82c231)
Follow-up unhappy-path discussion: https://github.com/jqlang/jq/issues/704

# Documentation (from new manual.yml)

> 
> ## `--in-place` / `-i`
>  
> This adds direct-file in-place editing semantics similar to `sed -i`:
>  
> - the input file is also the output target;
> - jq writes to a temporary file in the same directory, then renames into place;
> - exactly one input file argument is required.
>  
> ### Example usage patterns
>  
> #### 1) Update a package version from a shell variable
> ```bash
>  jq -i ".version = ${VER}" package.json
> ```
>  
> #### 2) Compact JSON rewrite in place
> ```bash
> jq -c --in-place '.count += 1' state.json
> ```
>  
> #### 3) Normalize key order in place
> ```bash
> jq -S --in-place '.' config.json
> ```
>  
> #### 4) Slurp + transform + write back to same file
> ```bash
> jq -s --in-place 'map(.enabled = true)' records.json
> ```
>  
> #### 5) Raw-text output in place (intentional non-JSON file replacement)
> ```bash
> jq -r --in-place '.items[]' items.json
> ```
>  
> ### Invalid combinations / unhappy paths (now explicitly handled)
>  
> #### Missing file argument
> ```bash
> jq --in-place '.+1'
> # exits non-zero (usage error)
> ```
>  
> #### stdin target is rejected
> ```bash
> printf '1\n' | jq --in-place '.+1' -
> # exits non-zero (usage error)
> ```
>  
> #### Multiple file arguments are rejected
> ```bash
> jq --in-place '.+1' a.json b.json
> # exits non-zero (usage error)
>```
>  
> #### `--null-input` cannot be combined with `--in-place`
> ```bash
> jq -n --in-place '.+1' a.json
> # exits non-zero (usage error)
> ```
>  
> ### Failure safety guarantees
>  
> If jq fails, the original input file is preserved:
>  
> - compile error (e.g. invalid filter) leaves original file unchanged;
> - runtime error (e.g. `error("boom")`) leaves original file unchanged;
> - temp-file creation failure (e.g. non-writable directory) leaves original file unchanged.
>  
> Temporary output is cleaned up on error.

