### PR TITLE
Link library blocks in dependency order

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -234,6 +234,9 @@ EXTRA_DIST = $(DOC_FILES) $(man_MANS) $(TESTS) $(TEST_LOG_COMPILER)     \
         tests/modules/test_bind_order2.jq                               \
         tests/modules/cycle_a.jq tests/modules/cycle_b.jq               \
         tests/modules/cycle_self.jq                                     \
+        tests/modules/chain_a.jq tests/modules/chain_b.jq               \
+        tests/modules/chain_c.jq tests/modules/diamond_leaf.jq          \
+        tests/modules/diamond_used.jq tests/modules/diamond_unused.jq   \
         tests/onig.supp tests/local.supp                                \
         tests/setup tests/torture/input0.json                           \
         tests/optional.test tests/man.test tests/manonig.test           \

--- a/src/linker.c
+++ b/src/linker.c
@@ -28,7 +28,17 @@ struct lib_entry {
 struct lib_loading_state {
   struct lib_entry *entries;
   uint64_t ct;
+  // Indices into entries[], in the order the libraries finished loading
+  // (DFS post-order), so that dependencies precede their dependents.
+  uint64_t *order;
+  uint64_t order_ct;
 };
+
+static void lib_state_finish(struct lib_loading_state *lib_state, uint64_t idx) {
+  lib_state->order = jv_mem_realloc(lib_state->order,
+                                    (lib_state->order_ct + 1) * sizeof(uint64_t));
+  lib_state->order[lib_state->order_ct++] = idx;
+}
 static int load_library(jq_state *jq, jv lib_path,
                         int is_data, int raw, int optional,
                         const char *as, block *out_block,
@@ -374,6 +384,7 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
     lib_state->entries[state_idx].name = strdup(jv_string_value(lib_path));
     lib_state->entries[state_idx].def = program;
     lib_state->entries[state_idx].loading = 0;
+    lib_state_finish(lib_state, state_idx);
   } else {
     // import "foo" as bar;
     src = locfile_init(jq, jv_string_value(lib_path), jv_string_value(data), jv_string_length_bytes(jv_copy(data)));
@@ -396,6 +407,7 @@ static int load_library(jq_state *jq, jv lib_path, int is_data, int raw, int opt
       program = block_bind_self(program, OP_IS_CALL_PSEUDO);
       lib_state->entries[state_idx].def = program;
       lib_state->entries[state_idx].loading = 0;
+      lib_state_finish(lib_state, state_idx);
     }
   }
   *out_block = program;
@@ -435,7 +447,7 @@ jv load_module_meta(jq_state *jq, jv mod_relpath) {
 int load_program(jq_state *jq, struct locfile* src, block *out_block) {
   int nerrors = 0;
   block program;
-  struct lib_loading_state lib_state = {0,0};
+  struct lib_loading_state lib_state = {0,0,0,0};
   nerrors = jq_parse(src, &program);
   if (nerrors)
     return nerrors;
@@ -459,15 +471,26 @@ int load_program(jq_state *jq, struct locfile* src, block *out_block) {
   }
 
   nerrors = process_dependencies(jq, jq_get_jq_origin(jq), jq_get_prog_origin(jq), &program, &lib_state);
+  // Join the libraries in the order they finished loading, so that a library
+  // always precedes the libraries that depend on it.  block_mark_referenced
+  // walks the joined block backwards and only descends into definitions it has
+  // already seen referenced, so a dependency placed after its dependents would
+  // have its own body left unmarked and dropped from under it.
   block libs = gen_noop();
+  for (uint64_t i = 0; i < lib_state.order_ct; ++i) {
+    struct lib_entry *e = &lib_state.entries[lib_state.order[i]];
+    if (nerrors == 0 && !block_is_const(e->def))
+      libs = block_join(libs, e->def);
+    else
+      block_free(e->def);
+    e->def = gen_noop();
+  }
   for (uint64_t i = 0; i < lib_state.ct; ++i) {
     free(lib_state.entries[i].name);
-    if (nerrors == 0 && !block_is_const(lib_state.entries[i].def))
-      libs = block_join(libs, lib_state.entries[i].def);
-    else
-      block_free(lib_state.entries[i].def);
+    block_free(lib_state.entries[i].def);
   }
   free(lib_state.entries);
+  free(lib_state.order);
   if (nerrors)
     block_free(program);
   else

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1930,6 +1930,29 @@ import "shadow1" as f; import "shadow2" as f; import "shadow1" as e; [e::e, f::e
 null
 [2,3]
 
+# Transitively included modules must not be dropped as unreferenced (#3597)
+include "chain_a"; chain_a
+null
+"c"
+
+# ... including when the shared dependency is first pulled in by a module
+# whose own definitions end up unused, in either include order
+include "diamond_used"; include "diamond_unused"; diamond_used
+null
+1
+
+include "diamond_unused"; include "diamond_used"; diamond_used
+null
+1
+
+include "diamond_leaf"; include "diamond_used"; diamond_used
+null
+1
+
+include "diamond_used"; include "diamond_leaf"; diamond_used
+null
+1
+
 %%FAIL
 module (.+1); 0
 jq: error: Module metadata must be constant at <top-level>, line 1, column 8:

--- a/tests/modules/chain_a.jq
+++ b/tests/modules/chain_a.jq
@@ -1,0 +1,2 @@
+include "chain_b";
+def chain_a: chain_b;

--- a/tests/modules/chain_b.jq
+++ b/tests/modules/chain_b.jq
@@ -1,0 +1,2 @@
+include "chain_c";
+def chain_b: chain_c;

--- a/tests/modules/chain_c.jq
+++ b/tests/modules/chain_c.jq
@@ -1,0 +1,1 @@
+def chain_c: "c";

--- a/tests/modules/diamond_leaf.jq
+++ b/tests/modules/diamond_leaf.jq
@@ -1,0 +1,2 @@
+def _diamond_helper: 1;
+def diamond_leaf: _diamond_helper;

--- a/tests/modules/diamond_unused.jq
+++ b/tests/modules/diamond_unused.jq
@@ -1,0 +1,2 @@
+include "diamond_leaf";
+def diamond_unused: diamond_leaf;

--- a/tests/modules/diamond_used.jq
+++ b/tests/modules/diamond_used.jq
@@ -1,0 +1,2 @@
+include "diamond_leaf";
+def diamond_used: diamond_leaf;


### PR DESCRIPTION
Commit f58787 moved library registration to before the library's own dependencies are processed, which changed `lib_state.entries` from DFS post-order to DFS pre-order. `load_program` joins the entries in index order, so a library is now emitted into the block ahead of the libraries it depends on.

During dead-code elimination, `block_mark_referenced` walks instructions backward. Because dependents now appear after their dependencies, the backward pass hits the dependency before its caller has marked it. The pass skips inspecting the dependency's body, causing `block_drop_unreferenced` to free required definitions while the dependency still references them via `bound_by`. This dangling reference triggers the compilation assertions.

This PR records library load completion using DFS post-order traversal and combine the blocks in that sequence. This reinstates the pre f58787c invariant that a library always precedes its dependents, without breaking circular-import detection.

Thanks to @tianon, whose analysis of `block_mark_referenced` in #3570 is what this builds on.

Fixes #3597.