### PR TITLE
parse: reject numeric literals with unterminated fraction

### DIFF
--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -611,17 +611,14 @@ static void jv_test(void) {
     jv_free(v);
   }
   {
-    jv v = jv_parse("23.");
-    assert(jv_get_kind(v) == JV_KIND_INVALID);
-    v = jv_invalid_get_msg(v);
-    assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
-    jv_free(v);
-
-    v = jv_parse("23.e1");
-    assert(jv_get_kind(v) == JV_KIND_INVALID);
-    v = jv_invalid_get_msg(v);
-    assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
-    jv_free(v);
+    const char* invalid_numbers[] = {"23.", "23.e1", "0.", "-1."};
+    for (size_t i = 0; i < sizeof(invalid_numbers) / sizeof(invalid_numbers[0]); i++) {
+      jv v = jv_parse(invalid_numbers[i]);
+      assert(jv_get_kind(v) == JV_KIND_INVALID);
+      v = jv_invalid_get_msg(v);
+      assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
+      jv_free(v);
+    }
   }
   /// Arrays and numbers
   {

--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -610,6 +610,19 @@ static void jv_test(void) {
     assert(strcmp(jv_string_value(v), "Expected separator between values at line 1, column 9 (while parsing '{\"a':\"12\"}')") == 0);
     jv_free(v);
   }
+  {
+    jv v = jv_parse("23.");
+    assert(jv_get_kind(v) == JV_KIND_INVALID);
+    v = jv_invalid_get_msg(v);
+    assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
+    jv_free(v);
+
+    v = jv_parse("23.e1");
+    assert(jv_get_kind(v) == JV_KIND_INVALID);
+    v = jv_invalid_get_msg(v);
+    assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
+    jv_free(v);
+  }
   /// Arrays and numbers
   {
     jv a = jv_array();

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -530,6 +530,10 @@ static pfunc check_literal(struct jv_parser* p) {
   } else {
     // FIXME: better parser
     p->tokenbuf[p->tokenpos] = 0;
+    const char* dot = strchr(p->tokenbuf, '.');
+    if (dot && (dot[1] < '0' || dot[1] > '9')) {
+      return "Invalid numeric literal";
+    }
 #ifdef USE_DECNUM
     jv number = jv_number_with_literal(p->tokenbuf);
     if (jv_get_kind(number) == JV_KIND_INVALID) {

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2499,6 +2499,14 @@ try fromjson catch .
 "{'a': 123}"
 "Invalid string literal; expected \", but got ' at line 1, column 5 (while parsing '{'a': 123}')"
 
+.[] | try fromjson catch .
+["23.","23.e1","0.","-1.","23.0"]
+"Invalid numeric literal at EOF at line 1, column 3 (while parsing '23.')"
+"Invalid numeric literal at EOF at line 1, column 5 (while parsing '23.e1')"
+"Invalid numeric literal at EOF at line 1, column 2 (while parsing '0.')"
+"Invalid numeric literal at EOF at line 1, column 3 (while parsing '-1.')"
+23.0
+
 # ltrimstr/1 rtrimstr/1 don't leak on invalid input #2977
 
 try ltrimstr(1) catch "x", try rtrimstr(1) catch "x" | "ok"


### PR DESCRIPTION
Fixes #2414.

Before this change, jq accepted numeric literals like `23.`, `23.e1`, `0.`, and `-1.` even though a fraction must contain at least one digit after `.`.

This updates `check_literal()` to reject number tokens whose decimal point is not followed by a digit before they reach the numeric conversion helpers. The change is intentionally limited to this unterminated-fraction family so it does not alter other numeric forms that jq's existing tests currently exercise.

Validation:
- `tests/jqtest`
- `make check`
