### PR TITLE
Fix inconsistent `delpaths` behavior with mixed negative indices

### DIFF
--- a/src/jv_aux.c
+++ b/src/jv_aux.c
@@ -519,12 +519,51 @@ static jv delpaths_sorted(jv object, jv paths, int start) {
   return object;
 }
 
+// Rewrite negative array indices in a single path to their non-negative
+// equivalents, relative to the (undeleted) object each index points into.
+// This lets delpaths_sorted group and delete positive and negative indices
+// that refer to the same element as if they were simultaneous, matching the
+// leaf-level behavior of jv_dels (see jqlang/jq#3538).
+static jv delpaths_normalize(jv object, jv path) {
+  jv newpath = jv_array();
+  jv node = object;
+  jv_array_foreach(path, i, key) {
+    if (jv_get_kind(node) == JV_KIND_ARRAY &&
+        jv_get_kind(key) == JV_KIND_NUMBER &&
+        !jvp_number_is_nan(key) &&
+        jv_number_value(key) < 0) {
+      double didx = jv_number_value(key) + jv_array_length(jv_copy(node));
+      // Only normalize in-range indices; out-of-range negatives are left as-is
+      // so existing error/no-op semantics are preserved.
+      if (didx >= 0) {
+        jv_free(key);
+        key = jv_number(didx);
+      }
+    }
+    newpath = jv_array_append(newpath, jv_copy(key));
+    node = jv_get(node, key);
+  }
+  jv_free(node);
+  jv_free(path);
+  return newpath;
+}
+
 jv jv_delpaths(jv object, jv paths) {
   if (jv_get_kind(paths) != JV_KIND_ARRAY) {
     jv_free(object);
     jv_free(paths);
     return jv_invalid_with_msg(jv_string("Paths must be specified as an array"));
   }
+  // Normalize negative array indices before sorting so that positive and
+  // negative indices to the same element are grouped together (jqlang/jq#3538).
+  jv normpaths = jv_array();
+  jv_array_foreach(paths, i, path) {
+    if (jv_get_kind(path) == JV_KIND_ARRAY)
+      path = delpaths_normalize(jv_copy(object), path);
+    normpaths = jv_array_append(normpaths, path);
+  }
+  jv_free(paths);
+  paths = normpaths;
   paths = jv_sort(paths, jv_copy(paths));
   jv_array_foreach(paths, i, elem) {
     if (jv_get_kind(elem) != JV_KIND_ARRAY) {

--- a/tests/jq.test
+++ b/tests/jq.test
@@ -1185,6 +1185,20 @@ del(.[1], .[-6], .[2], .[-3:9])
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 [0, 3, 5, 6, 9]
 
+# mixed positive/negative indices at non-leaf levels must delete the same
+# elements as at leaf level, i.e. as if all deletions were simultaneous (#3538)
+del(.[0][-6], .[-1][6])
+[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+[[0,1,2,3,5,7,8,9]]
+
+del(.[-1][-6], .[0][6])
+[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+[[0,1,2,3,5,7,8,9]]
+
+delpaths([[-1,-6],[0,6]])
+[[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+[[0,1,2,3,5,7,8,9]]
+
 del(.[nan])
 [1,2,3]
 [1,2,3]


### PR DESCRIPTION
Fixes #3538.

## Problem
At a non-leaf array level, mixing positive and negative indices that point to the same element deletes the wrong elements:
```
del(.[0][-6], .[-1][6])   # on [[0..9]]
  got:      [[0,1,2,4,5,7,8,9]]
  expected: [[0,1,2,3,5,7,8,9]]
```
The leaf level already handles this correctly; only nested levels were wrong.

## Root cause
`delpaths_sorted` groups paths by the raw key via `jv_equal`. A negative index (`-1`) and the positive index to the same element (`0`) aren't equal, so they became separate groups processed sequentially through `jv_set`/`jv_get` — effectively deleting the negatives first and shifting positions. Leaf-level `jv_dels` already reconciles both signs against the original length; non-leaf levels didn't.

## Approach
Normalize in-range negative array indices to their non-negative equivalents (relative to the undeleted object) **before** sorting, so equivalent indices group together and delete simultaneously. Out-of-range negatives are left untouched to preserve existing no-op/error semantics.

## Testing
- Added 3 cases to `tests/jq.test` (both `del(...)` forms + the `delpaths([...])` form). Verified they **fail without the fix** (550/553), pass with it.
- Full suite: **553/553**.
