### PR TITLE
Fix array slice extension exposing hidden elements

### DIFF
--- a/src/jv.c
+++ b/src/jv.c
@@ -870,7 +870,10 @@ static jv* jvp_array_write(jv* a, int i) {
   int pos = i + jvp_array_offset(*a);
   if (pos < array->alloc_length && jvp_refcnt_unshared(a->u.ptr)) {
     // use existing array space
-    for (int j = array->length; j <= pos; j++) {
+    int logical_end = jvp_array_offset(*a) + jvp_array_length(*a);
+    for (int j = logical_end; j <= pos; j++) {
+      if (j < array->length)
+        jv_free(array->elements[j]);
       array->elements[j] = JV_NULL;
     }
     array->length = imax(pos + 1, array->length);

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -471,6 +471,15 @@ flatten(3,2,1)
 "abcdefghi"
 ["","","abcdefg","hi","",""]
 
+# Extending an array slice should not expose elements past the slice (#3022)
+[range(10)] | .[0:3] | .[5] = true
+null
+[0,1,2,null,null,true]
+
+[range(6) | {index: .}] | .[1:3] | .[5] = true
+null
+[{"index":1},{"index":2},null,null,null,true]
+
 del(.[2:4],.[0],.[-2:])
 [0,1,2,3,4,5,6,7]
 [1,4,5]


### PR DESCRIPTION
## Summary

- fill extended array slices from their logical end instead of the backing array's physical length
- release hidden backing values before replacing the extension gap with `null`
- add regression coverage for zero- and non-zero-offset slices

## Root cause

Array slices share their backing storage. When an unshared slice was extended within the existing allocation, `jvp_array_write()` initialized gaps starting at the backing array's physical length. Values between the slice's logical end and that physical length were therefore left intact and became visible again.

Start gap initialization at the slice's offset plus logical length, freeing any initialized hidden values before replacing them with `null`.

Fixes #3022

## Testing

- `make check VERBOSE=yes`
- `./configure --disable-docs --enable-valgrind --with-oniguruma=builtin && make -j8 && make check VERBOSE=yes`
