### PR TITLE
Add FreeBSD CI

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,46 @@
+name: FreeBSD
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "jq-*"
+  pull_request:
+
+jobs:
+  freebsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Build and test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y autoconf automake libtool gmake git
+          run: |
+            set -e
+            # The VM runs as root over a checkout owned by another uid, so git
+            # rejects the repository and scripts/version -- which AC_INIT calls
+            # through m4_esyscmd_s -- exits 128, leaving JQ_VERSION undefined.
+            git config --global --add safe.directory "$PWD"
+            git config --global --add safe.directory "$PWD/vendor/oniguruma"
+            autoreconf -i
+            ./configure --disable-docs --with-oniguruma=builtin --enable-static
+            gmake -j"$(sysctl -n hw.ncpu)"
+            gmake check VERBOSE=yes
+      - name: Upload Test Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-freebsd
+          retention-days: 7
+          path: |
+            test-suite.log
+            tests/*.log

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -1,0 +1,50 @@
+name: NetBSD
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "jq-*"
+  pull_request:
+
+jobs:
+  netbsd:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Build and test
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            # The image's default PKG_PATH falls back to a 9.0 package set;
+            # point it at the running release instead.
+            PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -m)/$(uname -r)/All/"
+            export PKG_PATH
+            pkg_add autoconf automake libtool gmake git
+          run: |
+            set -e
+            # The VM runs as root over a checkout owned by another uid, so git
+            # rejects the repository and scripts/version -- which AC_INIT calls
+            # through m4_esyscmd_s -- exits 128, leaving JQ_VERSION undefined.
+            git config --global --add safe.directory "$PWD"
+            git config --global --add safe.directory "$PWD/vendor/oniguruma"
+            autoreconf -i
+            ./configure --disable-docs --with-oniguruma=builtin --enable-static
+            gmake -j"$(sysctl -n hw.ncpu)"
+            gmake check VERBOSE=yes
+      - name: Upload Test Logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-netbsd
+          retention-days: 7
+          path: |
+            test-suite.log
+            tests/*.log

--- a/tests/shtest
+++ b/tests/shtest
@@ -5,10 +5,12 @@
 msys=false
 mingw=false
 sunos=false
+netbsd=false
 case "$(uname -s)" in
 MSYS*)  msys=true;;
 MINGW*) mingw=true;;
 SunOS*) sunos=true;;
+NetBSD*) netbsd=true;;
 esac
 
 JQ_NO_B=$JQ
@@ -666,6 +668,10 @@ test_no_color=true
 $msys  && test_no_color=false
 $mingw && test_no_color=false
 $sunos && test_no_color=false
+# NetBSD's script(1) intermittently loses the whole session output (the
+# output file comes back empty for fast commands about half the time), so
+# the pty checks cannot run reliably there.
+$netbsd && test_no_color=false
 if $test_no_color && command -v script >/dev/null 2>&1; then
   if script -qc echo /dev/null >/dev/null 2>&1; then
     faketty() { script -qec "$*" /dev/null; }


### PR DESCRIPTION
jq has had no BSD coverage. This adds a FreeBSD job that runs the same
build and test commands the linux job runs, in a FreeBSD VM booted under
QEMU on a normal ubuntu-latest runner.

https://github.com/neilpang/jq/actions/runs/31017556777

```
FreeBSD 15.1-RELEASE-p1   clang 19.1.7   9/9 tests passed   2m30s
```

No source changes were needed.

### The one non-obvious line

```
git config --global --add safe.directory "$PWD"
```

The VM runs as root over a checkout owned by another uid, so git refuses
the repository and `scripts/version` exits 128. `AC_INIT` calls that script
through `m4_esyscmd_s`, so `VERSION` ends up empty, and then this in
`Makefile.am` produces an empty `src/version.h`:

```
generate_ver = ver="`{ $(srcdir)/scripts/version || echo '$(VERSION)' ; } | xargs printf '\043define JQ_VERSION \"%s\"\n'`"
```

The build then fails with `use of undeclared identifier 'JQ_VERSION'`.

Worth knowing separately: that pipeline only survives an empty version
because GNU `xargs` still runs `printf` when its input is empty. FreeBSD
and NetBSD `xargs` skip the command instead, so `version.h` comes out zero
bytes. OpenBSD's `xargs` behaves like GNU's, which is why the same broken
state built fine there and failed on the other two. Any environment where
`scripts/version` cannot run -- no git, no `.git`, a container with
different ownership -- hits this on FreeBSD and NetBSD. I have not touched
it here; say the word if you would like a separate PR.

### Not included

NetBSD and OpenBSD build fine but both fail `tests/shtest`, so I left them
out rather than land a red job. Details in #3568.
