### PR TITLE
Fix compile crash in transitive include chains

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -234,6 +234,8 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/modules/test_bind_order2.jq                               \
         tests/modules/cycle_a.jq tests/modules/cycle_b.jq               \
         tests/modules/cycle_self.jq                                     \
+        tests/modules/cross_base.jq tests/modules/cross_gen.jq          \
+        tests/modules/cross_mid.jq tests/modules/cross_user.jq          \
         tests/onig.supp tests/local.supp                                \
         tests/setup tests/torture/input0.json                           \
         tests/optional.test tests/man.test tests/manonig.test           \

--- a/src/linker.c
+++ b/src/linker.c
@@ -459,13 +459,20 @@ int load_program(jq_state *jq, struct locfile* src, block *out_block) {
   }
 
   nerrors = process_dependencies(jq, jq_get_jq_origin(jq), jq_get_prog_origin(jq), &program, &lib_state);
-  block libs = gen_noop();
-  for (uint64_t i = 0; i < lib_state.ct; ++i) {
+  for (uint64_t i = 0; i < lib_state.ct; ++i)
     free(lib_state.entries[i].name);
-    if (nerrors == 0 && !block_is_const(lib_state.entries[i].def))
-      libs = block_join(libs, lib_state.entries[i].def);
+  // Join library blocks in reverse registration order so that deeper dependencies
+  // (registered later via DFS pre-order) appear earlier in the block than their
+  // dependents.  block_mark_referenced traverses backward (last-to-first), so
+  // dependents are processed first and mark their dependencies as referenced
+  // before those dependencies are encountered -- preventing transitive callees
+  // from being incorrectly freed as unreferenced.
+  block libs = gen_noop();
+  for (uint64_t i = lib_state.ct; i > 0; --i) {
+    if (nerrors == 0 && !block_is_const(lib_state.entries[i-1].def))
+      libs = block_join(libs, lib_state.entries[i-1].def);
     else
-      block_free(lib_state.entries[i].def);
+      block_free(lib_state.entries[i-1].def);
   }
   free(lib_state.entries);
   if (nerrors)

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1930,6 +1930,19 @@ import "shadow1" as f; import "shadow2" as f; import "shadow1" as e; [e::e, f::e
 null
 [2,3]
 
+# Regression tests for cross-module transitive-include bug (value-arg path):
+# An included module that itself includes another module must not cause the
+# transitively-included module's functions to be freed as unreferenced.
+include "cross_mid"; cross_wrap(5)
+null
+5
+
+# Regression tests for cross-module transitive-include bug (filter-arg path):
+# Same scenario but with a filter argument crossing the module boundary.
+include "cross_user"; cross_use_gen
+null
+[0,1,2]
+
 %%FAIL
 module (.+1); 0
 jq: error: Module metadata must be constant at <top-level>, line 1, column 8:

--- a/tests/modules/cross_base.jq
+++ b/tests/modules/cross_base.jq
@@ -1,0 +1,2 @@
+def _cross_table: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
+def cross_lookup($i): _cross_table | .[$i % 16];

--- a/tests/modules/cross_gen.jq
+++ b/tests/modules/cross_gen.jq
@@ -1,0 +1,2 @@
+def _cross_items: [0,1,2];
+def cross_gen: _cross_items | .[];

--- a/tests/modules/cross_mid.jq
+++ b/tests/modules/cross_mid.jq
@@ -1,0 +1,2 @@
+include "cross_base";
+def cross_wrap($i): cross_lookup($i);

--- a/tests/modules/cross_user.jq
+++ b/tests/modules/cross_user.jq
@@ -1,0 +1,3 @@
+include "cross_gen";
+def cross_collect(gen): [gen];
+def cross_use_gen: cross_collect(cross_gen);


### PR DESCRIPTION
Any program that uses `include` (or `import`) to load a module which itself includes or imports another module aborts at compile time with one of two assertion failures, depending on the call pattern:

    jq: src/compile.c:1086: nesting_level: Assertion `bc && target && target->compiled' failed.

    jq: src/compile.c:1158: expand_call_arglist: Assertion `0 && "Unknown function type"' failed.

The program never executes; the crash is purely a compiler artefact and occurs even if the offending call site is unreachable at runtime.

When `load_program` assembles the final block, it joins `lib_state` entries in registration order. Libraries are registered DFS pre-order, so an importer always receives a lower index than its dependencies, placing callers before callees in the joined block.

`block_mark_referenced` traverses the block last-to-first. Its `saw_top` optimisation skips any `CLOSURE_CREATE` not yet marked referenced at the time it is encountered. With callers preceding callees in the block, callees appear earlier in the backward pass -- before the callers' subfunctions have been walked to mark them -- so `block_drop_unreferenced` frees them as unreferenced. Any caller that holds a `bound_by` pointer into the freed instruction is then corrupt. Two assertion failures result:

- `expand_call_arglist`: the default assert fires when `bound_by->op` contains a reallocated opcode rather than `CLOSURE_CREATE` or `CLOSURE_PARAM`.
- `nesting_level`: the assert fires when `bound_by->compiled` is `NULL` because the freed slot was reused by a not-yet-compiled `CLOSURE_CREATE`.

The regression was introduced by commit f58787c41835d9b17795730cb04925fdba25c71c ("Detect circular module imports to prevent stack overflow"), which restructured the dependency loop in `load_program` to add the `loading` flag for circular-import detection; the restructuring left `lib_state` entries joined in registration order rather than the reverse order that `block_mark_referenced` requires.

Fix by iterating `lib_state` in reverse when building `libs`. Reverse registration order places callees before callers in the block; the backward pass encounters callers first, marks their callees referenced, and those callees are retained correctly when the pass reaches them.

Assisted-By: "claude my eyes right out"