### PR TITLE
Count the line a value ends on when its newline has not been read yet

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -193,6 +193,9 @@ struct jq_util_input_state {
   size_t buf_valid_len;
   jv current_filename;
   size_t current_line;
+  // Set when the last read stopped short of a newline, i.e. the next value
+  // parsed out of the buffer sits on the line after current_line.
+  int mid_line;
 };
 
 static void fprinter(void *data, const char *fname) {
@@ -277,6 +280,7 @@ static int jq_util_input_read_more(jq_util_input_state *state) {
     if (f != NULL) {
       jv_free(state->current_filename);
       state->current_line = 0;
+      state->mid_line = 0;
       if (!strcmp(f, "-")) {
         state->current_input = stdin;
         state->current_filename = jv_string("<stdin>");
@@ -309,8 +313,12 @@ static int jq_util_input_read_more(jq_util_input_state *state) {
     } else {
       const char *p = memchr(state->buf, '\n', max_gets_len);
 
-      if (p != NULL)
+      if (p != NULL) {
         state->current_line++;
+        state->mid_line = 0;
+      } else {
+        state->mid_line = 1;
+      }
 
       if (p == NULL && feof(state->current_input)) {
         size_t i;
@@ -367,7 +375,7 @@ jv jq_util_input_get_position(jq_state *jq) {
   if (jv_get_kind(s->current_filename) != JV_KIND_STRING)
     return jv_string("<unknown>");
 
-  jv v = jv_string_fmt("%s:%lu", jv_string_value(s->current_filename), (unsigned long)s->current_line);
+  jv v = jv_string_fmt("%s:%lu", jv_string_value(s->current_filename), (unsigned long)(s->current_line + s->mid_line));
   return v;
 }
 
@@ -389,7 +397,7 @@ jv jq_util_input_get_current_line(jq_state* jq) {
   if (cb != jq_util_input_next_input_cb)
     return jv_invalid_with_msg(jv_string("Unknown input line number"));
   jq_util_input_state *s = (jq_util_input_state *)cb_data;
-  jv v = jv_number(s->current_line);
+  jv v = jv_number(s->current_line + s->mid_line);
   return v;
 }
 

--- a/tests/shtest
+++ b/tests/shtest
@@ -356,6 +356,50 @@ if [ "$EC" -ne 2 ]; then
     exit 1
 fi
 
+## Regression tests for issues #2242 and #2244 input_line_number
+## The counter only advanced when a read happened to land on a newline, so a
+## value on a line whose newline had not been read yet reported the line
+## before it: the last line of input without a trailing newline, and any value
+## ending exactly on the read-buffer boundary.
+
+printf '1\n2\n3\n' > $d/input
+printf '1\n2\n3\n' > $d/expected
+$VALGRIND $Q $JQ -c input_line_number $d/input > $d/out
+cmp $d/out $d/expected
+
+# no trailing newline on the last line (#2244)
+printf '1\n2\n3' > $d/input
+printf '1\n2\n3\n' > $d/expected
+$VALGRIND $Q $JQ -c input_line_number $d/input > $d/out
+cmp $d/out $d/expected
+
+# a single value with no trailing newline is still on line 1
+printf '0' > $d/input
+echo 1 > $d/expected
+$VALGRIND $Q $JQ -c input_line_number $d/input > $d/out
+cmp $d/out $d/expected
+
+# raw input, no trailing newline
+printf 'a\nb\nc' > $d/input
+printf '1\n2\n3\n' > $d/expected
+$VALGRIND $Q $JQ -R -c input_line_number $d/input > $d/out
+cmp $d/out $d/expected
+
+# a value ending exactly on the read-buffer boundary (#2242). The lengths
+# sweep the boundary so this keeps working if the buffer size changes.
+for len in 4087 4088 4089 4090 4091 4092 4093; do
+    awk -v n=$len 'BEGIN{printf "0\n\""; while (n-- > 0) printf "a"; printf "\"\n0\n"}' > $d/input
+    printf '1\n2\n3\n' > $d/expected
+    $VALGRIND $Q $JQ -c input_line_number $d/input > $d/out
+    cmp $d/out $d/expected
+done
+
+# several values on one line all report that line
+printf '1 2 3\n' > $d/input
+printf '1\n1\n1\n' > $d/expected
+$VALGRIND $Q $JQ -c input_line_number $d/input > $d/out
+cmp $d/out $d/expected
+
 ## Fuzz parser
 
 ## XXX With a $(urandom) builtin we could move this test into tests/all.test


### PR DESCRIPTION
Fixes #2242. Fixes #2244.

`current_line` in `src/util.c` is incremented only when a read happens to contain a newline, so a value sitting on a line whose newline has not been read yet reports the line before it. The two open issues are the same bug seen from different angles:

```
$ printf '1\n2\n3' | jq input_line_number     # no trailing newline (#2244)
1
2
2

$ printf '0' | jq input_line_number
0

$ python3 -c "print('0\n\"' + 'a'*4089 + '\"\n0')" | jq input_line_number   # (#2242)
1
1
3
```

The third case is the boundary one. `fgets` reads at most `max_gets_len - 1` bytes, so when a value's closing token lands exactly on that boundary the parser returns the value before the newline that ends its line has been read. #2242 reports the trigger length as 4095 on 1.6; on master the constants make it 4089, which is why the original reproducer no longer shows it.

The fix tracks whether the last read stopped short of a newline and adds that to the reported count, so the answer is the line the input actually sits on rather than the number of newlines seen so far. The manual says `input_line_number` "returns the line number of the input currently being filtered", which is the behaviour this restores.

A read that ends on a newline is unaffected, so the common path does not change, and several values on one line still all report that line. `jq_util_input_get_position` gets the same treatment, since otherwise an input error raised mid-line would name a different line than `input_line_number` does.

There was no test coverage for `input_line_number` at all, so `tests/shtest` gains cases for the trailing-newline variants, raw input, several values on one line, and a sweep across the read-buffer boundary. The sweep covers a range of lengths rather than the single triggering one so it keeps testing something if the buffer size changes. Reverting `src/util.c` with the tests in place fails on the `1\n2\n3` case.
