### PR TITLE
Pad out-of-bounds array slice assignments

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -34,7 +34,7 @@ static struct sort_cmp_state sort_cmp_state;
 #endif
 #endif
 
-static jv parse_slice(jv j, jv slice, int* pstart, int* pend) {
+static jv parse_slice(jv j, jv slice, int* pstart, int* pend, int allow_out_of_bounds) {
   // Array slices
   jv start_jv = jv_object_get(jv_copy(slice), jv_string("start"));
   jv end_jv = jv_object_get(slice, jv_string("end"));
@@ -77,7 +77,7 @@ static jv parse_slice(jv j, jv slice, int* pstart, int* pend) {
   if (isnan(dstart)) dstart = 0;
   if (dstart < 0)    dstart += len;
   if (dstart < 0)    dstart = 0;
-  if (dstart > len)  dstart = len;
+  if (!allow_out_of_bounds && dstart > len) dstart = len;
   start = dstart > INT_MAX ? INT_MAX : (int)dstart; // Rounds down
 
   if (isnan(dend))   dend = len;
@@ -89,7 +89,8 @@ static jv parse_slice(jv j, jv slice, int* pstart, int* pend) {
                                                 // but round end up
 
   if (end < start) end = start;
-  assert(0 <= start && start <= end && end <= len);
+  assert(0 <= start && start <= end);
+  assert(allow_out_of_bounds || end <= len);
   *pstart = start;
   *pend = end;
   return jv_true();
@@ -123,7 +124,7 @@ jv jv_get(jv t, jv k) {
     jv_free(k);
   } else if (jv_get_kind(t) == JV_KIND_ARRAY && jv_get_kind(k) == JV_KIND_OBJECT) {
     int start, end;
-    jv e = parse_slice(jv_copy(t), k, &start, &end);
+    jv e = parse_slice(jv_copy(t), k, &start, &end, 0);
     if (jv_get_kind(e) == JV_KIND_TRUE) {
       v = jv_array_slice(t, start, end);
     } else {
@@ -132,7 +133,7 @@ jv jv_get(jv t, jv k) {
     }
   } else if (jv_get_kind(t) == JV_KIND_STRING && jv_get_kind(k) == JV_KIND_OBJECT) {
     int start, end;
-    jv e = parse_slice(jv_copy(t), k, &start, &end);
+    jv e = parse_slice(jv_copy(t), k, &start, &end, 0);
     if (jv_get_kind(e) == JV_KIND_TRUE) {
       v = jv_string_slice(t, start, end);
     } else {
@@ -191,13 +192,22 @@ jv jv_set(jv t, jv k, jv v) {
              (jv_get_kind(t) == JV_KIND_ARRAY || isnull)) {
     if (isnull) t = jv_array();
     int start, end;
-    jv e = parse_slice(jv_copy(t), k, &start, &end);
+    jv e = parse_slice(jv_copy(t), k, &start, &end, 1);
     if (jv_get_kind(e) == JV_KIND_TRUE) {
       if (jv_get_kind(v) == JV_KIND_ARRAY) {
         int array_len = jv_array_length(jv_copy(t));
+        int insert_len = jv_array_length(jv_copy(v));
+        if (start > array_len) {
+          if (insert_len == 0) {
+            start = end = array_len;
+          } else {
+            t = jv_array_set(t, start - 1, jv_null());
+            array_len = start;
+            end = start;
+          }
+        }
         assert(0 <= start && start <= end && end <= array_len);
         int slice_len = end - start;
-        int insert_len = jv_array_length(jv_copy(v));
         if (slice_len < insert_len) {
           // array is growing
           int shift = insert_len - slice_len;
@@ -303,7 +313,7 @@ static jv jv_dels(jv t, jv keys) {
         }
       } else if (jv_get_kind(key) == JV_KIND_OBJECT) {
         int start, end;
-        jv e = parse_slice(jv_copy(t), key, &start, &end);
+        jv e = parse_slice(jv_copy(t), key, &start, &end, 0);
         if (jv_get_kind(e) == JV_KIND_TRUE) {
           starts = jv_array_append(starts, jv_number(start));
           ends = jv_array_append(ends, jv_number(end));

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -481,6 +481,21 @@ del(.[2:4],.[0],.[-2:])
 [0,1,"a","b",4,5,6,7]
 [0,1,"a","b","c",4,5,6,7]
 
+# Assignment to a slice beyond the array pads with nulls (issue #2813)
+.[10:11] |= [2]
+[1]
+[1,null,null,null,null,null,null,null,null,null,2]
+
+# Padding also works when the replacement has multiple elements
+.[3:4] = [2,3]
+[1]
+[1,null,null,2,3]
+
+# Assigning an empty array to a slice beyond the array remains a no-op
+.[10:11] = []
+[1]
+[1]
+
 # Slices at large offsets (issue #1108)
 #
 # This is written this way because [range(<large number>)] is


### PR DESCRIPTION
Fixes #2813.

## Summary

- preserve an out-of-bounds slice start when assigning to an array
- pad the gap with `null` values before inserting the replacement array
- keep slice reads, deletions, and empty out-of-bounds replacements unchanged

For example:

```jq
[1] | .[10:11] |= [2]
```

now produces:

```json
[1,null,null,null,null,null,null,null,null,null,2]
```

This is consistent with assigning directly to array index 10.

## Tests

- `make check`
- `git diff --check`
