### PR TITLE
Fix destructuring in path expressions

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -998,7 +998,14 @@ block gen_destructure(block var, block matchers, block body) {
     top = BLOCK(top, gen_op_simple(DUP));
   }
 
-  return BLOCK(top, gen_subexp(var), gen_op_simple(POP), bind_alternation_matchers(matchers, body));
+  return BLOCK(top,
+               gen_op_simple(SUBEXP_BEGIN),
+               gen_subexp(var),
+               gen_op_simple(POP),
+               bind_alternation_matchers(matchers,
+                                         BLOCK(gen_op_simple(SUBEXP_END),
+                                               gen_op_simple(POP),
+                                               body)));
 }
 
 // Like gen_var_binding(), but bind `break`'s wildcard unbound variable

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1120,6 +1120,19 @@ path(.)
 42
 []
 
+# Regression test for #3128
+[path({} as {$a} | .), path(. as {$a} | .)]
+null
+[[], []]
+
+path({meta: {key: "a"}} as {meta: {$key}} | .[$key])
+{"a": 1}
+["a"]
+
+[path({key: "a"} as {$key} ?// [$key] | .[$key]), path(["a"] as {$key} ?// [$key] | .[$key])]
+{"a": 1}
+[["a"], ["a"]]
+
 try path(.a | map(select(.b == 0))) catch .
 {"a":[{"b":0}]}
 "Invalid path expression with result [{\"b\":0}]"


### PR DESCRIPTION
Fixes #3128.

## Summary

- Wrap destructuring source evaluation with a matched `SUBEXP_BEGIN` / `SUBEXP_END` pair, then discard the source value before evaluating the body. This preserves the bindings without letting the destructured source contribute to path traversal.
- Keep that scope in `gen_destructure()` rather than `bind_alternation_matchers()`. The matcher helper is also used by `reduce` and `foreach`, so changing it would alter those constructs outside this fix.
- Cover plain, nested, and alternative destructuring in path expressions.

## Tests

All three regression cases were verified RED on upstream `master` and GREEN with this change:

- plain destructuring of a literal and of the input inside `path()`
- nested destructuring whose binding selects a path component
- both branches of alternative destructuring (`?//`)

Additional validation:

- `make check` — 9/9 tests passed
- AddressSanitizer/UndefinedBehaviorSanitizer regression run — passed
