### PR TITLE
Bind only `$x`, not `x` in `def f($x): ...`

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -553,7 +553,9 @@ block gen_function(const char* name, block formals, block body) {
     i->nformals = 0;
     if (i->op == CLOSURE_PARAM_REGULAR) {
       i->op = CLOSURE_PARAM;
-      body = gen_var_binding(gen_call(i->symbol, gen_noop()), i->symbol, body);
+      char *regular = strdup("@regular");
+      body = gen_var_binding(gen_call(regular, gen_noop()), i->symbol, body);
+      i->symbol = regular;
     }
     block_bind_subblock(inst_block(i), body, OP_IS_CALL_PSEUDO | OP_HAS_BINDING, 0);
   }


### PR DESCRIPTION
@wader brought to my attention in https://github.com/01mf02/jaq/issues/428 that jq currently has the following behaviour:

~~~
$ jq -cn 'def f($a): [a],$a; f(1,2)'
[1,2]
1
[1,2]
2
~~~

That means that in a function `f($a)`, both `a` and `$a` are bound. This has already been pointed out by @pkoppstein in @nicowilliams's PR #524, which added "regular" definition arguments (where "regular" means "$..." here).

This PR tries to rectify this, by changing how to compile regular definition arguments. Let us use @wader's example above and see what it rewrites to:

~~~ jq
# before
def f(x0): x0 as a | a as $a | [a], $a;
# after
def f(x0): x0 as @regular | @regular as $a | [a], $a;
~~~

The only change is that it binds any regular argument as `@regular`, which is a variable name that cannot be referenced by the user.

This excludes a few programs that previously compiled (including @wader's example above):

~~~
# before
$ jq -n 'def f($a): a; f(1)'
1
# after
$ jq -n 'def f($a): a; f(1)'
jq: error: a/0 is not defined at <top-level>, line 1, column 12:
    def f($a): a; f(1)
               ^
jq: 1 compile error
~~~

Furthermore, it changes the meaning of some programs:

~~~
# before
$ jq -nc 'def foo(a;$a):[a,$a]; foo(1;2)'
[2,2]
# after
$ jq -nc 'def foo(a;$a):[a,$a]; foo(1;2)'
[1,2]
~~~