### PR TITLE
docs: clarify shebang compatibility across jq versions

### DIFF
--- a/docs/content/manual/dev/manual.yml
+++ b/docs/content/manual/dev/manual.yml
@@ -3698,6 +3698,12 @@ sections:
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
       with the arguments (`$@`) that were passed to `sh`.
 
+      The example above uses the jq 1.8 and later behaviour. For compatibility
+      with jq 1.7 and earlier, keep the shebang on the first line and put a
+      backslash-continued comment immediately on the second line, followed by
+      the `exec` line. jq 1.8 and later support backslash-continued comments
+      in any position.
+
   - title: Modules
     body: |
 

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3696,7 +3696,13 @@ sections:
       run `exec jq --args -MRnf -- /path/to/total 1 2` replacing itself
       with a `jq` interpreter invoked with the specified options (`-M`,
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
-      with the arguments (`$@`) that were passed to `sh`.      The example above uses the jq 1.8 and later behaviour. For compatibility      with jq 1.7 and earlier, keep the shebang on the first line and put a      backslash-continued comment immediately on the second line, followed by      the `exec` line. jq 1.8 and later support backslash-continued comments      in any position.
+      with the arguments (`$@`) that were passed to `sh`.
+
+            The example above uses the jq 1.8 and later behaviour. For compatibility
+                  with jq 1.7 and earlier, keep the shebang on the first line and put a
+                        backslash-continued comment immediately on the second line, followed by
+                              the `exec` line. jq 1.8 and later support backslash-continued comments
+                                    in any position.
 
   - title: Modules
     body: |

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3696,7 +3696,7 @@ sections:
       run `exec jq --args -MRnf -- /path/to/total 1 2` replacing itself
       with a `jq` interpreter invoked with the specified options (`-M`,
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
-      with the arguments (`$@`) that were passed to `sh`.
+      with the arguments (`$@`) that were passed to `sh`.      The example above uses the jq 1.8 and later behaviour. For compatibility      with jq 1.7 and earlier, keep the shebang on the first line and put a      backslash-continued comment immediately on the second line, followed by      the `exec` line. jq 1.8 and later support backslash-continued comments      in any position.
 
   - title: Modules
     body: |

--- a/docs/content/manual/v1.8/manual.yml
+++ b/docs/content/manual/v1.8/manual.yml
@@ -3698,11 +3698,11 @@ sections:
       `-R`, `-n`, `--args`), that evaluates the current file (`$0`),
       with the arguments (`$@`) that were passed to `sh`.
 
-            The example above uses the jq 1.8 and later behaviour. For compatibility
-                  with jq 1.7 and earlier, keep the shebang on the first line and put a
-                        backslash-continued comment immediately on the second line, followed by
-                              the `exec` line. jq 1.8 and later support backslash-continued comments
-                                    in any position.
+      The example above uses the jq 1.8 and later behaviour. For compatibility
+      with jq 1.7 and earlier, keep the shebang on the first line and put a
+      backslash-continued comment immediately on the second line, followed by
+      the `exec` line. jq 1.8 and later support backslash-continued comments
+      in any position.
 
   - title: Modules
     body: |

--- a/jq.1.prebuilt
+++ b/jq.1.prebuilt
@@ -4134,6 +4134,9 @@ reduce (
 .P
 The \fBexec\fR line is considered a comment by jq, so it is ignored\. But it is not ignored by \fBsh\fR, since in \fBsh\fR a backslash at the end of the line does not continue the comment\. With this trick, when the script is invoked as \fBtotal 1 2\fR, \fB/bin/sh \-\- /path/to/total 1 2\fR will be run, and \fBsh\fR will then run \fBexec jq \-\-args \-MRnf \-\- /path/to/total 1 2\fR replacing itself with a \fBjq\fR interpreter invoked with the specified options (\fB\-M\fR, \fB\-R\fR, \fB\-n\fR, \fB\-\-args\fR), that evaluates the current file (\fB$0\fR), with the arguments (\fB$@\fR) that were passed to \fBsh\fR\.
 .
+.P
+The example above uses the jq 1\.8 and later behaviour\. For compatibility with jq 1\.7 and earlier, keep the shebang on the first line and put a backslash\-continued comment immediately on the second line, followed by the \fBexec\fR line\. jq 1\.8 and later support backslash\-continued comments in any position\.
+.
 .SH "MODULES"
 jq has a library/module system\. Modules are files whose names end in \fB\.jq\fR\.
 .


### PR DESCRIPTION
## Summary

- clarify that the documented shebang form relies on jq 1.8 behavior
- describe the compatible placement for jq 1.7 and earlier
- update both manual sources and the generated manpage

## Validation

- manual schema validation
- generated manpage lint
- `git diff --check`
- remote branch blobs verified against the validated local files

Fixes #3573