### PR TITLE
Preserve captures inside zero-width regex matches

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -962,6 +962,47 @@ static int f_match_name_iter(const UChar* name, const UChar *name_end, int ngrou
   return 0;
 }
 
+static jv f_match_captures(const char *input, const OnigRegion *region,
+    regex_t *reg) {
+  jv captures = jv_array();
+  for (int i = 1; i < region->num_regs; ++i) {
+    unsigned long idx;
+    unsigned long len;
+    const char *fr;
+    jv cap;
+
+    if (region->beg[i] == -1) {
+      cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(-1));
+      cap = jv_object_set(cap, jv_string("string"), jv_null());
+      cap = jv_object_set(cap, jv_string("length"), jv_number(0));
+    } else if (region->beg[i] == region->end[i]) {
+      fr = input;
+      for (idx = 0; fr < input + region->beg[i]; idx++) {
+        fr += jvp_utf8_decode_length(*fr);
+      }
+      cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(idx));
+      cap = jv_object_set(cap, jv_string("string"), jv_string(""));
+      cap = jv_object_set(cap, jv_string("length"), jv_number(0));
+    } else {
+      fr = input;
+      for (idx = len = 0; fr < input + region->end[i]; len++) {
+        if (fr == input + region->beg[i]) idx = len, len = 0;
+        fr += jvp_utf8_decode_length(*fr);
+      }
+
+      unsigned long blen = region->end[i] - region->beg[i];
+      cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(idx));
+      cap = jv_object_set(cap, jv_string("length"), jv_number(len));
+      cap = jv_object_set(cap, jv_string("string"),
+          jv_string_sized(input + region->beg[i], blen));
+    }
+    cap = jv_object_set(cap, jv_string("name"), jv_null());
+    captures = jv_array_append(captures, cap);
+  }
+  onig_foreach_name(reg, f_match_name_iter, &captures);
+  return captures;
+}
+
 static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
   int test = jv_equal(testmode, jv_true());
   jv result;
@@ -1069,21 +1110,7 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
         jv match = jv_object_set(jv_object(), jv_string("offset"), jv_number(idx));
         match = jv_object_set(match, jv_string("length"), jv_number(0));
         match = jv_object_set(match, jv_string("string"), jv_string(""));
-        jv captures = jv_array();
-        for (int i = 1; i < region->num_regs; ++i) {
-          jv cap = jv_object();
-          if (region->beg[i] == -1) {
-            cap = jv_object_set(cap, jv_string("offset"), jv_number(-1));
-            cap = jv_object_set(cap, jv_string("string"), jv_null());
-          } else {
-            cap = jv_object_set(cap, jv_string("offset"), jv_number(idx));
-            cap = jv_object_set(cap, jv_string("string"), jv_string(""));
-          }
-          cap = jv_object_set(cap, jv_string("length"), jv_number(0));
-          cap = jv_object_set(cap, jv_string("name"), jv_null());
-          captures = jv_array_append(captures, cap);
-        }
-        onig_foreach_name(reg, f_match_name_iter, &captures);
+        jv captures = f_match_captures(input_string, region, reg);
         match = jv_object_set(match, jv_string("captures"), captures);
         result = jv_array_append(result, match);
         // ensure '"qux" | match("(?=u)"; "g")' matches just once; advance the
@@ -1111,42 +1138,7 @@ static jv f_match(jq_state *jq, jv input, jv regex, jv modifiers, jv testmode) {
       unsigned long blen = region->end[0]-region->beg[0];
       match = jv_object_set(match, jv_string("length"), jv_number(len));
       match = jv_object_set(match, jv_string("string"), jv_string_sized(input_string+region->beg[0],blen));
-      jv captures = jv_array();
-      for (int i = 1; i < region->num_regs; ++i) {
-        // Empty capture.
-        if (region->beg[i] == region->end[i]) {
-          // Didn't match.
-          jv cap;
-          if (region->beg[i] == -1) {
-            cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(-1));
-            cap = jv_object_set(cap, jv_string("string"), jv_null());
-          } else {
-            fr = input_string;
-            for (idx = 0; fr < input_string+region->beg[i]; idx++) {
-              fr += jvp_utf8_decode_length(*fr);
-            }
-            cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(idx));
-            cap = jv_object_set(cap, jv_string("string"), jv_string(""));
-          }
-          cap = jv_object_set(cap, jv_string("length"), jv_number(0));
-          cap = jv_object_set(cap, jv_string("name"), jv_null());
-          captures = jv_array_append(captures, cap);
-          continue;
-        }
-        fr = input_string;
-        for (idx = len = 0; fr < input_string+region->end[i]; len++) {
-          if (fr == input_string+region->beg[i]) idx = len, len=0;
-          fr += jvp_utf8_decode_length(*fr);
-        }
-
-        blen = region->end[i]-region->beg[i];
-        jv cap = jv_object_set(jv_object(), jv_string("offset"), jv_number(idx));
-        cap = jv_object_set(cap, jv_string("length"), jv_number(len));
-        cap = jv_object_set(cap, jv_string("string"), jv_string_sized(input_string+region->beg[i],blen));
-        cap = jv_object_set(cap, jv_string("name"), jv_null());
-        captures = jv_array_append(captures,cap);
-      }
-      onig_foreach_name(reg,f_match_name_iter,&captures);
+      jv captures = f_match_captures(input_string, region, reg);
       match = jv_object_set(match, jv_string("captures"), captures);
       result = jv_array_append(result, match);
       start = (const UChar*)(input_string+region->end[0]);

--- a/tests/onig.test
+++ b/tests/onig.test
@@ -11,6 +11,23 @@
 "ab"
 [{"offset":0,"length":0,"string":"","captures":[]},{"offset":1,"length":0,"string":"","captures":[]},{"offset":2,"length":0,"string":"","captures":[]}]
 
+# captures inside zero-width lookarounds may still consume input
+[match("(?=(a))"; "g")]
+"ab"
+[{"offset":0,"length":0,"string":"","captures":[{"offset":0,"length":1,"string":"a","name":null}]}]
+
+[match("(?<=(a))"; "g")]
+"ab"
+[{"offset":1,"length":0,"string":"","captures":[{"offset":0,"length":1,"string":"a","name":null}]}]
+
+[match("(?=(é))"; "g")]
+"aé"
+[{"offset":1,"length":0,"string":"","captures":[{"offset":1,"length":1,"string":"é","name":null}]}]
+
+[match("(?=(?<letter>a)(b)?)"; "g")]
+"éa"
+[{"offset":1,"length":0,"string":"","captures":[{"offset":1,"length":1,"string":"a","name":"letter"},{"offset":-1,"string":null,"length":0,"name":null}]}]
+
 # global zero-width matches must not land inside a multibyte character
 [match(""; "g") | .offset]
 "aé€🚀b"
@@ -221,4 +238,3 @@ sub("(?<x>.)"; "\(.x)!")
 [splits("b+"; "i")]
 "abAABBabA"
 ["a","AA","a","A"]
-


### PR DESCRIPTION
### What / why

`match` treats a zero-width outer match as if every participating capture were
also zero-width. Lookarounds can consume input inside a capture without
consuming it in group 0, so jq currently erases the capture text, length, and
(for lookbehind) its real offset:

```console
$ printf '"ab"\n' | jq -c '[match("(?<=(a))"; "g")]'
# before: capture offset 1, string "", length 0
# after:  capture offset 0, string "a", length 1
```

The same problem affects multibyte captures inside lookarounds.

### Fix

Build capture objects from each Oniguruma region regardless of whether group 0
is zero-width. The shared helper preserves the existing behavior for unmatched
and empty captures, named captures, and UTF-8 codepoint offsets.

### Tests

Added lookahead, lookbehind, and multibyte regression cases to
`tests/onig.test`. They fail on the previous code and pass with this change.

- `./jq --run-tests tests/onig.test` — 54/54 passed
- `make check` — jq 9/9, Oniguruma unit 7/7, Oniguruma samples 14/14
