### PR TITLE
parse: reject numeric literals with unterminated fraction

### DIFF
--- a/src/jq_test.c
+++ b/src/jq_test.c
@@ -610,6 +610,19 @@ static void jv_test(void) {
     assert(strcmp(jv_string_value(v), "Expected separator between values at line 1, column 9 (while parsing '{\"a':\"12\"}')") == 0);
     jv_free(v);
   }
+  {
+    const char* invalid_numbers[] = {"23.", "23.e1", "0.", "-1."};
+    for (size_t i = 0; i < sizeof(invalid_numbers) / sizeof(invalid_numbers[0]); i++) {
+      jv v = jv_parse(invalid_numbers[i]);
+      assert(jv_get_kind(v) == JV_KIND_INVALID);
+      v = jv_invalid_get_msg(v);
+      assert(strstr(jv_string_value(v), "Invalid numeric literal") != NULL);
+      jv_free(v);
+    }
+    jv ok = jv_parse("23.0");
+    assert(jv_get_kind(ok) == JV_KIND_NUMBER);
+    jv_free(ok);
+  }
   /// Arrays and numbers
   {
     jv a = jv_array();

--- a/src/jv_parse.c
+++ b/src/jv_parse.c
@@ -534,6 +534,15 @@ static pfunc check_literal(struct jv_parser* p) {
   } else {
     // FIXME: better parser
     p->tokenbuf[p->tokenpos] = 0;
+    // RFC 8259: a fraction is '.' followed by one or more digits.
+    // decNumber/strtod accept "23." / "23.e1", which silently truncates
+    // to 23 / 230 instead of rejecting the token (#2414).
+    {
+      const char* dot = strchr(p->tokenbuf, '.');
+      if (dot && (dot[1] < '0' || dot[1] > '9')) {
+        return "Invalid numeric literal";
+      }
+    }
 #ifdef USE_DECNUM
     jv number = jv_number_with_literal(p->tokenbuf);
     if (jv_get_kind(number) == JV_KIND_INVALID) {

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -2499,6 +2499,15 @@ try fromjson catch .
 "{'a': 123}"
 "Invalid string literal; expected \", but got ' at line 1, column 5 (while parsing '{'a': 123}')"
 
+# Unterminated fractions are invalid JSON (#2414)
+.[] | try fromjson catch .
+["23.","23.e1","0.","-1.","23.0"]
+"Invalid numeric literal at EOF at line 1, column 3 (while parsing '23.')"
+"Invalid numeric literal at EOF at line 1, column 5 (while parsing '23.e1')"
+"Invalid numeric literal at EOF at line 1, column 2 (while parsing '0.')"
+"Invalid numeric literal at EOF at line 1, column 3 (while parsing '-1.')"
+23.0
+
 # ltrimstr/1 rtrimstr/1 don't leak on invalid input #2977
 
 try ltrimstr(1) catch "x", try rtrimstr(1) catch "x" | "ok"


### PR DESCRIPTION
`echo 23. | jq .` currently succeeds and prints `23`. RFC 8259 requires a fraction to contain at least one digit after `.`, so `23.`, `23.e1`, `0.`, and `-1.` are invalid JSON.

**Triage / Root cause:** `check_literal()` in `src/jv_parse.c` hands the token to decNumber/`strtod`, which accept a trailing `.` and silently drop it. The JSON tokenizer never checks that a `.` is followed by a digit.

**Fix:** reject a numeric token whose `.` is not followed by a digit, before conversion. Valid forms such as `23.0` and `0.5` still parse.

**Verification:**
- `tests/jqtest` — 551 of 551 tests passed
- `make check` — 9/9 PASS (`mantest`, `jqtest`, `shtest`, `utf8test`, `base64test`, `uritest`, `optionaltest`, `onigtest`, `manonigtest`)

**Notes:** #3524 attempted the same check and was self-closed by the author with no review comments (not a maintainer rejection). The bug is still present on current `master`. This does not change jq program syntax; it only applies to the JSON parser (`jv_parse` / `fromjson`).

Fixes #2414
