### PR TITLE
Upload attestation bundle as a release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,21 +386,25 @@ jobs:
         with:
           pattern: jq-*
           merge-multiple: true
+      - name: Prepare release artifacts
+        run: |
+          cp jq-linux-amd64 jq-linux64
+          cp jq-macos-amd64 jq-osx-amd64
+          cp jq-windows-amd64.exe jq-win64.exe
+      - name: Generate signed attestations
+        id: attest
+        uses: actions/attest@v4
+        with:
+          subject-path: jq-*
       - name: Upload release
         env:
           TAG_NAME: ${{ github.ref_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp jq-linux-amd64 jq-linux64
-          cp jq-macos-amd64 jq-osx-amd64
-          cp jq-windows-amd64.exe jq-win64.exe
+          mv "${{ steps.attest.outputs.bundle-path }}" jq-attestation.json
           sha256sum jq-* > sha256sum.txt
           gh release create "$TAG_NAME" --draft --title "jq ${TAG_NAME#jq-}" --generate-notes
           gh release upload "$TAG_NAME" --clobber jq-* sha256sum.txt
-      - name: Generate signed attestations
-        uses: actions/attest@v4
-        with:
-          subject-path: jq-*
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v7
         with:


### PR DESCRIPTION
The bundle generated by actions/attest is currently only retrievable
via the GitHub attestations API, which requires authentication.
Uploading it as jq-attestation.json lets downstream consumers
(distro packagers, unauthenticated CI) verify provenance offline.
