### PR TITLE
fix(reduce): preserve init under backtracking

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -832,7 +832,8 @@ static block bind_alternation_matchers(block matchers, block body) {
 
 block gen_reduce(block source, block matcher, block init, block body) {
   block res_var = gen_op_var_fresh(STOREV, "reduce");
-  block loop = BLOCK(gen_op_simple(DUPN),
+  block dot_var = gen_op_var_fresh(STOREV, "dot");
+  block loop = BLOCK(gen_op_simple(DUP),
                      source,
                      bind_alternation_matchers(matcher,
                                   BLOCK(gen_op_bound(LOADVN, res_var),
@@ -842,8 +843,17 @@ block gen_reduce(block source, block matcher, block init, block body) {
   return BLOCK(gen_op_simple(DUP),
                init,
                res_var,
+               BLOCK(
+                 // dummy null
+                 gen_op_pushk_under(jv_null()),
+                 // stores the actual input
+                 dot_var
+               ),
                gen_op_target(FORK, loop),
+               // consumes dummy null and restores the actual input
+               gen_op_bound(LOADVN, dot_var),
                loop,
+               // consumes dummy null and restores the result
                gen_op_bound(LOADVN, res_var));
 }
 

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2542,6 +2542,17 @@ foreach .[] as $x (0, 1; . + $x)
 2
 4
 
+# regression test for #3227 (reduce)
+[] | reduce .[] as $x (0, 0; .)
+null
+0
+0
+
+[] | reduce .[] as $x (0, 0; .) as $y | $y
+null
+0
+0
+
 # regression test for CVE-2025-49014 (use of fmt after free)
 # tests with both empty string literal and empty string created by function
 # as they seems to behave reference wise differently.


### PR DESCRIPTION
Closes #3227.

`reduce` with a backtracking init (e.g. `0, 0`) could fail with `Cannot iterate over null` because the leading `DUPN` in `gen_reduce` writes null into the stack slot that earlier forkpoints later restore. When init backtracks, the source expression sees `null` instead of the original input.

Store the original input in a temporary stack variable (`dot`) and load it into the loop once, keeping the pre-fork stack slot intact. This mirrors the `STOREV`/`LOADVN` handling already used for the reduction state.

Regression tests are added alongside the existing `foreach` #3227 tests.