### PR TITLE
Fix isfinite to return false for NaN

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -50,7 +50,7 @@ def index($i):   indices($i) | .[0];       # TODO: optimize
 def rindex($i):  indices($i) | .[-1:][0];  # TODO: optimize
 def paths: path(recurse)|select(length > 0);
 def paths(node_filter): path(recurse|select(node_filter))|select(length > 0);
-def isfinite: type == "number" and (isinfinite | not);
+def isfinite: type == "number" and (isinfinite | not) and (isnan | not);
 def arrays: select(type == "array");
 def objects: select(type == "object");
 def iterables: select(type|. == "array" or . == "object");

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -694,6 +694,14 @@ null
 null
 [true,true]
 
+nan|isfinite
+null
+false
+
+[0, 1, nan, infinite, -infinite] | map(isfinite)
+null
+[true, true, false, false, false]
+
 1 + tonumber + ("10" | tonumber)
 4
 15


### PR DESCRIPTION
The isfinite builtin incorrectly returned true for NaN because it only checked for infinity, not for NaN. A finite number is neither infinite nor NaN.