### PR TITLE
Disable colored output on a dumb terminal

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -169,7 +169,8 @@ sections:
         By default, jq outputs colored JSON if writing to a
         terminal. You can force it to produce color even if writing to
         a pipe or a file using `-C`, and disable color with `-M`.
-        When the `NO_COLOR` environment variable is not empty, jq disables
+        When the `NO_COLOR` environment variable is not empty or
+        the `TERM` environment variable is set to `dumb`, jq disables
         colored output by default, but you can enable it by `-C`.
 
         Colors can be configured with the `JQ_COLORS` environment

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "May 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -115,7 +115,7 @@ Output the fields of each object with the keys in sorted order\.
 \fB\-\-color\-output\fR / \fB\-C\fR and \fB\-\-monochrome\-output\fR / \fB\-M\fR:
 .
 .IP
-By default, jq outputs colored JSON if writing to a terminal\. You can force it to produce color even if writing to a pipe or a file using \fB\-C\fR, and disable color with \fB\-M\fR\. When the \fBNO_COLOR\fR environment variable is not empty, jq disables colored output by default, but you can enable it by \fB\-C\fR\.
+By default, jq outputs colored JSON if writing to a terminal\. You can force it to produce color even if writing to a pipe or a file using \fB\-C\fR, and disable color with \fB\-M\fR\. When the \fBNO_COLOR\fR environment variable is not empty or the \fBTERM\fR environment variable is set to \fBdumb\fR, jq disables colored output by default, but you can enable it by \fB\-C\fR\.
 .
 .IP
 Colors can be configured with the \fBJQ_COLORS\fR environment variable (see below)\.

--- a/src/main.c
+++ b/src/main.c
@@ -539,7 +539,10 @@ int main(int argc, char* argv[]) {
 #ifdef USE_ISATTY
   if (isatty(STDOUT_FILENO)) {
 #ifndef WIN32
-    dumpopts |= JV_PRINT_ISATTY | JV_PRINT_COLOR;
+    char *terminal = getenv("TERM");
+    dumpopts |= JV_PRINT_ISATTY;
+    if (terminal && strcmp(terminal, "dumb"))
+      dumpopts |= JV_PRINT_COLOR;
 #else
   /* Verify we actually have the console, as the NUL device is also regarded as
      tty.  Windows can handle color if ANSICON (or ConEmu) is installed, or

--- a/tests/shtest
+++ b/tests/shtest
@@ -640,7 +640,7 @@ for colors in '/' '[30' '30m' '30:31m:32' '30:*:31' 'invalid'; do
 done
 unset JQ_COLORS
 
-# Check $NO_COLOR
+# Check $NO_COLOR and $TERM
 test_no_color=true
 $msys  && test_no_color=false
 $mingw && test_no_color=false
@@ -653,22 +653,32 @@ if $test_no_color && command -v script >/dev/null 2>&1; then
       sed 's/^\x5E\x44\x08\x08//'; }
   fi
 
-  faketty $JQ_NO_B -n . > $d/color
+  faketty env TERM=xterm-256color $JQ_NO_B -n . > $d/color
   printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  faketty env NO_COLOR= $JQ_NO_B -n . > $d/color
+  faketty env TERM=xterm-256color NO_COLOR= $JQ_NO_B -n . > $d/color
   printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  faketty env NO_COLOR=1 $JQ_NO_B -n . > $d/color
+  faketty env TERM=xterm-256color NO_COLOR=1 $JQ_NO_B -n . > $d/color
   printf 'null\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color
   cmp $d/color $d/expect
-  faketty env NO_COLOR=1 $JQ_NO_B -Cn . > $d/color
+  faketty env TERM=xterm-256color NO_COLOR=1 $JQ_NO_B -Cn . > $d/color
+  printf '\033[0;90mnull\033[0m\r\n' > $d/expect
+  od -tc $d/expect
+  od -tc $d/color
+  cmp $d/color $d/expect
+  faketty env TERM=dumb $JQ_NO_B -n . > $d/color
+  printf 'null\r\n' > $d/expect
+  od -tc $d/expect
+  od -tc $d/color
+  cmp $d/color $d/expect
+  faketty env TERM=dumb $JQ_NO_B -Cn . > $d/color
   printf '\033[0;90mnull\033[0m\r\n' > $d/expect
   od -tc $d/expect
   od -tc $d/color


### PR DESCRIPTION
There should be no need to specify -M or NO_COLOR if TERM=dumb.