### PR TITLE
docs: `in` example use [3,4] instead of [0,1]

### DIFF
--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -990,7 +990,7 @@ sections:
           - program: '.[] | in({"foo": 42})'
             input: '["foo", "bar"]'
             output: ['true', 'false']
-          - program: 'map(in([0,1]))'
+          - program: 'map(in([3,4]))'
             input: '[2, 0]'
             output: ['[false, true]']
 


### PR DESCRIPTION
The example of jq is excellent, but `[0,1]` may misunderstand the role of 'with key' as the role of 'with value'
