### PR TITLE
Fix _TIME_BITS conflict on x32 ABI

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -1,4 +1,4 @@
-#if __SIZEOF_POINTER__==4
+#if __SIZEOF_POINTER__==4 && !defined(__ILP32__)
 # define _TIME_BITS 64
 #endif
 #ifndef __sun__


### PR DESCRIPTION
## Summary
- On x32 (ILP32 ABI on x86-64), `__SIZEOF_POINTER__==4` but `time_t` is already 64 bits (`__TIMESIZE==64`), so defining `_TIME_BITS=64` explicitly conflicts with glibc's `features-time64.h` which requires `_FILE_OFFSET_BITS=64` when `_TIME_BITS=64` is set.
- Fix: Skip the `_TIME_BITS=64` definition when `__ILP32__` is defined, since x32 always has 64-bit `time_t` and doesn't need the time64 workaround.

## Test plan
- [x] Built successfully on x32 Gentoo with the fix
- [ ] Test on other 32-bit ABIs (i386, arm32) to confirm no regression
- [ ] Add x32 build test to CI if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)