### PR TITLE
perf: use `add(.[]|f)` instead of `map(f)|add`

### DIFF
--- a/src/builtin.jq
+++ b/src/builtin.jq
@@ -39,8 +39,8 @@ def recurse(f; cond): def r: ., (f | select(cond) | r); r;
 def recurse: recurse(.[]?);
 
 def to_entries: [keys_unsorted[] as $k | {key: $k, value: .[$k]}];
-def from_entries: map({ (.key // .Key // .name // .Name):
-  if has("value") then .value else .Value end }) | add // {};
+def from_entries: add(.[] | { (.key // .Key // .name // .Name):
+  if has("value") then .value else .Value end }) // {};
 def with_entries(f): to_entries | map(f) | from_entries;
 def reverse: [.[length - 1 - range(0;length)]];
 def indices($i): if type == "array" and ($i|type) == "array" then .[$i]


### PR DESCRIPTION
Improved performance by approximately 26% in this case:

```bash
old='def from_entries: map({ (.key // .Key // .name // .Name):
  if has("value") then .value else .Value end }) | add // {};'
new='def from_entries: add(.[] | { (.key // .Key // .name // .Name):
  if has("value") then .value else .Value end }) // {};'
gen='{x:range(300), y: range(600)}|to_entries'
run="$gen|from_entries"

time jq -n "$gen" >/dev/null
time jq -n "$old$run" >/dev/null
time jq -n "$new$run" >/dev/null
```

```text
real    0m1.015s
user    0m0.988s
sys     0m0.004s

real    0m1.663s
user    0m1.660s
sys     0m0.000s

real    0m1.489s
user    0m1.486s
sys     0m0.000s
```
