### PR TITLE
Fix typo 'you may wish [to] use'

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -888,7 +888,7 @@ sections:
           section on the identity filter for the implications of this
           definition for numeric input.
 
-          To compute the absolute value of a number as a floating point number, you may wish use `fabs`.
+          To compute the absolute value of a number as a floating point number, you may wish to use `fabs`.
 
         examples:
           - program: 'map(abs)'

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -876,7 +876,7 @@ sections:
           section on the identity filter for the implications of this
           definition for numeric input.
 
-          To compute the absolute value of a number as a floating point number, you may wish use `fabs`.
+          To compute the absolute value of a number as a floating point number, you may wish to use `fabs`.
 
         examples:
           - program: 'map(abs)'

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -888,7 +888,7 @@ sections:
           section on the identity filter for the implications of this
           definition for numeric input.
 
-          To compute the absolute value of a number as a floating point number, you may wish use `fabs`.
+          To compute the absolute value of a number as a floating point number, you may wish to use `fabs`.
 
         examples:
           - program: 'map(abs)'

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -867,7 +867,7 @@ The builtin function \fBabs\fR is defined naively as: \fBif \. < 0 then \- \. el
 For numeric input, this is the absolute value\. See the section on the identity filter for the implications of this definition for numeric input\.
 .
 .P
-To compute the absolute value of a number as a floating point number, you may wish use \fBfabs\fR\.
+To compute the absolute value of a number as a floating point number, you may wish to use \fBfabs\fR\.
 .
 .IP "" 4
 .


### PR DESCRIPTION
Fix all instances of the phrase "you may wish use `fabs`" ->  "you may wish _to_ use `fabs`" (emphasis mine) in the manual.