### PR TITLE
Fix delpaths() negative index handling at non-leaf positions

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -473,6 +473,30 @@ jv jv_getpath(jv root, jv path) {
 // assumes paths is a sorted array of arrays
 static jv delpaths_sorted(jv object, jv paths, int start) {
   jv delkeys = jv_array();
+  // Normalize negative indices at non-leaf positions so that paths
+  // like [-1,-6] and [0,6] get grouped together rather than treated
+  // as different sub-objects (fixes #3538).
+  if (jv_get_kind(object) == JV_KIND_ARRAY) {
+    int alen = jv_array_length(jv_copy(object));
+    for (int i = 0; i < jv_array_length(jv_copy(paths)); i++) {
+      jv path = jv_array_get(jv_copy(paths), i);
+      if (jv_array_length(jv_copy(path)) > start + 1) {
+        jv key = jv_array_get(jv_copy(path), start);
+        if (jv_get_kind(key) == JV_KIND_NUMBER) {
+          double num = jv_number_value(key);
+          if (num < 0) {
+            int normalized = (int)num + alen;
+            if (normalized >= 0) {
+              jv newpath = jv_array_set(jv_copy(path), start, jv_number(normalized));
+              paths = jv_array_set(paths, i, newpath);
+            }
+          }
+        }
+        jv_free(key);
+      }
+      jv_free(path);
+    }
+  }
   for (int i=0; i<jv_array_length(jv_copy(paths));) {
     assert(jv_array_length(jv_array_get(jv_copy(paths), i)) > start);
     int delkey = jv_array_length(jv_array_get(jv_copy(paths), i)) == start + 1;


### PR DESCRIPTION
## Description

When `delpaths()` receives paths with negative indices at **non-leaf** positions (e.g., `[-1, -6]` and `[0, 6]` on a single-element outer array), the negative index was not being normalized to its positive equivalent before the grouping step. This caused paths targeting the **same** sub-array to be treated as **different** groups, leading to **sequential deletion** (element indices shift after the first deletion) instead of **simultaneous deletion**.

## Example

```jq
[[0,1,2,3,4,5,6,7,8,9]] | delpaths([[-1,-6],[0,6]])
```

**Before (bug):** `[[0,1,2,3,5,6,8,9]]` — deletes index 4 (`-6`), then index 6 from the modified array
**After (fix):** `[[0,1,2,3,5,7,8,9]]` — simultaneously deletes indices 4 and 6 from the original array

## Root Cause

In `src/jv_aux.c`, function `delpaths_sorted()`, paths are grouped by their first key. `[-1, -6]` and `[0, 6]` refer to the same sub-array (since `-1` normalizes to `0` on a single-element outer array), but they were left as-is after sorting. The grouping loop saw two different first keys (`-1` vs `0`) and processed them one after the other instead of together.

## Fix

Before the existing grouping/iteration loop, add a normalization step that converts negative integer keys at non-leaf path positions to their positive equivalents. The guard condition (`path length > start + 1`) ensures only non-leaf positions are normalized — leaf-level negative index handling in `jv_dels()` already works correctly and is left unchanged.

## Testing

- `make check` — **all 9 tests pass**
- Manual verification of the reproducer and edge cases (leaf-level negative indices, mixed positive/negative, object paths, etc.)

Fixes #3538