### PR TITLE
docs: clarify shebang comment-continuation across jq versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -305,7 +305,7 @@ Full commit log can be found at <https://github.com/jqlang/jq/compare/jq-1.7.1..
 
   ```sh
   #!/bin/sh --
-  # Can be use to do shebang scripts.
+  # Can be used to do shebang scripts.
   # Next line will be seen as a comment be of the trailing backslash. \
   exec jq ...
   # this jq expression will result in [1]

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3698,6 +3698,14 @@ sections:
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
       with the arguments (`$@`) that were passed to `sh`.
 
+      Note on version differences: before jq 1.8.0, backslash-continued
+      comments were recognized only in the special shebang form (a `#!`
+      line followed by a continued comment). Starting with 1.8.0, Tcl-style
+      multiline comments work generally, so a trailing backslash continues a
+      `#` comment anywhere. Portable shebang scripts should still use the
+      classic `#!/bin/sh --` plus continued-comment `exec jq ...` pattern
+      shown above so they work on both pre-1.8 and 1.8+ builds.
+
   - title: Modules
     body: |
 

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3698,6 +3698,14 @@ sections:
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
       with the arguments (`$@`) that were passed to `sh`.
 
+      Note on version differences: before jq 1.8.0, backslash-continued
+      comments were recognized only in the special shebang form (a `#!`
+      line followed by a continued comment). Starting with 1.8.0, Tcl-style
+      multiline comments work generally, so a trailing backslash continues a
+      `#` comment anywhere. Portable shebang scripts should still use the
+      classic `#!/bin/sh --` plus continued-comment `exec jq ...` pattern
+      shown above so they work on both pre-1.8 and 1.8+ builds.
+
   - title: Modules
     body: |
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1,5 +1,5 @@
 .
-.TH "JQ" "1" "May 2025" "" ""
+.TH "JQ" "1" "July 2026" "" ""
 .
 .SH "NAME"
 \fBjq\fR \- Command\-line JSON processor
@@ -4133,6 +4133,9 @@ reduce (
 .
 .P
 The \fBexec\fR line is considered a comment by jq, so it is ignored\. But it is not ignored by \fBsh\fR, since in \fBsh\fR a backslash at the end of the line does not continue the comment\. With this trick, when the script is invoked as \fBtotal 1 2\fR, \fB/bin/sh \-\- /path/to/total 1 2\fR will be run, and \fBsh\fR will then run \fBexec jq \-\-args \-MRnf \-\- /path/to/total 1 2\fR replacing itself with a \fBjq\fR interpreter invoked with the specified options (\fB\-M\fR, \fB\-R\fR, \fB\-n\fR, \fB\-\-args\fR), that evaluates the current file (\fB$0\fR), with the arguments (\fB$@\fR) that were passed to \fBsh\fR\.
+.
+.P
+Note on version differences: before jq 1\.8\.0, backslash\-continued comments were recognized only in the special shebang form (a \fB#!\fR line followed by a continued comment)\. Starting with 1\.8\.0, Tcl\-style multiline comments work generally, so a trailing backslash continues a \fB#\fR comment anywhere\. Portable shebang scripts should still use the classic \fB#!/bin/sh \-\-\fR plus continued\-comment \fBexec jq \.\.\.\fR pattern shown above so they work on both pre\-1\.8 and 1\.8+ builds\.
 .
 .SH "MODULES"
 jq has a library/module system\. Modules are files whose names end in \fB\.jq\fR\.


### PR DESCRIPTION
## Summary

Documents the shebang / backslash-continued-comment behavior difference between pre-1.8 and 1.8+ jq builds, so portable scripts keep working when machines have mixed versions (e.g. FreeBSD 1.8.x vs macOS 1.7.1).

## Changes

- Add a short version-difference note after the existing shebang example in the manual (`v1.8` + `dev`).
- Recommend keeping the classic `#!/bin/sh --` + continued-comment `exec jq ...` pattern for portability.
- Fix a nearby NEWS grammar typo in the same shebang example (`Can be use` → `Can be used`).

## Why

Issue #3573 reports confusion when the shebang trick behaved differently across jq versions. 1.8.0 generalized Tcl-style multiline comments; earlier versions only accepted the special shebang form. The classic pattern remains the portable choice.

Closes #3573
