### PR TITLE
docs: fix "happened" spelling in tutorial changelog entries

### DIFF
--- a/docs/content/tutorial/default.yml
+++ b/docs/content/tutorial/default.yml
@@ -207,7 +207,7 @@ body:
         "name": "Nico Williams"
       }
       {
-        "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happend because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
+        "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happened because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
         "name": "Nico Williams"
       }
       {
@@ -249,7 +249,7 @@ body:
           "name": "Nico Williams"
         },
         {
-          "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happend because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
+          "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happened because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
           "name": "Nico Williams"
         },
         {
@@ -300,7 +300,7 @@ body:
           ]
         },
         {
-          "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happend because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
+          "message": "Fix iteration problem for non decimal string\n\nWhen the string transformation to number failed, all following\ntransformation failed too.\n\nThis happened because status in decNumberFromString function is\nupdated just in error case. Reusing the DEC_CONTEXT that failed\nbefore results into error even if the string is valid number.",
           "name": "Nico Williams",
           "parents": [
             "https://github.com/jqlang/jq/commit/174db0f93552bdb551ae1f3c5c64744df0ad8e2f"


### PR DESCRIPTION
## Summary
- Fix `happend` -> `happened` in duplicated tutorial changelog entry text in `docs/content/tutorial/default.yml`.

## Related issue
- N/A (trivial docs typo fix)

## Validation
- Not run; docs-only wording change.