### PR TITLE
fix(fromdateiso8601): support fractional seconds

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -72,13 +72,22 @@ def flatten($x): if $x < 0 then error("flatten depth must not be negative") else
 def flatten: _flatten(-1);
 def range($x): range(0;$x);
 def fromdateiso8601:
-  _match_impl("^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})\\.([0-9]+)Z$"; null; false) as $m
-  | if ($m | length) > 0 then
-      (($m[0].captures[0].string + "Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
-       + ("0." + $m[0].captures[1].string | tonumber))
-    else
-      strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
-    end;
+  if type == "string" and endswith("Z") then
+    (rindex(".") as $dot
+     | if $dot == 19 and length > 21 then
+         (.[20:length-1] as $frac
+          | ($frac | try ("0." + . | tonumber) catch null) as $n
+          | if $n != null then
+              (.[:19] + "Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) + $n
+            else
+              strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+            end)
+       else
+         strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+       end)
+  else
+    strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+  end;
 def todateiso8601: strftime("%Y-%m-%dT%H:%M:%SZ");
 def fromdate: fromdateiso8601;
 def todate: todateiso8601;

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -71,7 +71,14 @@ def _flatten($x): reduce .[] as $i ([]; if $i | type == "array" and $x != 0 then
 def flatten($x): if $x < 0 then error("flatten depth must not be negative") else _flatten($x) end;
 def flatten: _flatten(-1);
 def range($x): range(0;$x);
-def fromdateiso8601: strptime("%Y-%m-%dT%H:%M:%SZ")|mktime;
+def fromdateiso8601:
+  _match_impl("^([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2})\\.([0-9]+)Z$"; null; false) as $m
+  | if ($m | length) > 0 then
+      (($m[0].captures[0].string + "Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
+       + ("0." + $m[0].captures[1].string | tonumber))
+    else
+      strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+    end;
 def todateiso8601: strftime("%Y-%m-%dT%H:%M:%SZ");
 def fromdate: fromdateiso8601;
 def todate: todateiso8601;

--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -72,19 +72,23 @@ def flatten($x): if $x < 0 then error("flatten depth must not be negative") else
 def flatten: _flatten(-1);
 def range($x): range(0;$x);
 def fromdateiso8601:
-  if type == "string" and endswith("Z") then
-    (rindex(".") as $dot
-     | if $dot == 19 and length > 21 then
-         (.[20:length-1] as $frac
-          | ($frac | try ("0." + . | tonumber) catch null) as $n
-          | if $n != null then
-              (.[:19] + "Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) + $n
-            else
-              strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
-            end)
-       else
-         strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
-       end)
+  if type == "string" then
+    if length == 20 then
+      strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+    else
+      (length as $len
+       | if $len > 21 and .[$len-1:$len] == "Z" and .[19:20] == "." then
+           (.[20:$len-1] as $frac
+            | ($frac | try ("0." + . | tonumber) catch null) as $n
+            | if $n != null then
+                (.[:19] + "Z" | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) + $n
+              else
+                strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+              end)
+         else
+           strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
+         end)
+    end
   else
     strptime("%Y-%m-%dT%H:%M:%SZ") | mktime
   end;

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1896,6 +1896,15 @@ last(range(365 * 67)|("1970-03-01T01:02:03Z"|strptime("%Y-%m-%dT%H:%M:%SZ")|mkti
 null
 [2037,1,11,1,2,3,3,41]
 
+# Fractional seconds in ISO 8601 dates (#2224)
+fromdateiso8601
+"2020-12-11T01:00:52.605001Z"
+1607648452.605001
+
+fromdateiso8601
+"2020-12-11T01:00:52Z"
+1607648452
+
 # module system
 import "a" as foo; import "b" as bar; def fooa: foo::a; [fooa, bar::a, bar::b, foo::a]
 null


### PR DESCRIPTION
`fromdateiso8601` currently rejects ISO 8601 strings with a fractional second part, such as `"2020-12-11T01:00:52.605001Z"` (reported in #2224).\n\nThis change detects the Zulu fractional-second pattern, strips the fraction for `strptime|mktime`, then adds it back as a number. Whole-second inputs keep the original code path so existing behavior is preserved.\n\n- Added regression tests in `tests/jq.test` covering both fractional and whole-second inputs.\n- `make check` passes (9/9).\n\nNote: #2296 proposes a broader regex-based parser but has remained open with merge conflicts since 2021. This PR is a focused minimal fix for the fractional-second case in #2224.\n\nCloses #2224