### PR TITLE
Fix range/3 to reject non-numeric bounds

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -150,7 +150,9 @@ def skip($n; expr):
   else error("skip doesn't support negative count") end;
 # range/3, with a `by` expression argument
 def range($init; $upto; $by):
-    if $by > 0 then $init|while(. < $upto; . + $by)
+    if ($init|type) != "number" or ($upto|type) != "number" or ($by|type) != "number"
+    then error("Range bounds must be numeric")
+  elif $by > 0 then $init|while(. < $upto; . + $by)
   elif $by < 0 then $init|while(. > $upto; . + $by)
   else empty end;
 def first(g): label $out | g | ., break $out;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2118,6 +2118,24 @@ null
 false
 false
 
+# jqlang/jq#3116: range/3 must reject non-numeric bounds like range/1 and
+# range/2 already do, instead of silently looping forever or emitting empty.
+[try range(0;[];1) catch .]
+null
+["Range bounds must be numeric"]
+
+[try range([];0;1) catch .]
+null
+["Range bounds must be numeric"]
+
+[try range(0;5;[]) catch .]
+null
+["Range bounds must be numeric"]
+
+[range(0;5;1)]
+null
+[0,1,2,3,4]
+
 IN(range(10;20); range(10))
 null
 false


### PR DESCRIPTION
## Summary

Closes #3116.

`range/1` and `range/2` are implemented via the C `RANGE` opcode (`src/execute.c`), which already validates that its bounds are numbers and raises `Range bounds must be numeric` otherwise. `range/3` (`range($init; $upto; $by)`), however, is defined purely in `src/builtin.jq` using `while(. < $upto; . + $by)` / `while(. > $upto; . + $by)`, so the generic `<` / `>` comparison silently accepts any jv type instead of erroring.

This causes two observable bugs reported in #3116:

- `range(0;[];1)` never terminates, since a number is always `<` an array under jq's type ordering, so the `while` loop runs forever.
- `range([];0;1)` produces no output at all and no error, since an array is never `<` a number, instead of surfacing a type error like `range/2` does for the equivalent case (`range(0;[])`).

## Fix

Add an explicit type check at the top of `range/3` in `src/builtin.jq` that raises the same `Range bounds must be numeric` error `range/2` already produces when any of `$init`, `$upto`, or `$by` is not a number. This is a jq-only change scoped to `range/3` — it does not touch the `RANGE` opcode or `range/1`/`range/2`, so there is no performance impact on those (this matches a concern raised in the issue thread about avoiding a jq-coded rewrite of `range/2` for performance reasons; that concern doesn't apply here since `range/3` was already jq-coded).

## Testing

- Built jq from source (`autoreconf -i && ./configure --with-oniguruma=builtin && make -j8`) and ran `make check` before the change: 9/9 test suites pass (baseline).
- Reproduced both bugs from the issue on the baseline build:
  - `range([];0;1)` → silently produced empty output, no error.
  - `range(0;[];1)` → looped forever (had to be killed with a timeout).
- Applied the fix, rebuilt, and confirmed both cases now raise `Range bounds must be numeric`, consistent with `range/2`'s existing error for the analogous case.
- Confirmed normal usage is unaffected: `range(0;5;1)`, negative step (`range(10;0;-2)`), float step (`range(1.5;5;1.5)`), and the `$by == 0` → `empty` case all behave exactly as before.
- Added 4 regression tests to `tests/jq.test` covering the two bug cases, a third non-numeric-`$by` case, and a normal-usage sanity check.
- Ran `make check` again after the change: 9/9 test suites still pass, no regressions.
- Sanity-checked the new tests themselves by temporarily reverting the fix and re-running the test suite: it hung indefinitely on the new `range(0;[];1)` regression test, confirming the test genuinely exercises the bug rather than passing vacuously.

## Test plan

- [x] `make check` passes locally (9/9 test suites)
- [x] New regression tests fail (hang) without the fix and pass with it
- [x] Manually verified `range/3` with non-numeric bounds now errors consistently with `range/2`
- [x] Manually verified normal `range/3` usage (positive/negative/float step) is unchanged