### PR TITLE
Fix a handful of typos

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2901,7 +2901,7 @@ sections:
               . as {realnames: $names, posts: [$first, $second]} | ...
 
           The variable declarations in array patterns (e.g., `. as
-          [$first, $second]`) bind to the elements of the array in from
+          [$first, $second]`) bind to the elements of the array from
           the element at index zero on up, in order.  When there is no
           value at the index for an array pattern element, `null` is
           bound to that variable.

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -1820,7 +1820,7 @@ sections:
 
           Whitespace characters are the usual `" "`, `"\n"` `"\t"`, `"\r"`
           and also all characters in the Unicode character database with the
-          whitespace property. Note that what considers whitespace might
+          whitespace property. Note that what is considered whitespace might
           change in the future.
 
         examples:

--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -2819,7 +2819,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.3/manual.yml
+++ b/docs/content/manual/v1.3/manual.yml
@@ -1008,7 +1008,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.4/manual.yml
+++ b/docs/content/manual/v1.4/manual.yml
@@ -1414,7 +1414,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -2253,7 +2253,7 @@ sections:
               . as {realnames: $names, posts: [$first, $second]} | ...
 
           The variable declarations in array patterns (e.g., `. as
-          [$first, $second]`) bind to the elements of the array in from
+          [$first, $second]`) bind to the elements of the array from
           the element at index zero on up, in order.  When there is no
           value at the index for an array pattern element, `null` is
           bound to that variable.

--- a/docs/content/manual/v1.5/manual.yml
+++ b/docs/content/manual/v1.5/manual.yml
@@ -2171,7 +2171,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2432,7 +2432,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.6/manual.yml
+++ b/docs/content/manual/v1.6/manual.yml
@@ -2514,7 +2514,7 @@ sections:
               . as {realnames: $names, posts: [$first, $second]} | ...
 
           The variable declarations in array patterns (e.g., `. as
-          [$first, $second]`) bind to the elements of the array in from
+          [$first, $second]`) bind to the elements of the array from
           the element at index zero on up, in order.  When there is no
           value at the index for an array pattern element, `null` is
           bound to that variable.

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -2733,7 +2733,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/docs/content/manual/v1.7/manual.yml
+++ b/docs/content/manual/v1.7/manual.yml
@@ -2815,7 +2815,7 @@ sections:
               . as {realnames: $names, posts: [$first, $second]} | ...
 
           The variable declarations in array patterns (e.g., `. as
-          [$first, $second]`) bind to the elements of the array in from
+          [$first, $second]`) bind to the elements of the array from
           the element at index zero on up, in order.  When there is no
           value at the index for an array pattern element, `null` is
           bound to that variable.

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -2901,7 +2901,7 @@ sections:
               . as {realnames: $names, posts: [$first, $second]} | ...
 
           The variable declarations in array patterns (e.g., `. as
-          [$first, $second]`) bind to the elements of the array in from
+          [$first, $second]`) bind to the elements of the array from
           the element at index zero on up, in order.  When there is no
           value at the index for an array pattern element, `null` is
           bound to that variable.

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -1820,7 +1820,7 @@ sections:
 
           Whitespace characters are the usual `" "`, `"\n"` `"\t"`, `"\r"`
           and also all characters in the Unicode character database with the
-          whitespace property. Note that what considers whitespace might
+          whitespace property. Note that what is considered whitespace might
           change in the future.
 
         examples:

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -2819,7 +2819,7 @@ sections:
       which to place the data.
 
       It is also possible to define functions in jq, although this is
-      is a feature whose biggest use is defining jq's standard library
+      a feature whose biggest use is defining jq's standard library
       (many jq functions such as `map` and `select` are in fact written
       in jq).
 

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3120,7 +3120,7 @@ Variables are an absolute necessity in most programming languages, but they\'re 
 In most languages, variables are the only means of passing around data\. If you calculate a value, and you want to use it more than once, you\'ll need to store it in a variable\. To pass a value to another part of the program, you\'ll need that part of the program to define a variable (as a function parameter, object member, or whatever) in which to place the data\.
 .
 .P
-It is also possible to define functions in jq, although this is is a feature whose biggest use is defining jq\'s standard library (many jq functions such as \fBmap\fR and \fBselect\fR are in fact written in jq)\.
+It is also possible to define functions in jq, although this is a feature whose biggest use is defining jq\'s standard library (many jq functions such as \fBmap\fR and \fBselect\fR are in fact written in jq)\.
 .
 .P
 jq has reduction operators, which are very powerful but a bit tricky\. Again, these are mostly used internally, to define some useful bits of jq\'s standard library\.

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -1984,7 +1984,7 @@ jq \'[\.[]|trimstr("foo")]\'
 \fBrtrim\fR trims only trailing (right side) whitespace\.
 .
 .P
-Whitespace characters are the usual \fB" "\fR, \fB"\en"\fR \fB"\et"\fR, \fB"\er"\fR and also all characters in the Unicode character database with the whitespace property\. Note that what considers whitespace might change in the future\.
+Whitespace characters are the usual \fB" "\fR, \fB"\en"\fR \fB"\et"\fR, \fB"\er"\fR and also all characters in the Unicode character database with the whitespace property\. Note that what is considered whitespace might change in the future\.
 .
 .IP "" 4
 .

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -3219,7 +3219,7 @@ Multiple variables may be declared using a single \fBas\fR expression by providi
 .IP "" 0
 .
 .P
-The variable declarations in array patterns (e\.g\., \fB\. as [$first, $second]\fR) bind to the elements of the array in from the element at index zero on up, in order\. When there is no value at the index for an array pattern element, \fBnull\fR is bound to that variable\.
+The variable declarations in array patterns (e\.g\., \fB\. as [$first, $second]\fR) bind to the elements of the array from the element at index zero on up, in order\. When there is no value at the index for an array pattern element, \fBnull\fR is bound to that variable\.
 .
 .P
 Variables are scoped over the rest of the expression that defines them, so


### PR DESCRIPTION
Fix the following additional typos I found:
- "Note that what considers whitespace might change" -> "Note that what is considered whitespace might change"
- "this is is a feature" -> "this is a feature"
- "elements of the array in from the element at index zero on up" -> "elements of the array from the element at index zero on up" (dropped in)
  - I feel less confident I'm reading this one correctly, perhaps it is not a typo.

I've finished my read through of the manual, so I won't be finding more typos that should be batched up into a single PR for the time being.