### PR TITLE
Add options `--rawfd` and `--slurpfd`

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -266,6 +266,20 @@ sections:
         available in the program and has a string whose content is set to the text
         in the file named `bar`.
 
+      * `--slurpfd variable-name fd`:
+
+        This option is just like `--slurpfile` except it reads from the file
+        descriptor `fd` (specified as a decimal integer). The parent process of
+        jq is expected to have opened `fd` for reading and set it up to be
+        inherited by jq.
+
+      * `--rawfd variable-name fd`:
+
+        This option is just like `--rawfile` except it reads from the file
+        descriptor `fd` (specified as a decimal integer). The parent process of
+        jq is expected to have opened `fd` for reading and set it up to be
+        inherited by jq.
+
       * `--args`:
 
         Remaining arguments are positional string arguments.  These are

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "May 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -200,6 +200,18 @@ This option reads all the JSON texts in the named file and binds an array of the
 .
 .IP
 This option reads in the named file and binds its content to the given global variable\. If you run jq with \fB\-\-rawfile foo bar\fR, then \fB$foo\fR is available in the program and has a string whose content is set to the text in the file named \fBbar\fR\.
+.
+.TP
+\fB\-\-slurpfd variable\-name fd\fR:
+.
+.IP
+This option is just like \fB\-\-slurpfile\fR except it reads from the file descriptor \fBfd\fR (specified as a decimal integer)\. The parent process of jq is expected to have opened \fBfd\fR for reading and set it up to be inherited by jq\.
+.
+.TP
+\fB\-\-rawfd variable\-name fd\fR:
+.
+.IP
+This option is just like \fB\-\-rawfile\fR except it reads from the file descriptor \fBfd\fR (specified as a decimal integer)\. The parent process of jq is expected to have opened \fBfd\fR for reading and set it up to be inherited by jq\.
 .
 .TP
 \fB\-\-args\fR:

--- a/src/jv.h
+++ b/src/jv.h
@@ -249,7 +249,8 @@ jv jv_parse_custom_flags(const char* string, int flags);
 typedef void (*jv_nomem_handler_f)(void *);
 void jv_nomem_handler(jv_nomem_handler_f, void *);
 
-jv jv_load_file(const char *, int, int);
+jv jv_load_from_fd(int, const char*, int);
+jv jv_load_file(const char*, int);
 
 typedef struct jv_parser jv_parser;
 jv_parser* jv_parser_new(int);

--- a/src/jv.h
+++ b/src/jv.h
@@ -249,7 +249,7 @@ jv jv_parse_custom_flags(const char* string, int flags);
 typedef void (*jv_nomem_handler_f)(void *);
 void jv_nomem_handler(jv_nomem_handler_f, void *);
 
-jv jv_load_file(const char *, int);
+jv jv_load_file(const char *, int, int);
 
 typedef struct jv_parser jv_parser;
 jv_parser* jv_parser_new(int);

--- a/src/jv_file.c
+++ b/src/jv_file.c
@@ -2,6 +2,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,27 +10,52 @@
 #include "jv.h"
 #include "jv_unicode.h"
 
-jv jv_load_file(const char* filename, int raw) {
+static int jv_strtofd(const char* decimal) {
+  if(!('0' <= *decimal && *decimal <= '9')) return -1;
+  intmax_t parsed = strtoimax(decimal, (char**)&decimal, 10);
+  int fd = parsed;
+  if(*decimal || fd != parsed) return -1;
+  return fd;
+}
+
+jv jv_load_file(const char* source, int raw, int is_fd) {
   struct stat sb;
-  int fd = open(filename, O_RDONLY);
-  if (fd == -1) {
-    return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
-                                             filename,
-                                             strerror(errno)));
+  int fd;
+  if(is_fd) {
+    fd = jv_strtofd(source);
+    if(fd == -1) {
+      return jv_invalid_with_msg(jv_string_fmt("Not a file descriptor: %s",
+                                               source));
+    }
+  } else {
+    fd = open(source, O_RDONLY);
+    if (fd == -1) {
+      return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
+                                               source,
+                                               strerror(errno)));
+    }
   }
-  if (fstat(fd, &sb) == -1 || S_ISDIR(sb.st_mode)) {
-    close(fd);
-    return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
-                                             filename,
+  if (fstat(fd, &sb) == -1) {
+    int staterr = errno;
+    if(!is_fd) close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Cannot stat %s%s: %s",
+                                             is_fd ? "FD " : "", source,
+                                             strerror(staterr)));
+  }
+  if (S_ISDIR(sb.st_mode)) {
+    if(!is_fd) close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Cannot read %s%s: %s",
+                                             is_fd ? "FD " : "", source,
                                              "It's a directory"));
   }
+
   FILE* file = fdopen(fd, "r");
   struct jv_parser* parser = NULL;
   jv data;
   if (!file) {
-    close(fd);
-    return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
-                                             filename,
+    if(!is_fd) close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Could not open %s%s: %s",
+                                             is_fd ? "FD " : "", source,
                                              strerror(errno)));
   }
   if (raw) {
@@ -75,8 +101,8 @@ jv jv_load_file(const char* filename, int raw) {
   int badread = ferror(file);
   if (fclose(file) != 0 || badread) {
     jv_free(data);
-    return jv_invalid_with_msg(jv_string_fmt("Error reading from %s",
-                                             filename));
+    return jv_invalid_with_msg(jv_string_fmt("Error reading from %s%s",
+                                             is_fd ? "FD " : "", source));
   }
   return data;
 }

--- a/src/jv_file.c
+++ b/src/jv_file.c
@@ -2,7 +2,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,42 +9,19 @@
 #include "jv.h"
 #include "jv_unicode.h"
 
-static int jv_strtofd(const char* decimal) {
-  if(!('0' <= *decimal && *decimal <= '9')) return -1;
-  intmax_t parsed = strtoimax(decimal, (char**)&decimal, 10);
-  int fd = parsed;
-  if(*decimal || fd != parsed) return -1;
-  return fd;
-}
-
-jv jv_load_file(const char* source, int raw, int is_fd) {
+jv jv_load_from_fd(int fd, const char *fd_description, int raw) {
   struct stat sb;
-  int fd;
-  if(is_fd) {
-    fd = jv_strtofd(source);
-    if(fd == -1) {
-      return jv_invalid_with_msg(jv_string_fmt("Not a file descriptor: %s",
-                                               source));
-    }
-  } else {
-    fd = open(source, O_RDONLY);
-    if (fd == -1) {
-      return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
-                                               source,
-                                               strerror(errno)));
-    }
-  }
   if (fstat(fd, &sb) == -1) {
     int staterr = errno;
-    if(!is_fd) close(fd);
-    return jv_invalid_with_msg(jv_string_fmt("Cannot stat %s%s: %s",
-                                             is_fd ? "FD " : "", source,
+    close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Cannot stat %s: %s",
+                                             fd_description,
                                              strerror(staterr)));
   }
   if (S_ISDIR(sb.st_mode)) {
-    if(!is_fd) close(fd);
-    return jv_invalid_with_msg(jv_string_fmt("Cannot read %s%s: %s",
-                                             is_fd ? "FD " : "", source,
+    close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Cannot read %s: %s",
+                                             fd_description,
                                              "It's a directory"));
   }
 
@@ -53,9 +29,9 @@ jv jv_load_file(const char* source, int raw, int is_fd) {
   struct jv_parser* parser = NULL;
   jv data;
   if (!file) {
-    if(!is_fd) close(fd);
-    return jv_invalid_with_msg(jv_string_fmt("Could not open %s%s: %s",
-                                             is_fd ? "FD " : "", source,
+    close(fd);
+    return jv_invalid_with_msg(jv_string_fmt("Could not open stream for %s: %s",
+                                             fd_description,
                                              strerror(errno)));
   }
   if (raw) {
@@ -101,8 +77,18 @@ jv jv_load_file(const char* source, int raw, int is_fd) {
   int badread = ferror(file);
   if (fclose(file) != 0 || badread) {
     jv_free(data);
-    return jv_invalid_with_msg(jv_string_fmt("Error reading from %s%s",
-                                             is_fd ? "FD " : "", source));
+    return jv_invalid_with_msg(jv_string_fmt("Error reading from %s",
+                                             fd_description));
   }
   return data;
+}
+
+jv jv_load_file(const char *filename, int raw) {
+  int fd = open(filename, O_RDONLY);
+  if (fd == -1) {
+    return jv_invalid_with_msg(jv_string_fmt("Could not open %s: %s",
+                                             filename,
+                                             strerror(errno)));
+  }
+  return jv_load_from_fd(fd, filename, raw);
 }

--- a/src/linker.c
+++ b/src/linker.c
@@ -352,9 +352,9 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
   block program;
   jv data;
   if (is_data && !raw)
-    data = jv_load_file(jv_string_value(lib_path), 0);
+    data = jv_load_file(jv_string_value(lib_path), 0, 0);
   else
-    data = jv_load_file(jv_string_value(lib_path), 1);
+    data = jv_load_file(jv_string_value(lib_path), 1, 0);
   int state_idx;
   if (!jv_is_valid(data)) {
     program = gen_noop();
@@ -412,7 +412,7 @@ jv load_module_meta(jq_state *jq, jv mod_relpath) {
   if (!jv_is_valid(lib_path))
     return lib_path;
   jv meta = jv_null();
-  jv data = jv_load_file(jv_string_value(lib_path), 1);
+  jv data = jv_load_file(jv_string_value(lib_path), 1, 0);
   if (jv_is_valid(data)) {
     block program;
     struct locfile* src = locfile_init(jq, jv_string_value(lib_path), jv_string_value(data), jv_string_length_bytes(jv_copy(data)));

--- a/src/linker.c
+++ b/src/linker.c
@@ -352,9 +352,9 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
   block program;
   jv data;
   if (is_data && !raw)
-    data = jv_load_file(jv_string_value(lib_path), 0, 0);
+    data = jv_load_file(jv_string_value(lib_path), 0);
   else
-    data = jv_load_file(jv_string_value(lib_path), 1, 0);
+    data = jv_load_file(jv_string_value(lib_path), 1);
   int state_idx;
   if (!jv_is_valid(data)) {
     program = gen_noop();
@@ -412,7 +412,7 @@ jv load_module_meta(jq_state *jq, jv mod_relpath) {
   if (!jv_is_valid(lib_path))
     return lib_path;
   jv meta = jv_null();
-  jv data = jv_load_file(jv_string_value(lib_path), 1, 0);
+  jv data = jv_load_file(jv_string_value(lib_path), 1);
   if (jv_is_valid(data)) {
     block program;
     struct locfile* src = locfile_init(jq, jv_string_value(lib_path), jv_string_value(data), jv_string_length_bytes(jv_copy(data)));

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,9 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <libgen.h>
+#include <limits.h>
 #ifdef HAVE_SETLOCALE
 #include <locale.h>
 #endif
@@ -98,6 +100,9 @@ static void usage(int code, int keep_it_short) {
       "      --slurpfile name file set $name to an array of JSON values read\n"
       "                            from the file;\n"
       "      --rawfile name file   set $name to string contents of file;\n"
+      "      --slurpfd name fd     set $name to an array of JSON values read\n"
+      "                            from the file descriptor;\n"
+      "      --rawfd name fd       set $name to string contents read from fd;\n"
       "      --args                consume remaining arguments as positional\n"
       "                            string values;\n"
       "      --jsonargs            consume remaining arguments as positional\n"
@@ -140,6 +145,57 @@ static int isoption(const char** text, char shortopt, const char* longopt, int i
     }
   }
   return 0;
+}
+
+enum arg_file {
+  NOT_ARG_FILE = 0,
+  ARG_RAW_FILE,
+  ARG_SLURP_FILE,
+  ARG_RAW_FD,
+  ARG_SLURP_FD
+};
+static enum arg_file is_arg_file_option(const char** text, int is_short) {
+  if(isoption(text, 0, "rawfile",   is_short)) return ARG_RAW_FILE;
+  if(isoption(text, 0, "slurpfile", is_short)) return ARG_SLURP_FILE;
+  if(isoption(text, 0, "rawfd",     is_short)) return ARG_RAW_FD;
+  if(isoption(text, 0, "slurpfd",   is_short)) return ARG_SLURP_FD;
+  return NOT_ARG_FILE;
+}
+static const char* show_arg_file(enum arg_file option) {
+  switch(option) {
+  case ARG_RAW_FILE:   return "rawfile";
+  case ARG_SLURP_FILE: return "slurpfile";
+  case ARG_RAW_FD:     return "rawfd";
+  case ARG_SLURP_FD:   return "slurpfd";
+  case NOT_ARG_FILE:
+  }
+  assert(0);
+}
+static int arg_file_wants_fd(enum arg_file option) {
+  switch(option) {
+  case ARG_RAW_FILE:
+  case ARG_SLURP_FILE: return 0;
+  case ARG_RAW_FD:
+  case ARG_SLURP_FD:   return 1;
+  case NOT_ARG_FILE:
+  }
+  assert(0);
+}
+static int arg_file_is_raw(enum arg_file option) {
+  switch(option) {
+  case ARG_RAW_FILE:
+  case ARG_RAW_FD:     return 1;
+  case ARG_SLURP_FILE:
+  case ARG_SLURP_FD:   return 0;
+  case NOT_ARG_FILE:
+  }
+  assert(0);
+}
+static int jq_strtofd(const char *decimal) {
+  if(!isdigit(*decimal)) return -1;
+  uintmax_t fd = strtoumax(decimal, (char**)&decimal, 10);
+  if(*decimal || fd > INT_MAX) return -1;
+  return fd;
 }
 
 enum {
@@ -374,7 +430,7 @@ int main(int argc, char* argv[]) {
         text++;
         is_short = 1;
       }
-      int raw; // Temporary for --rawfile
+      enum arg_file arg_file; // Temporary for --{raw,slurp}{file,fd}
 
       // Parse a long option in one iteration or iterate over short options
       while (text != NULL) {
@@ -480,18 +536,32 @@ int main(int argc, char* argv[]) {
             program_arguments = jv_object_set(program_arguments, jv_string(argv[i+1]), v);
           }
           i += 2; // skip the next two arguments
-        } else if ((raw = isoption(&text, 0, "rawfile", is_short)) ||
-            isoption(&text, 0, "slurpfile", is_short)) {
-          const char *which = raw ? "rawfile" : "slurpfile";
+        } else if ((arg_file = is_arg_file_option(&text, is_short))) {
           if (i >= argc - 2) {
-            fprintf(stderr, "jq: --%s takes two parameters (e.g. --%s varname filename)\n", which, which);
+            fprintf(stderr, "jq: --%s takes two parameters (e.g. --%s varname %s)\n",
+                    show_arg_file(arg_file), show_arg_file(arg_file),
+                    arg_file_wants_fd(arg_file) ? "5" : "filename");
             die();
           }
           if (!jv_object_has(jv_copy(program_arguments), jv_string(argv[i+1]))) {
-            jv data = jv_load_file(argv[i+2], raw);
+            jv data;
+            if (arg_file_wants_fd(arg_file)) {
+              int fd = jq_strtofd(argv[i+2]);
+              if(fd == -1) {
+                fprintf(stderr, "jq: not a file descriptor: %s\n", argv[i+2]);
+                die();
+              }
+              char *fd_description;
+              if(asprintf(&fd_description, "FD %d", fd) < 0) {
+                perror("malloc");
+                exit(2);
+              }
+              data = jv_load_from_fd(fd, fd_description, arg_file_is_raw(arg_file));
+              free(fd_description);
+            } else data = jv_load_file(argv[i+2], arg_file_is_raw(arg_file));
             if (!jv_is_valid(data)) {
               data = jv_invalid_get_msg(data);
-              fprintf(stderr, "jq: Bad JSON in --%s %s %s: %s\n", which,
+              fprintf(stderr, "jq: Bad JSON in --%s %s %s: %s\n", show_arg_file(arg_file),
                       argv[i+1], argv[i+2], jv_string_value(data));
               jv_free(data);
               ret = JQ_ERROR_SYSTEM;

--- a/src/main.c
+++ b/src/main.c
@@ -488,7 +488,7 @@ int main(int argc, char* argv[]) {
             die();
           }
           if (!jv_object_has(jv_copy(program_arguments), jv_string(argv[i+1]))) {
-            jv data = jv_load_file(argv[i+2], raw);
+            jv data = jv_load_file(argv[i+2], raw, 0);
             if (!jv_is_valid(data)) {
               data = jv_invalid_get_msg(data);
               fprintf(stderr, "jq: Bad JSON in --%s %s %s: %s\n", which,
@@ -603,7 +603,7 @@ int main(int argc, char* argv[]) {
       exit(2);
     }
 
-    jv data = jv_load_file(program, 1);
+    jv data = jv_load_file(program, 1, 0);
     if (!jv_is_valid(data)) {
       data = jv_invalid_get_msg(data);
       fprintf(stderr, "jq: %s\n", jv_string_value(data));

--- a/src/main.c
+++ b/src/main.c
@@ -488,7 +488,7 @@ int main(int argc, char* argv[]) {
             die();
           }
           if (!jv_object_has(jv_copy(program_arguments), jv_string(argv[i+1]))) {
-            jv data = jv_load_file(argv[i+2], raw, 0);
+            jv data = jv_load_file(argv[i+2], raw);
             if (!jv_is_valid(data)) {
               data = jv_invalid_get_msg(data);
               fprintf(stderr, "jq: Bad JSON in --%s %s %s: %s\n", which,
@@ -603,7 +603,7 @@ int main(int argc, char* argv[]) {
       exit(2);
     }
 
-    jv data = jv_load_file(program, 1, 0);
+    jv data = jv_load_file(program, 1);
     if (!jv_is_valid(data)) {
       data = jv_invalid_get_msg(data);
       fprintf(stderr, "jq: %s\n", jv_string_value(data));

--- a/tests/shtest
+++ b/tests/shtest
@@ -308,6 +308,22 @@ cat > $d/expected <<'EOF'
 EOF
 cmp $d/out $d/expected
 
+# --slurpfd, --rawfd
+$VALGRIND $JQ -n --slurpfd foo 8 8< $JQBASEDIR/tests/modules/data.json \
+  --rawfd bar 9 9<> $JQBASEDIR/tests/modules/data.json '{$foo, $bar}' > $d/out
+cat > $d/expected <<'EOF'
+{
+  "foo": [
+    {
+      "this": "is a test",
+      "that": "is too"
+    }
+  ],
+  "bar": "{\n  \"this\": \"is a test\",\n  \"that\": \"is too\"\n}\n"
+}
+EOF
+cmp $d/out $d/expected
+
 # --args, --jsonargs, $ARGS.positional
 $VALGRIND $JQ -n -c --args '$ARGS.positional' foo bar baz > $d/out
 printf '["foo","bar","baz"]\n' > $d/expected


### PR DESCRIPTION
These allow jq to read data from files that might not have names, make it easier for shell scripts that use jq to avoid races, etc., without resorting to tricks like `/dev/fd` or `/proc/self/fd` that might not always be available (and don't quite behave the same). These options are otherwise very similar to `--rawfile` and `--slurpfile` and share most of their code.

I'm using this on (GNU/)Linux. I'd appreciate feedback about/testing on other platforms. I didn't find a contributors' guidelines file or a style guide, so please tell me if I should do something differently!